### PR TITLE
Display set info and preset overview

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -336,15 +336,21 @@ ScreenManager:
             on_release: app.root.current = "presets"
 
 <PresetOverviewScreen>:
+    overview_list: overview_list
+    preset_label: preset_label
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
         MDLabel:
-            text: "Preset Overview - summary of the chosen preset"
+            id: preset_label
+            text: ""
             halign: "center"
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1
+        ScrollView:
+            MDList:
+                id: overview_list
         MDRaisedButton:
             text: "Back to Detail"
             on_release: app.root.current = "preset_detail"


### PR DESCRIPTION
## Summary
- show sets in workout active and rest screens
- add preset overview list with set count
- centralize default sets per exercise

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686525ea343c8332a29fff2f74a5bc1a