### PR TITLE
Enhance preset screen and library navigation

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -64,19 +64,30 @@ ScreenManager:
         ScrollView:
             MDList:
                 OneLineListItem:
+                    id: preset_day1
                     text: "Day 1 - Push"
-                    on_release: root.select_preset("Day 1")
+                    on_release: root.select_preset("Day 1", self)
                 OneLineListItem:
+                    id: preset_day2
                     text: "Day 2 - Pull"
-                    on_release: root.select_preset("Day 2")
+                    on_release: root.select_preset("Day 2", self)
                 OneLineListItem:
+                    id: preset_day3
                     text: "Day 3 - Legs"
-                    on_release: root.select_preset("Day 3")
+                    on_release: root.select_preset("Day 3", self)
         MDLabel:
             text: "Selected: " + root.selected_preset if root.selected_preset else "Select a preset"
             halign: "center"
         MDRaisedButton:
+            text: "Select Preset"
+            disabled: not root.selected_preset
+            on_release: root.confirm_selection()
+        MDRaisedButton:
             text: "Edit Preset"
+            disabled: not root.selected_preset
+            on_release: app.root.current = "edit_preset"
+        MDRaisedButton:
+            text: "New Preset"
             on_release: app.root.current = "edit_preset"
         MDRaisedButton:
             text: "Back to Home"
@@ -88,7 +99,7 @@ ScreenManager:
         spacing: "10dp"
         padding: "20dp"
         MDLabel:
-            text: "PresetDetailScreen"
+            text: root.preset_name if root.preset_name else "PresetDetailScreen"
             halign: "center"
         MDRaisedButton:
             text: "Go to Preset Overview"
@@ -106,8 +117,8 @@ ScreenManager:
             text: "ExerciseLibraryScreen"
             halign: "center"
         MDRaisedButton:
-            text: "Back to Home"
-            on_release: app.root.current = "home"
+            text: "Back"
+            on_release: root.go_back()
 
 <ProgressScreen@MDScreen>:
     BoxLayout:
@@ -270,7 +281,9 @@ ScreenManager:
             halign: "center"
         MDRaisedButton:
             text: "Open Exercise Library"
-            on_release: app.root.current = "exercise_library"
+            on_release:
+                app.root.get_screen('exercise_library').previous_screen = 'edit_preset'
+                app.root.current = 'exercise_library'
         MDRaisedButton:
             text: "Back to Presets"
             on_release: app.root.current = "presets"

--- a/main.py
+++ b/main.py
@@ -1,9 +1,14 @@
 from kivymd.app import MDApp
 from kivy.lang import Builder
-
 from kivy.clock import Clock
-from kivy.properties import NumericProperty
+from kivy.properties import (
+    NumericProperty,
+    StringProperty,
+    ObjectProperty,
+)
 from kivymd.uix.screen import MDScreen
+from core import WORKOUT_PRESETS
+import time
 
 
 class WorkoutActiveScreen(MDScreen):
@@ -30,11 +35,6 @@ class WorkoutActiveScreen(MDScreen):
     def format_time(self):
         minutes, seconds = divmod(int(self.elapsed), 60)
         return f"{minutes:02d}:{seconds:02d}"
-from kivymd.uix.screen import MDScreen
-from kivy.properties import StringProperty, NumericProperty
-from core import WORKOUT_PRESETS
-from kivy.clock import Clock
-import time
 
 
 class RestScreen(MDScreen):
@@ -72,16 +72,39 @@ class RestScreen(MDScreen):
                 self.manager.current = "workout_active"
 
 
-
 class PresetsScreen(MDScreen):
     """Screen to select a workout preset."""
 
     selected_preset = StringProperty("")
+    selected_item = ObjectProperty(None, allownone=True)
 
-    def select_preset(self, name):
-        """Select a preset from WORKOUT_PRESETS."""
+    def select_preset(self, name, item):
+        """Select a preset from WORKOUT_PRESETS and highlight item."""
+        if self.selected_item:
+            self.selected_item.md_bg_color = (0, 0, 0, 0)
+        self.selected_item = item
+        self.selected_item.md_bg_color = MDApp.get_running_app().theme_cls.primary_light
         if name in WORKOUT_PRESETS:
             self.selected_preset = name
+
+    def confirm_selection(self):
+        if self.selected_preset and self.manager:
+            detail = self.manager.get_screen("preset_detail")
+            detail.preset_name = self.selected_preset
+            self.manager.current = "preset_detail"
+
+
+class PresetDetailScreen(MDScreen):
+    preset_name = StringProperty("")
+
+
+class ExerciseLibraryScreen(MDScreen):
+    previous_screen = StringProperty("home")
+
+    def go_back(self):
+        if self.manager:
+            self.manager.current = self.previous_screen
+
 
 class WorkoutApp(MDApp):
     def build(self):


### PR DESCRIPTION
## Summary
- highlight selected preset in **PresetsScreen**
- add buttons for selecting/new presets
- disable preset actions until a preset is chosen
- remember previous screen for **ExerciseLibraryScreen** and allow going back
- display selected preset in **PresetDetailScreen**

## Testing
- `python -m py_compile main.py core.py`

------
https://chatgpt.com/codex/tasks/task_e_6864e37599648332a35b1a948dfdcdd7