### PR TITLE
Add color customization with improved settings

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -23,6 +23,7 @@ MDScreenManager:
             pos_hint: {"center_x": 0.5}
             on_release: app.root.current = "home"
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
 
 <HomeScreen>:
     name: "home"
@@ -40,16 +41,19 @@ MDScreenManager:
             pos_hint: {"center_x": 0.5}
             on_release: app.root.current = "select_workout"
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
         MDRaisedButton:
             text: "Settings"
             pos_hint: {"center_x": 0.5}
             on_release: app.root.current = "settings"
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
         MDRaisedButton:
             text: "Start Workout"
             pos_hint: {"center_x": 0.5}
             on_release: app.root.current = "start_workout"
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
 
 <SelectWorkoutScreen>:
     name: "select_workout"
@@ -67,11 +71,13 @@ MDScreenManager:
             pos_hint: {"center_x": 0.5}
             on_release: app.root.current = "start_workout"
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
         MDRaisedButton:
             text: "Back"
             pos_hint: {"center_x": 0.5}
             on_release: app.root.current = "home"
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
 
 <SettingsScreen>:
     name: "settings"
@@ -84,45 +90,24 @@ MDScreenManager:
             text: "Settings"
             halign: "center"
             font_style: "H5"
-        MDLabel:
-            text: "Select Color Scheme"
-            halign: "center"
-        MDGridLayout:
-            cols: 2
-            spacing: dp(10)
-            size_hint_y: None
-            height: self.minimum_height
-            MDRaisedButton:
-                text: "Blue"
-                on_release: app.change_color_scheme("Blue")
-                md_bg_color: app.get_color_tuple(app.button_color)
-            MDRaisedButton:
-                text: "Red"
-                on_release: app.change_color_scheme("Red")
-                md_bg_color: app.get_color_tuple(app.button_color)
-            MDRaisedButton:
-                text: "Green"
-                on_release: app.change_color_scheme("Green")
-                md_bg_color: app.get_color_tuple(app.button_color)
-            MDRaisedButton:
-                text: "Purple"
-                on_release: app.change_color_scheme("Purple")
-                md_bg_color: app.get_color_tuple(app.button_color)
         MDRaisedButton:
             text: "Screen Color"
             pos_hint: {"center_x": 0.5}
             on_release: app.open_screen_color_picker()
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
         MDRaisedButton:
             text: "Button Color"
             pos_hint: {"center_x": 0.5}
             on_release: app.open_button_color_picker()
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
         MDRaisedButton:
             text: "Back"
             pos_hint: {"center_x": 0.5}
             on_release: app.go_home()
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
 
 <StartWorkoutScreen>:
     name: "start_workout"
@@ -140,11 +125,13 @@ MDScreenManager:
             pos_hint: {"center_x": 0.5}
             on_release: app.root.current = "active"
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
         MDRaisedButton:
             text: "Back"
             pos_hint: {"center_x": 0.5}
             on_release: app.go_home()
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
 
 <ActiveScreen>:
     name: "active"
@@ -162,11 +149,13 @@ MDScreenManager:
             pos_hint: {"center_x": 0.5}
             on_release: app.root.current = "rest"
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
         MDRaisedButton:
             text: "Stop"
             pos_hint: {"center_x": 0.5}
             on_release: app.go_home()
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
 
 <RestScreen>:
     name: "rest"
@@ -184,8 +173,10 @@ MDScreenManager:
             pos_hint: {"center_x": 0.5}
             on_release: app.root.current = "active"
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)
         MDRaisedButton:
             text: "Stop"
             pos_hint: {"center_x": 0.5}
             on_release: app.go_home()
             md_bg_color: app.get_color_tuple(app.button_color)
+            text_color: app.get_color_tuple(app.button_text_color)

--- a/main.py
+++ b/main.py
@@ -5,12 +5,15 @@ from kivy.properties import StringProperty
 from kivy.utils import get_color_from_hex, get_hex_from_color
 from kivy.uix.colorpicker import ColorPicker
 from kivy.uix.popup import Popup
+from kivy.uix.boxlayout import BoxLayout
 from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
+from kivymd.uix.button import MDRaisedButton
 
-CONFIG_PATH = os.path.join(os.path.dirname(__file__), "workout_app", "settings", "config.json")
 DEFAULT_COLOR = "Blue"
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "settings", "config.json")
 DEFAULT_SCREEN_COLOR = "#FFFFFF"
+DEFAULT_BUTTON_TEXT_COLOR = "#FFFFFF"
 DEFAULT_BUTTON_COLOR = "#2196F3"
 
 
