### PR TITLE
Simplify preset data model

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,50 +1,33 @@
 """Core data structures for workout presets."""
 
-from dataclasses import dataclass, field
-from typing import List, Dict
+# A very simple representation of workout presets. Each preset only
+# includes a name and a list of exercises. Repetition schemes are not
+# defined here so that workouts can be customised later on.
 
-
-@dataclass
-class Exercise:
-    """Represents a single exercise in a workout preset."""
-
-    name: str
-    sets: int
-    reps: int
-
-
-@dataclass
-class WorkoutPreset:
-    """A workout preset consisting of multiple exercises."""
-
-    name: str
-    exercises: List[Exercise] = field(default_factory=list)
-
-
-WORKOUT_PRESETS: Dict[str, WorkoutPreset] = {
-    "Day 1": WorkoutPreset(
-        name="Day 1 - Push",
-        exercises=[
-            Exercise("Bench Press", 3, 10),
-            Exercise("Overhead Press", 3, 10),
-            Exercise("Tricep Dip", 3, 12),
+WORKOUT_PRESETS = [
+    {
+        "name": "Push",
+        "exercises": [
+            "Bench Press",
+            "Overhead Press",
+            "Tricep Dip",
         ],
-    ),
-    "Day 2": WorkoutPreset(
-        name="Day 2 - Pull",
-        exercises=[
-            Exercise("Pull Up", 3, 8),
-            Exercise("Barbell Row", 3, 10),
-            Exercise("Bicep Curl", 3, 12),
+    },
+    {
+        "name": "Pull",
+        "exercises": [
+            "Pull Up",
+            "Barbell Row",
+            "Bicep Curl",
         ],
-    ),
-    "Day 3": WorkoutPreset(
-        name="Day 3 - Legs",
-        exercises=[
-            Exercise("Squat", 3, 10),
-            Exercise("Lunge", 3, 12),
-            Exercise("Calf Raise", 3, 15),
+    },
+    {
+        "name": "Legs",
+        "exercises": [
+            "Squat",
+            "Lunge",
+            "Calf Raise",
         ],
-    ),
-}
+    },
+]
 

--- a/main.kv
+++ b/main.kv
@@ -64,17 +64,17 @@ ScreenManager:
         ScrollView:
             MDList:
                 OneLineListItem:
-                    id: preset_day1
-                    text: "Day 1 - Push"
-                    on_release: root.select_preset("Day 1", self)
+                    id: preset_push
+                    text: "Push"
+                    on_release: root.select_preset("Push", self)
                 OneLineListItem:
-                    id: preset_day2
-                    text: "Day 2 - Pull"
-                    on_release: root.select_preset("Day 2", self)
+                    id: preset_pull
+                    text: "Pull"
+                    on_release: root.select_preset("Pull", self)
                 OneLineListItem:
-                    id: preset_day3
-                    text: "Day 3 - Legs"
-                    on_release: root.select_preset("Day 3", self)
+                    id: preset_legs
+                    text: "Legs"
+                    on_release: root.select_preset("Legs", self)
         MDLabel:
             text: "Selected: " + root.selected_preset if root.selected_preset else "Select a preset"
             halign: "center"

--- a/main.py
+++ b/main.py
@@ -115,7 +115,7 @@ class PresetsScreen(MDScreen):
             self.selected_item.md_bg_color = (0, 0, 0, 0)
         self.selected_item = item
         self.selected_item.md_bg_color = MDApp.get_running_app().theme_cls.primary_light
-        if name in WORKOUT_PRESETS:
+        if any(p["name"] == name for p in WORKOUT_PRESETS):
             self.selected_preset = name
 
     def confirm_selection(self):


### PR DESCRIPTION
## Summary
- simplify `core.py` by removing dataclasses
- store presets in a list of dictionaries with only names and exercises
- update `main.py` preset selection logic for the new structure
- adjust preset labels in `main.kv` to use Push/Pull/Legs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686518a470d88332b75e70ffcf4e3628