### PR TITLE
Fix screen class name typo

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ class WorkoutMainScreen(BaseWorkoutScreen):
     pass
 
 
-class EditWorkoutScreenScreen(BaseWorkoutScreen):
+class EditWorkoutScreen(BaseWorkoutScreen):
     pass
 
 
@@ -81,7 +81,7 @@ class WorkoutApp(App):
     def build(self):
         sm = ScreenManager(transition=NoTransition())  # <- this makes transitions instant
         sm.add_widget(WorkoutMainScreen(name="main"))
-        sm.add_widget(EditWorkoutScreenScreen(name="edit"))
+        sm.add_widget(EditWorkoutScreen(name="edit"))
         sm.add_widget(WorkOutDataScreen(name="data"))
         sm.add_widget(ExerciseExecutionScreen(name="exercise"))
         sm.add_widget(EndWorkoutScreen(name="end"))

--- a/workout.kv
+++ b/workout.kv
@@ -107,7 +107,7 @@
                 on_press: root.workout_data_button_action()
 
 
-<EditWorkoutScreenScreen>:
+<EditWorkoutScreen>:
     BoxLayout:
         orientation: 'vertical'
         padding: 20


### PR DESCRIPTION
## Summary
- rename `EditWorkoutScreenScreen` to `EditWorkoutScreen`
- update kv file to match new class name

## Testing
- `pytest -q`
- `python3 -m py_compile *.py test/test.py`

------
https://chatgpt.com/codex/tasks/task_e_6859ac2f7380833298f1ebe40d05fd17