### PR TITLE
Implement ready state for rest timer

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -192,6 +192,8 @@ ScreenManager:
                 text: root.timer_label
                 halign: "center"
                 font_style: "H4"
+                theme_text_color: "Custom"
+                text_color: root.timer_color
             MDIconButton:
                 icon: "plus"
                 on_release: root.adjust_timer(10)


### PR DESCRIPTION
## Summary
- add ready timer state in RestScreen
- toggle ready state by tapping the timer
- only transition when timer is ready and reaches zero
- allow resuming countdown when adding time from zero
- show timer color based on ready state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686544d426a4833298faa93fd972759e