### PR TITLE
Add workout session flow

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -176,6 +176,9 @@ ScreenManager:
             MDIconButton:
                 icon: "plus"
                 on_release: root.adjust_timer(10)
+        MDLabel:
+            text: "Next: " + root.next_exercise_name if root.next_exercise_name else ""
+            halign: "center"
         Widget:
             size_hint_y: None
             height: "20dp"
@@ -193,7 +196,6 @@ ScreenManager:
             on_release: app.root.current = "workout_summary"
 
 <WorkoutActiveScreen>:
-    on_pre_enter: root.start_timer()
     on_leave: root.stop_timer()
     BoxLayout:
         orientation: "vertical"
@@ -205,7 +207,7 @@ ScreenManager:
             halign: "center"
             font_style: "H2"
         MDLabel:
-            text: "WorkoutActiveScreen"
+            text: root.exercise_name
             halign: "center"
         MDRaisedButton:
             text: "End Set"
@@ -225,8 +227,8 @@ ScreenManager:
             MDList:
                 id: metric_list
         MDRaisedButton:
-            text: "Back to Rest"
-            on_release: app.root.current = "rest"
+            text: "Save Metrics"
+            on_release: root.save_metrics()
 
 <WorkoutEditScreen@MDScreen>:
     BoxLayout:
@@ -252,14 +254,15 @@ ScreenManager:
             text: "Back to Rest"
             on_release: app.root.current = "rest"
 
-<WorkoutSummaryScreen@MDScreen>:
+<WorkoutSummaryScreen>:
+    summary_list: summary_list
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
-        MDLabel:
-            text: "WorkoutSummaryScreen"
-            halign: "center"
+        ScrollView:
+            MDList:
+                id: summary_list
         MDRaisedButton:
             text: "Back to Home"
             on_release: app.root.current = "home"
@@ -293,7 +296,7 @@ ScreenManager:
             text: "Back to Presets"
             on_release: app.root.current = "presets"
 
-<PresetOverviewScreen@MDScreen>:
+<PresetOverviewScreen>:
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -306,5 +309,5 @@ ScreenManager:
             on_release: app.root.current = "preset_detail"
         MDRaisedButton:
             text: "Start Workout"
-            on_release: app.root.current = "rest"
+            on_release: root.start_workout()
 

--- a/main.py
+++ b/main.py
@@ -11,10 +11,39 @@ from kivymd.uix.screen import MDScreen
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.textfield import MDTextField
 from kivymd.uix.label import MDLabel
+from kivymd.uix.list import OneLineListItem
 from core import WORKOUT_PRESETS
 
 import time
 import math
+
+
+class WorkoutSession:
+    """Simple in-memory representation of a workout session."""
+
+    def __init__(self, exercises, sets_per_exercise=1):
+        self.exercises = [
+            {"name": name, "sets": sets_per_exercise, "results": []}
+            for name in exercises
+        ]
+        self.current_exercise = 0
+        self.current_set = 0
+
+    def next_exercise_name(self):
+        if self.current_exercise < len(self.exercises):
+            return self.exercises[self.current_exercise]["name"]
+        return ""
+
+    def record_metrics(self, metrics):
+        if self.current_exercise >= len(self.exercises):
+            return True
+        ex = self.exercises[self.current_exercise]
+        ex["results"].append(metrics)
+        self.current_set += 1
+        if self.current_set >= ex["sets"]:
+            self.current_set = 0
+            self.current_exercise += 1
+        return self.current_exercise >= len(self.exercises)
 
 
 class WorkoutActiveScreen(MDScreen):
@@ -23,6 +52,7 @@ class WorkoutActiveScreen(MDScreen):
     elapsed = NumericProperty(0.0)
     start_time = NumericProperty(0.0)
     formatted_time = StringProperty("00:00")
+    exercise_name = StringProperty("")
     _event = None
 
     def start_timer(self, *args):
@@ -32,6 +62,13 @@ class WorkoutActiveScreen(MDScreen):
         self.formatted_time = "00:00"
         self.start_time = time.time()
         self._event = Clock.schedule_interval(self._update_elapsed, 0.1)
