### PR TITLE
Fix MDColorPicker import

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,7 +4,9 @@ from kivy.lang import Builder
 from kivy.properties import StringProperty, NumericProperty, BooleanProperty
 from kivy.clock import Clock
 from kivy.utils import get_color_from_hex, get_hex_from_color
-from kivymd.uix.picker import MDColorPicker
+# KivyMD 1.2 moved color picker classes to the "pickers" module
+# instead of "picker".
+from kivymd.uix.pickers import MDColorPicker
 from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.button import MDRaisedButton


### PR DESCRIPTION
## Summary
- fix import path for MDColorPicker in main.py

## Testing
- `python -m py_compile main.py core.py`

------
https://chatgpt.com/codex/tasks/task_e_68642a3d54b88332a811b256aa8f2e85