### PR TITLE
Add hex color customization

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -1,0 +1,191 @@
+MDScreenManager:
+    WelcomeScreen:
+    HomeScreen:
+    SelectWorkoutScreen:
+    SettingsScreen:
+    StartWorkoutScreen:
+    ActiveScreen:
+    RestScreen:
+
+<WelcomeScreen>:
+    name: "welcome"
+    MDBoxLayout:
+        md_bg_color: app.get_color_tuple(app.screen_color)
+        orientation: "vertical"
+        spacing: dp(20)
+        padding: dp(20)
+        MDLabel:
+            text: "Welcome to the Workout App"
+            halign: "center"
+            font_style: "H5"
+        MDRaisedButton:
+            text: "Continue"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.root.current = "home"
+            md_bg_color: app.get_color_tuple(app.button_color)
+
+<HomeScreen>:
+    name: "home"
+    MDBoxLayout:
+        md_bg_color: app.get_color_tuple(app.screen_color)
+        orientation: "vertical"
+        spacing: dp(20)
+        padding: dp(20)
+        MDLabel:
+            text: "Home"
+            halign: "center"
+            font_style: "H5"
+        MDRaisedButton:
+            text: "Select Workout"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.root.current = "select_workout"
+            md_bg_color: app.get_color_tuple(app.button_color)
+        MDRaisedButton:
+            text: "Settings"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.root.current = "settings"
+            md_bg_color: app.get_color_tuple(app.button_color)
+        MDRaisedButton:
+            text: "Start Workout"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.root.current = "start_workout"
+            md_bg_color: app.get_color_tuple(app.button_color)
+
+<SelectWorkoutScreen>:
+    name: "select_workout"
+    MDBoxLayout:
+        md_bg_color: app.get_color_tuple(app.screen_color)
+        orientation: "vertical"
+        spacing: dp(20)
+        padding: dp(20)
+        MDLabel:
+            text: "Select Workout"
+            halign: "center"
+            font_style: "H5"
+        MDRaisedButton:
+            text: "Start"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.root.current = "start_workout"
+            md_bg_color: app.get_color_tuple(app.button_color)
+        MDRaisedButton:
+            text: "Back"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.root.current = "home"
+            md_bg_color: app.get_color_tuple(app.button_color)
+
+<SettingsScreen>:
+    name: "settings"
+    MDBoxLayout:
+        md_bg_color: app.get_color_tuple(app.screen_color)
+        orientation: "vertical"
+        spacing: dp(20)
+        padding: dp(20)
+        MDLabel:
+            text: "Settings"
+            halign: "center"
+            font_style: "H5"
+        MDLabel:
+            text: "Select Color Scheme"
+            halign: "center"
+        MDGridLayout:
+            cols: 2
+            spacing: dp(10)
+            size_hint_y: None
+            height: self.minimum_height
+            MDRaisedButton:
+                text: "Blue"
+                on_release: app.change_color_scheme("Blue")
+                md_bg_color: app.get_color_tuple(app.button_color)
+            MDRaisedButton:
+                text: "Red"
+                on_release: app.change_color_scheme("Red")
+                md_bg_color: app.get_color_tuple(app.button_color)
+            MDRaisedButton:
+                text: "Green"
+                on_release: app.change_color_scheme("Green")
+                md_bg_color: app.get_color_tuple(app.button_color)
+            MDRaisedButton:
+                text: "Purple"
+                on_release: app.change_color_scheme("Purple")
+                md_bg_color: app.get_color_tuple(app.button_color)
+        MDRaisedButton:
+            text: "Screen Color"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.open_screen_color_picker()
+            md_bg_color: app.get_color_tuple(app.button_color)
+        MDRaisedButton:
+            text: "Button Color"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.open_button_color_picker()
+            md_bg_color: app.get_color_tuple(app.button_color)
+        MDRaisedButton:
+            text: "Back"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.go_home()
+            md_bg_color: app.get_color_tuple(app.button_color)
+
+<StartWorkoutScreen>:
+    name: "start_workout"
+    MDBoxLayout:
+        md_bg_color: app.get_color_tuple(app.screen_color)
+        orientation: "vertical"
+        spacing: dp(20)
+        padding: dp(20)
+        MDLabel:
+            text: "Ready to start?"
+            halign: "center"
+            font_style: "H5"
+        MDRaisedButton:
+            text: "Begin"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.root.current = "active"
+            md_bg_color: app.get_color_tuple(app.button_color)
+        MDRaisedButton:
+            text: "Back"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.go_home()
+            md_bg_color: app.get_color_tuple(app.button_color)
+
+<ActiveScreen>:
+    name: "active"
+    MDBoxLayout:
+        md_bg_color: app.get_color_tuple(app.screen_color)
+        orientation: "vertical"
+        spacing: dp(20)
+        padding: dp(20)
+        MDLabel:
+            text: "Active Workout"
+            halign: "center"
+            font_style: "H5"
+        MDRaisedButton:
+            text: "Next"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.root.current = "rest"
+            md_bg_color: app.get_color_tuple(app.button_color)
+        MDRaisedButton:
+            text: "Stop"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.go_home()
+            md_bg_color: app.get_color_tuple(app.button_color)
+
+<RestScreen>:
+    name: "rest"
+    MDBoxLayout:
+        md_bg_color: app.get_color_tuple(app.screen_color)
+        orientation: "vertical"
+        spacing: dp(20)
+        padding: dp(20)
+        MDLabel:
+            text: "Rest"
+            halign: "center"
+            font_style: "H5"
+        MDRaisedButton:
+            text: "Next"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.root.current = "active"
+            md_bg_color: app.get_color_tuple(app.button_color)
+        MDRaisedButton:
+            text: "Stop"
+            pos_hint: {"center_x": 0.5}
+            on_release: app.go_home()
+            md_bg_color: app.get_color_tuple(app.button_color)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,132 @@
+import json
+import os
+from kivy.lang import Builder
+from kivy.properties import StringProperty
+from kivy.utils import get_color_from_hex, get_hex_from_color
+from kivy.uix.colorpicker import ColorPicker
+from kivy.uix.popup import Popup
+from kivymd.app import MDApp
+from kivymd.uix.screen import MDScreen
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "workout_app", "settings", "config.json")
+DEFAULT_COLOR = "Blue"
+DEFAULT_SCREEN_COLOR = "#FFFFFF"
+DEFAULT_BUTTON_COLOR = "#2196F3"
+
+
+def load_config():
+    defaults = {
+        "color_scheme": DEFAULT_COLOR,
+        "screen_color": DEFAULT_SCREEN_COLOR,
+        "button_color": DEFAULT_BUTTON_COLOR,
+    }
+    if not os.path.exists(CONFIG_PATH):
+        os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+        with open(CONFIG_PATH, "w") as f:
+            json.dump(defaults, f)
+        return defaults
+    with open(CONFIG_PATH, "r") as f:
+        data = json.load(f)
+    return {**defaults, **data}
+
+
+def save_config(color_scheme, screen_color, button_color):
+    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+    with open(CONFIG_PATH, "w") as f:
+        json.dump(
+            {
+                "color_scheme": color_scheme,
+                "screen_color": screen_color,
+                "button_color": button_color,
+            },
+            f,
+        )
+
+
+class WelcomeScreen(MDScreen):
+    pass
+
+
+class HomeScreen(MDScreen):
+    pass
+
+
+class SelectWorkoutScreen(MDScreen):
+    pass
+
+
+class SettingsScreen(MDScreen):
+    pass
+
+
+class StartWorkoutScreen(MDScreen):
+    pass
+
+
+class ActiveScreen(MDScreen):
+    pass
+
+
+class RestScreen(MDScreen):
+    pass
+
+
+class WorkoutApp(MDApp):
+    screen_color = StringProperty(DEFAULT_SCREEN_COLOR)
+    button_color = StringProperty(DEFAULT_BUTTON_COLOR)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        cfg = load_config()
+        self.color_scheme = cfg["color_scheme"]
+        self.screen_color = cfg["screen_color"]
+        self.button_color = cfg["button_color"]
+
+    def build(self):
+        self.theme_cls.primary_palette = self.color_scheme
+        return Builder.load_file("main.kv")
+
+    def change_color_scheme(self, color):
+        self.theme_cls.primary_palette = color
+        self.color_scheme = color
+        save_config(self.color_scheme, self.screen_color, self.button_color)
+
+    def change_screen_color(self, hex_color):
+        self.screen_color = hex_color
+        save_config(self.color_scheme, self.screen_color, self.button_color)
+
+    def change_button_color(self, hex_color):
+        self.button_color = hex_color
+        save_config(self.color_scheme, self.screen_color, self.button_color)
+
+    def get_color_tuple(self, hex_color):
+        return get_color_from_hex(hex_color)
+
+    def open_screen_color_picker(self):
+        picker = ColorPicker()
+        popup = Popup(title="Screen Color", content=picker, size_hint=(0.9, 0.9))
+
+        def on_color(instance, value):
+            self.change_screen_color(get_hex_from_color(value))
+            popup.dismiss()
+
+        picker.bind(color=on_color)
+        popup.open()
+
+    def open_button_color_picker(self):
+        picker = ColorPicker()
+        popup = Popup(title="Button Color", content=picker, size_hint=(0.9, 0.9))
+
+        def on_color(instance, value):
+            self.change_button_color(get_hex_from_color(value))
+            popup.dismiss()
+
+        picker.bind(color=on_color)
+        popup.open()
+
+    def go_home(self):
+        self.root.current = "home"
+
+
+if __name__ == "__main__":
+    WorkoutApp().run()

--- a/workout_app/settings/config.json
+++ b/workout_app/settings/config.json
@@ -1,0 +1,5 @@
+{
+  "color_scheme": "Blue",
+  "screen_color": "#FFFFFF",
+  "button_color": "#2196F3"
+}


### PR DESCRIPTION
## Summary
- allow choosing screen and button colors
- save chosen colors in settings
- use ColorPicker popups for color selection

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'kivy')*

------
https://chatgpt.com/codex/tasks/task_e_6863e7518c8883329eeb51228adcb367