### PR TITLE
Fix KivyMD toolbar import

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -85,7 +85,7 @@ MDScreenManager:
     MDBoxLayout:
         md_bg_color: app.get_color_tuple(app.screen_color)
         orientation: "vertical"
-        MDToolbar:
+        MDTopAppBar:
             title: "Settings"
             left_action_items: [["arrow-left", lambda x: app.go_home()]]
             elevation: 10

--- a/main.py
+++ b/main.py
@@ -10,7 +10,10 @@ from kivymd.uix.pickers import MDColorPicker
 from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.button import MDRaisedButton
-from kivymd.uix.toolbar import MDToolbar
+# KivyMD >=1.2 renamed MDToolbar to MDTopAppBar and moved it to the
+# "appbar" module. Import the new widget to avoid import errors on
+# recent versions.
+from kivymd.uix.appbar import MDTopAppBar
 
 DEFAULT_COLOR = "Blue"
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "settings", "config.json")


### PR DESCRIPTION
## Summary
- update toolbar import for KivyMD >= 1.2
- update kv file to use `MDTopAppBar`

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'kivy')*

------
https://chatgpt.com/codex/tasks/task_e_68642bbf8be88332a1a7f6f4e4aef7f8