### PR TITLE
Connect presets to database

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,0 +1,69 @@
+import sqlite3
+from pathlib import Path
+
+# Number of sets each exercise defaults to when starting a workout
+DEFAULT_SETS_PER_EXERCISE = 2
+
+# Will hold preset data loaded from the database. Each item is a dict with
+#   {'name': <preset name>, 'exercises': [<exercise names>]}
+WORKOUT_PRESETS = []
+
+def load_workout_presets(db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db"):
+    """Load workout presets from the SQLite database into WORKOUT_PRESETS."""
+    global WORKOUT_PRESETS
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute("SELECT id, name FROM presets ORDER BY id")
+    presets = []
+    for preset_id, preset_name in cursor.fetchall():
+        cursor.execute(
+            """
+            SELECT e.name
+            FROM sections s
+            JOIN section_exercises se ON se.section_id = s.id
+            JOIN exercises e ON se.exercise_id = e.id
+            WHERE s.preset_id = ?
+            ORDER BY s.position, se.position
+            """,
+            (preset_id,),
+        )
+        exercises = [row[0] for row in cursor.fetchall()]
+        presets.append({"name": preset_name, "exercises": exercises})
+    conn.close()
+    WORKOUT_PRESETS = presets
+    return presets
+
+
+class WorkoutSession:
+    """Simple in-memory representation of a workout session."""
+
+    def __init__(self, exercises, sets_per_exercise=1):
+        self.exercises = [
+            {"name": name, "sets": sets_per_exercise, "results": []}
+            for name in exercises
+        ]
+        self.current_exercise = 0
+        self.current_set = 0
+
+    def next_exercise_name(self):
+        if self.current_exercise < len(self.exercises):
+            return self.exercises[self.current_exercise]["name"]
+        return ""
+
+    def next_exercise_display(self):
+        if self.current_exercise < len(self.exercises):
+            ex = self.exercises[self.current_exercise]
+            return f"{ex['name']} set {self.current_set + 1} of {ex['sets']}"
+        return ""
+
+    def record_metrics(self, metrics):
+        if self.current_exercise >= len(self.exercises):
+            return True
+        ex = self.exercises[self.current_exercise]
+        ex["results"].append(metrics)
+        self.current_set += 1
+        if self.current_set >= ex["sets"]:
+            self.current_set = 0
+            self.current_exercise += 1
+        return self.current_exercise >= len(self.exercises)

--- a/main.py
+++ b/main.py
@@ -14,68 +14,21 @@ from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.textfield import MDTextField
 from kivymd.uix.label import MDLabel
 from kivymd.uix.list import OneLineListItem
+from pathlib import Path
 
-DEFAULT_SETS_PER_EXERCISE = 2
-WORKOUT_PRESETS = [
-    {
-        "name": "Day 1: Push",
-        "exercises": [
-            "Bench Press",
-            "Overhead Press",
-        ],
-    },
-    {
-        "name": "Day 2: Pull",
-        "exercises": [
-            "Barbell Row",
-            "Bicep Curl",
-        ],
-    },
-    {
-        "name": "Day 3: Legs",
-        "exercises": [
-            "Squat",
-            "Lunge",
-        ],
-    },
-]
+from core import (
+    DEFAULT_SETS_PER_EXERCISE,
+    WORKOUT_PRESETS,
+    WorkoutSession,
+    load_workout_presets,
+)
+
+# Load workout presets from the database at startup
+load_workout_presets(Path(__file__).resolve().parent / "data" / "workout.db")
 
 import time
 import math
 
-
-class WorkoutSession:
-    """Simple in-memory representation of a workout session."""
-
-    def __init__(self, exercises, sets_per_exercise=1):
-        self.exercises = [
-            {"name": name, "sets": sets_per_exercise, "results": []}
-            for name in exercises
-        ]
-        self.current_exercise = 0
-        self.current_set = 0
-
-    def next_exercise_name(self):
-        if self.current_exercise < len(self.exercises):
-            return self.exercises[self.current_exercise]["name"]
-        return ""
-
-    def next_exercise_display(self):
-        if self.current_exercise < len(self.exercises):
-            ex = self.exercises[self.current_exercise]
-            return f"{ex['name']} set {self.current_set + 1} of {ex['sets']}"
-        return ""
-
-    def record_metrics(self, metrics):
-        if self.current_exercise >= len(self.exercises):
-            return True
-        ex = self.exercises[self.current_exercise]
-        ex["results"].append(metrics)
-        self.current_set += 1
-        if self.current_set >= ex["sets"]:
-            self.current_set = 0
-            self.current_exercise += 1
-        return self.current_exercise >= len(self.exercises)
 
 
 class WorkoutActiveScreen(MDScreen):


### PR DESCRIPTION
## Summary
- move workout session logic and preset config into `core.py`
- load presets from `data/workout.db` at start up
- update `main.py` to use presets from `core`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865856cfd0c83328f03387a8b57cfdf