### PR TITLE
Fix rest timer adjustment when expired

### DIFF
--- a/main.py
+++ b/main.py
@@ -171,8 +171,10 @@ class RestScreen(MDScreen):
             self.timer_label = f"{minutes:02d}:{seconds:02d}"
 
     def adjust_timer(self, seconds):
-        self.target_time += seconds
         now = time.time()
+        if self.target_time <= now:
+            self.target_time = now
+        self.target_time += seconds
         if self.target_time <= now:
             self.target_time = now
             if hasattr(self, "_event") and self._event:


### PR DESCRIPTION
## Summary
- ensure pressing `+` after the rest timer reaches zero starts a full 10‑second countdown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656137550c833287af7925d70a03f5