### PR TITLE
Implement rest screen countdown logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ class RestScreen(MDScreen):
             self.manager.current = "active"
 
     def _tick(self, dt):
-        if self.ready and self.timer > 0:
+        if self.timer > 0:
             self.timer -= 1
             if self.timer <= 0:
                 self.timer = 0


### PR DESCRIPTION
## Summary
- adjust rest screen behavior so the timer always counts down
- keep the Begin button routing to the rest screen before workouts

## Testing
- `python -m py_compile main.py`
- `python -m py_compile core.py`

------
https://chatgpt.com/codex/tasks/task_e_6864290480f08332a95f3d9cfa544190