### PR TITLE
Refactor settings with KivyMD color picker

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -76,53 +76,62 @@ MDScreenManager:
 <SettingsScreen>:
     name: "settings"
     MDBoxLayout:
-        md_bg_color: app.get_color_tuple(app.screen_color)
         orientation: "vertical"
-        spacing: dp(20)
-        padding: dp(20)
-        MDLabel:
-            text: "Settings"
-            halign: "center"
-            font_style: "H5"
-        MDLabel:
-            text: "Select Color Scheme"
-            halign: "center"
-        MDGridLayout:
-            cols: 2
-            spacing: dp(10)
-            size_hint_y: None
-            height: self.minimum_height
-            MDRaisedButton:
-                text: "Blue"
-                on_release: app.change_color_scheme("Blue")
-                md_bg_color: app.get_color_tuple(app.button_color)
-            MDRaisedButton:
-                text: "Red"
-                on_release: app.change_color_scheme("Red")
-                md_bg_color: app.get_color_tuple(app.button_color)
-            MDRaisedButton:
-                text: "Green"
-                on_release: app.change_color_scheme("Green")
-                md_bg_color: app.get_color_tuple(app.button_color)
-            MDRaisedButton:
-                text: "Purple"
-                on_release: app.change_color_scheme("Purple")
-                md_bg_color: app.get_color_tuple(app.button_color)
-        MDRaisedButton:
-            text: "Screen Color"
-            pos_hint: {"center_x": 0.5}
-            on_release: app.open_screen_color_picker()
-            md_bg_color: app.get_color_tuple(app.button_color)
-        MDRaisedButton:
-            text: "Button Color"
-            pos_hint: {"center_x": 0.5}
-            on_release: app.open_button_color_picker()
-            md_bg_color: app.get_color_tuple(app.button_color)
-        MDRaisedButton:
-            text: "Back"
-            pos_hint: {"center_x": 0.5}
-            on_release: app.go_home()
-            md_bg_color: app.get_color_tuple(app.button_color)
+        md_bg_color: app.get_color_tuple(app.screen_color)
+
+        MDTopAppBar:
+            title: "Settings"
+            elevation: 10
+            left_action_items: [["arrow-left", lambda x: app.go_home()]]
+
+        ScrollView:
+            MDBoxLayout:
+                orientation: "vertical"
+                padding: dp(20)
+                spacing: dp(20)
+                size_hint_y: None
+                height: self.minimum_height
+
+                MDLabel:
+                    text: "Color Scheme"
+                    halign: "center"
+                    theme_text_color: "Primary"
+
+                MDGridLayout:
+                    cols: 2
+                    spacing: dp(10)
+                    adaptive_height: True
+                    MDRaisedButton:
+                        text: "Blue"
+                        on_release: app.change_color_scheme("Blue")
+                        md_bg_color: app.get_color_tuple(app.button_color)
+                    MDRaisedButton:
+                        text: "Red"
+                        on_release: app.change_color_scheme("Red")
+                        md_bg_color: app.get_color_tuple(app.button_color)
+                    MDRaisedButton:
+                        text: "Green"
+                        on_release: app.change_color_scheme("Green")
+                        md_bg_color: app.get_color_tuple(app.button_color)
+                    MDRaisedButton:
+                        text: "Purple"
+                        on_release: app.change_color_scheme("Purple")
+                        md_bg_color: app.get_color_tuple(app.button_color)
+
+                MDSeparator:
+                    height: dp(1)
+
+                MDRaisedButton:
+                    text: "Screen Color"
+                    pos_hint: {"center_x": 0.5}
+                    on_release: app.open_screen_color_picker()
+                    md_bg_color: app.get_color_tuple(app.button_color)
+
+                MDRaisedButton:
+                    text: "Button Color"
+                    pos_hint: {"center_x": 0.5}
+                    on_release: app.open_button_color_picker()
+                    md_bg_color: app.get_color_tuple(app.button_color)
 
 <StartWorkoutScreen>:
     name: "start_workout"

--- a/main.py
+++ b/main.py
@@ -3,8 +3,7 @@ import os
 from kivy.lang import Builder
 from kivy.properties import StringProperty
 from kivy.utils import get_color_from_hex, get_hex_from_color
-from kivy.uix.colorpicker import ColorPicker
-from kivy.uix.popup import Popup
+from kivymd.uix.picker import MDColorPicker
 from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
 
@@ -103,26 +102,22 @@ class WorkoutApp(MDApp):
         return get_color_from_hex(hex_color)
 
     def open_screen_color_picker(self):
-        picker = ColorPicker()
-        popup = Popup(title="Screen Color", content=picker, size_hint=(0.9, 0.9))
+        picker = MDColorPicker()
 
         def on_color(instance, value):
             self.change_screen_color(get_hex_from_color(value))
-            popup.dismiss()
 
-        picker.bind(color=on_color)
-        popup.open()
+        picker.bind(on_select_color=on_color)
+        picker.open()
 
     def open_button_color_picker(self):
-        picker = ColorPicker()
-        popup = Popup(title="Button Color", content=picker, size_hint=(0.9, 0.9))
+        picker = MDColorPicker()
 
         def on_color(instance, value):
             self.change_button_color(get_hex_from_color(value))
-            popup.dismiss()
 
-        picker.bind(color=on_color)
-        popup.open()
+        picker.bind(on_select_color=on_color)
+        picker.open()
 
     def go_home(self):
         self.root.current = "home"


### PR DESCRIPTION
## Summary
- refactor settings screen to use MDTopAppBar and ScrollView
- replace Kivy `ColorPicker` with `MDColorPicker`
- polish design with separators and KivyMD widgets

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6864264996748332aee51a8b1e40ccd2