+
+    def on_pre_enter(self, *args):
+        session = MDApp.get_running_app().workout_session
+        if session:
+            self.exercise_name = session.next_exercise_name()
+        self.start_timer()
+        return super().on_pre_enter(*args)
 
     def stop_timer(self, *args):
         """Stop updating the stopwatch without clearing the start time."""
@@ -50,8 +87,12 @@ class WorkoutActiveScreen(MDScreen):
 class RestScreen(MDScreen):
     timer_label = StringProperty("00:20")
     target_time = NumericProperty(0)
+    next_exercise_name = StringProperty("")
 
     def on_enter(self, *args):
+        session = MDApp.get_running_app().workout_session
+        if session:
+            self.next_exercise_name = session.next_exercise_name()
         if not self.target_time or self.target_time <= time.time():
             self.target_time = time.time() + 20
         self.update_timer(0)
@@ -103,6 +144,23 @@ class MetricInputScreen(MDScreen):
             row.add_widget(MDTextField(multiline=False))
             self.metric_list.add_widget(row)
 
+    def save_metrics(self):
+        metrics = {}
+        for row in reversed(self.metric_list.children):
+            if len(row.children) >= 2:
+                text_input = row.children[0]
+                label = row.children[1]
+                metrics[label.text] = text_input.text
+        app = MDApp.get_running_app()
+        if app.workout_session:
+            finished = app.workout_session.record_metrics(metrics)
+            if finished and self.manager:
+                self.manager.current = "workout_summary"
+            elif self.manager:
+                self.manager.current = "rest"
+        elif self.manager:
+            self.manager.current = "rest"
+
 class PresetsScreen(MDScreen):
     """Screen to select a workout preset."""
 
@@ -117,6 +175,7 @@ class PresetsScreen(MDScreen):
         self.selected_item.md_bg_color = MDApp.get_running_app().theme_cls.primary_light
         if any(p["name"] == name for p in WORKOUT_PRESETS):
             self.selected_preset = name
+            MDApp.get_running_app().selected_preset = name
 
     def confirm_selection(self):
         if self.selected_preset and self.manager:
@@ -137,9 +196,56 @@ class ExerciseLibraryScreen(MDScreen):
             self.manager.current = self.previous_screen
 
 
+class PresetOverviewScreen(MDScreen):
+    def start_workout(self):
+        app = MDApp.get_running_app()
+        preset_name = app.selected_preset
+        exercises = []
+        for p in WORKOUT_PRESETS:
+            if p["name"] == preset_name:
+                exercises = p["exercises"]
+                break
+        app.start_workout(exercises)
+        if self.manager:
+            self.manager.current = "rest"
+
+
+class WorkoutSummaryScreen(MDScreen):
+    summary_list = ObjectProperty(None)
+
+    def on_pre_enter(self, *args):
+        self.populate()
+        return super().on_pre_enter(*args)
+
+    def populate(self):
+        if not self.summary_list:
+            return
+        self.summary_list.clear_widgets()
+        app = MDApp.get_running_app()
+        session = app.workout_session
+        if not session:
+            return
+        for exercise in session.exercises:
+            self.summary_list.add_widget(OneLineListItem(text=exercise["name"]))
+            for idx, metrics in enumerate(exercise["results"], 1):
+                metrics_text = ", ".join(f"{k}: {v}" for k, v in metrics.items())
+                self.summary_list.add_widget(
+                    OneLineListItem(text=f"Set {idx}: {metrics_text}")
+                )
+
+
 class WorkoutApp(MDApp):
+    workout_session = None
+    selected_preset = ""
+
     def build(self):
         return Builder.load_file("main.kv")
+
+    def start_workout(self, exercises):
+        if exercises:
+            self.workout_session = WorkoutSession(exercises, sets_per_exercise=3)
+        else:
+            self.workout_session = None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a `WorkoutSession` helper and track session state in `WorkoutApp`
- update active/rest/metric screens to pull info from the session
- implement preset overview and summary screens in Python
- show next exercise, save metrics, and list results

## Testing
- `python -m py_compile main.py`
- `python -m py_compile core.py`

------
https://chatgpt.com/codex/tasks/task_e_68651b0273d08332afba65c7206e853a