### PR TITLE
Add rest countdown and workout stopwatch

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -1,11 +1,11 @@
 MDScreenManager:
+    RestScreen:
+    ActiveScreen:
     WelcomeScreen:
     HomeScreen:
     SelectWorkoutScreen:
     SettingsScreen:
     StartWorkoutScreen:
-    ActiveScreen:
-    RestScreen:
 
 <WelcomeScreen>:
     name: "welcome"
@@ -138,7 +138,7 @@ MDScreenManager:
         MDRaisedButton:
             text: "Begin"
             pos_hint: {"center_x": 0.5}
-            on_release: app.root.current = "active"
+            on_release: app.root.current = "rest"
             md_bg_color: app.get_color_tuple(app.button_color)
         MDRaisedButton:
             text: "Back"
@@ -157,16 +157,11 @@ MDScreenManager:
             text: "Active Workout"
             halign: "center"
             font_style: "H5"
-        MDRaisedButton:
-            text: "Next"
-            pos_hint: {"center_x": 0.5}
-            on_release: app.root.current = "rest"
-            md_bg_color: app.get_color_tuple(app.button_color)
-        MDRaisedButton:
-            text: "Stop"
-            pos_hint: {"center_x": 0.5}
-            on_release: app.go_home()
-            md_bg_color: app.get_color_tuple(app.button_color)
+        MDLabel:
+            id: active_timer
+            text: '{:02d}:{:02d}'.format(int(root.time_elapsed // 60), int(root.time_elapsed % 60))
+            halign: "center"
+            font_style: "H2"
 
 <RestScreen>:
     name: "rest"
@@ -180,12 +175,10 @@ MDScreenManager:
             halign: "center"
             font_style: "H5"
         MDRaisedButton:
-            text: "Next"
-            pos_hint: {"center_x": 0.5}
-            on_release: app.root.current = "active"
-            md_bg_color: app.get_color_tuple(app.button_color)
-        MDRaisedButton:
-            text: "Stop"
-            pos_hint: {"center_x": 0.5}
-            on_release: app.go_home()
-            md_bg_color: app.get_color_tuple(app.button_color)
+            id: rest_timer
+            text: str(root.timer)
+            on_release: root.toggle_ready()
+            md_bg_color: (0,1,0,1) if root.ready else (1,0,0,1)
+            size_hint_y: None
+            height: dp(200)
+            font_size: "48sp"

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 import json
 import os
 from kivy.lang import Builder
-from kivy.properties import StringProperty
+from kivy.properties import StringProperty, NumericProperty, BooleanProperty
+from kivy.clock import Clock
 from kivy.utils import get_color_from_hex, get_hex_from_color
 from kivy.uix.colorpicker import ColorPicker
 from kivy.uix.popup import Popup
@@ -64,11 +65,47 @@ class StartWorkoutScreen(MDScreen):
 
 
 class ActiveScreen(MDScreen):
-    pass
+    time_elapsed = NumericProperty(0)
+    _event = None
+
+    def on_pre_enter(self, *args):
+        self.time_elapsed = 0
+        self._event = Clock.schedule_interval(self._update_time, 1)
+
+    def on_leave(self, *args):
+        if self._event:
+            self._event.cancel()
+
+    def _update_time(self, dt):
+        self.time_elapsed += 1
 
 
 class RestScreen(MDScreen):
-    pass
+    timer = NumericProperty(20)
+    ready = BooleanProperty(False)
+    _event = None
+
+    def on_pre_enter(self, *args):
+        self.timer = 20
+        self.ready = False
+        self._event = Clock.schedule_interval(self._tick, 1)
+
+    def on_leave(self, *args):
+        if self._event:
+            self._event.cancel()
+
+    def toggle_ready(self):
+        self.ready = not self.ready
+        if self.timer == 0 and self.ready:
+            self.manager.current = "active"
+
+    def _tick(self, dt):
+        if self.ready and self.timer > 0:
+            self.timer -= 1
+            if self.timer <= 0:
+                self.timer = 0
+                if self.ready:
+                    self.manager.current = "active"
 
 
 class WorkoutApp(MDApp):


### PR DESCRIPTION
## Summary
- start the app on the rest screen
- begin workouts from the rest screen instead of the active screen
- add a 20‑second countdown in the rest screen with a ready toggle button
- when the countdown ends while ready, move to the active screen
- replace the active screen contents with a simple stopwatch timer

## Testing
- `python -m py_compile main.py`
- `pytest -q` *(no tests ran)*
- `python main.py` *(failed: ModuleNotFoundError: No module named 'kivy')*

------
https://chatgpt.com/codex/tasks/task_e_686424f4f3c483328584195b67385162