### PR TITLE
Add rest timer

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -134,17 +134,29 @@ ScreenManager:
             text: "Back to Home"
             on_release: app.root.current = "home"
 
-<RestScreen@MDScreen>:
+<RestScreen>:
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
-        MDLabel:
-            text: "RestScreen"
-            halign: "center"
-        MDRaisedButton:
-            text: "Start Set"
-            on_release: app.root.current = "workout_active"
+        BoxLayout:
+            orientation: "horizontal"
+            size_hint_y: None
+            height: self.minimum_height
+            MDIconButton:
+                icon: "plus"
+                on_release: root.adjust_timer(10)
+            MDLabel:
+                id: timer_label
+                text: root.timer_label
+                halign: "center"
+                font_style: "H4"
+            MDIconButton:
+                icon: "minus"
+                on_release: root.adjust_timer(-10)
+        Widget:
+            size_hint_y: None
+            height: "20dp"
         MDRaisedButton:
             text: "Record Metrics"
             on_release: app.root.current = "metric_input"

--- a/main.py
+++ b/main.py
@@ -1,5 +1,46 @@
 from kivymd.app import MDApp
 from kivy.lang import Builder
+from kivymd.uix.screen import MDScreen
+from kivy.properties import StringProperty, NumericProperty
+from kivy.clock import Clock
+import time
+
+
+class RestScreen(MDScreen):
+    timer_label = StringProperty("20")
+    target_time = NumericProperty(0)
+
+    def on_enter(self, *args):
+        self.target_time = time.time() + 20
+        self.update_timer(0)
+        self._event = Clock.schedule_interval(self.update_timer, 1)
+        return super().on_enter(*args)
+
+    def on_leave(self, *args):
+        if hasattr(self, "_event") and self._event:
+            self._event.cancel()
+        return super().on_leave(*args)
+
+    def update_timer(self, dt):
+        remaining = int(self.target_time - time.time())
+        if remaining <= 0:
+            self.timer_label = "0"
+            if hasattr(self, "_event") and self._event:
+                self._event.cancel()
+            if self.manager:
+                self.manager.current = "workout_active"
+        else:
+            self.timer_label = str(remaining)
+
+    def adjust_timer(self, seconds):
+        self.target_time += seconds
+        if self.target_time - time.time() <= 0:
+            if hasattr(self, "_event") and self._event:
+                self._event.cancel()
+            if self.manager:
+                self.manager.current = "workout_active"
+
+
 
 
 class WorkoutApp(MDApp):


### PR DESCRIPTION
## Summary
- implement `RestScreen` timer functionality in `main.py`
- update `RestScreen` layout to show timer with +/- controls and remove manual start button

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6864dfd5b3b083328c4fc1e6e916a29f