### PR TITLE
Improve stopwatch and timer update logic

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,48 +2,48 @@ from kivymd.app import MDApp
 from kivy.lang import Builder
 
 from kivy.clock import Clock
-from kivy.properties import NumericProperty
+from kivy.properties import NumericProperty, StringProperty
 from kivymd.uix.screen import MDScreen
+import time
 
 
 class WorkoutActiveScreen(MDScreen):
     """Screen that shows an active workout with a stopwatch."""
 
-    elapsed = NumericProperty(0)
+    elapsed = NumericProperty(0.0)
+    start_time = NumericProperty(0.0)
     _event = None
 
     def start_timer(self, *args):
-        """Start the stopwatch from zero."""
-        self.elapsed = 0
+        """Start or resume the stopwatch."""
+        if not self.start_time:
+            self.start_time = time.time()
         self.stop_timer()
-        self._event = Clock.schedule_interval(self._increment, 1)
+        self._event = Clock.schedule_interval(self._update_elapsed, 0.1)
 
     def stop_timer(self, *args):
-        """Stop the stopwatch if it is running."""
+        """Stop updating the stopwatch without clearing the start time."""
         if self._event:
             self._event.cancel()
             self._event = None
 
-    def _increment(self, dt):
-        self.elapsed += 1
+    def _update_elapsed(self, dt):
+        self.elapsed = time.time() - self.start_time
 
     def format_time(self):
-        minutes, seconds = divmod(int(self.elapsed), 60)
-        return f"{minutes:02d}:{seconds:02d}"
-from kivymd.uix.screen import MDScreen
-from kivy.properties import StringProperty, NumericProperty
-from kivy.clock import Clock
-import time
+        minutes, seconds = divmod(self.elapsed, 60)
+        return f"{int(minutes):02d}:{seconds:04.1f}"
 
 
 class RestScreen(MDScreen):
-    timer_label = StringProperty("20")
+    timer_label = StringProperty("20.0")
     target_time = NumericProperty(0)
 
     def on_enter(self, *args):
-        self.target_time = time.time() + 20
+        if not self.target_time or self.target_time <= time.time():
+            self.target_time = time.time() + 20
         self.update_timer(0)
-        self._event = Clock.schedule_interval(self.update_timer, 1)
+        self._event = Clock.schedule_interval(self.update_timer, 0.1)
         return super().on_enter(*args)
 
     def on_leave(self, *args):
@@ -52,19 +52,19 @@ class RestScreen(MDScreen):
         return super().on_leave(*args)
 
     def update_timer(self, dt):
-        remaining = int(self.target_time - time.time())
+        remaining = self.target_time - time.time()
         if remaining <= 0:
-            self.timer_label = "0"
+            self.timer_label = "0.0"
             if hasattr(self, "_event") and self._event:
                 self._event.cancel()
             if self.manager:
                 self.manager.current = "workout_active"
         else:
-            self.timer_label = str(remaining)
+            self.timer_label = f"{remaining:.1f}"
 
     def adjust_timer(self, seconds):
         self.target_time += seconds
-        if self.target_time - time.time() <= 0:
+        if self.target_time <= time.time():
             if hasattr(self, "_event") and self._event:
                 self._event.cancel()
             if self.manager:


### PR DESCRIPTION
## Summary
- refine WorkoutActiveScreen to properly track start time and update 10× per second
- smooth RestScreen timer updates with fractional seconds and saved end time

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'kivymd')*

------
https://chatgpt.com/codex/tasks/task_e_6864e1dc8424833295fcd02eca82db3e