@@ -19,6 +22,7 @@ def load_config():
         "color_scheme": DEFAULT_COLOR,
         "screen_color": DEFAULT_SCREEN_COLOR,
         "button_color": DEFAULT_BUTTON_COLOR,
+        "button_text_color": DEFAULT_BUTTON_TEXT_COLOR,
     }
     if not os.path.exists(CONFIG_PATH):
         os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
@@ -30,7 +34,7 @@ def load_config():
     return {**defaults, **data}
 
 
-def save_config(color_scheme, screen_color, button_color):
+def save_config(color_scheme, screen_color, button_color, button_text_color):
     os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
     with open(CONFIG_PATH, "w") as f:
         json.dump(
@@ -38,6 +42,7 @@ def save_config(color_scheme, screen_color, button_color):
                 "color_scheme": color_scheme,
                 "screen_color": screen_color,
                 "button_color": button_color,
+                "button_text_color": button_text_color,
             },
             f,
         )
@@ -74,6 +79,7 @@ class RestScreen(MDScreen):
 class WorkoutApp(MDApp):
     screen_color = StringProperty(DEFAULT_SCREEN_COLOR)
     button_color = StringProperty(DEFAULT_BUTTON_COLOR)
+    button_text_color = StringProperty(DEFAULT_BUTTON_TEXT_COLOR)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -81,6 +87,7 @@ class WorkoutApp(MDApp):
         self.color_scheme = cfg["color_scheme"]
         self.screen_color = cfg["screen_color"]
         self.button_color = cfg["button_color"]
+        self.button_text_color = cfg.get("button_text_color", DEFAULT_BUTTON_TEXT_COLOR)
 
     def build(self):
         self.theme_cls.primary_palette = self.color_scheme
@@ -89,15 +96,19 @@ class WorkoutApp(MDApp):
     def change_color_scheme(self, color):
         self.theme_cls.primary_palette = color
         self.color_scheme = color
-        save_config(self.color_scheme, self.screen_color, self.button_color)
+        save_config(self.color_scheme, self.screen_color, self.button_color, self.button_text_color)
 
     def change_screen_color(self, hex_color):
         self.screen_color = hex_color
-        save_config(self.color_scheme, self.screen_color, self.button_color)
+        save_config(self.color_scheme, self.screen_color, self.button_color, self.button_text_color)
 
     def change_button_color(self, hex_color):
         self.button_color = hex_color
-        save_config(self.color_scheme, self.screen_color, self.button_color)
+        save_config(self.color_scheme, self.screen_color, self.button_color, self.button_text_color)
+
+    def toggle_button_text_color(self):
+        self.button_text_color = "#000000" if self.button_text_color == "#FFFFFF" else "#FFFFFF"
+        save_config(self.color_scheme, self.screen_color, self.button_color, self.button_text_color)
 
     def get_color_tuple(self, hex_color):
         return get_color_from_hex(hex_color)
@@ -115,13 +126,20 @@ class WorkoutApp(MDApp):
 
     def open_button_color_picker(self):
         picker = ColorPicker()
-        popup = Popup(title="Button Color", content=picker, size_hint=(0.9, 0.9))
+        toggle = MDRaisedButton(text="Toggle Text Color")
+        layout = BoxLayout(orientation="vertical")
+        layout.add_widget(picker)
+        layout.add_widget(toggle)
+        popup = Popup(title="Button Color", content=layout, size_hint=(0.9, 0.9))
 
         def on_color(instance, value):
             self.change_button_color(get_hex_from_color(value))
-            popup.dismiss()
+
+        def on_toggle(instance):
+            self.toggle_button_text_color()
 
         picker.bind(color=on_color)
+        toggle.bind(on_release=on_toggle)
         popup.open()
 
     def go_home(self):

--- a/settings/config.json
+++ b/settings/config.json
@@ -1,0 +1,6 @@
+{
+  "color_scheme": "Blue",
+  "screen_color": "#FFFFFF",
+  "button_color": "#2196F3",
+  "button_text_color": "#FFFFFF"
+}

--- a/workout_app/settings/config.json
+++ b/workout_app/settings/config.json
@@ -1,5 +1,0 @@
-{
-  "color_scheme": "Blue",
-  "screen_color": "#FFFFFF",
-  "button_color": "#2196F3"
-}


### PR DESCRIPTION
## Summary
- store configuration in a top-level `settings` directory
- simplify settings screen to only Button Color and Screen Color choices
- add text color toggle for buttons
- update all buttons to respect color preferences

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686423fd37a48332967412d080a01a8c