### PR TITLE
Remove debug print from PresetsScreen

### DIFF
--- a/main.py
+++ b/main.py
@@ -192,8 +192,6 @@ class PresetsScreen(MDScreen):
         if not self.preset_list:
             return
         self.preset_list.clear_widgets()
-        # Debug print to inspect loaded presets
-        print("WORKOUT_PRESETS:", core.WORKOUT_PRESETS)
         for preset in core.WORKOUT_PRESETS:
             item = OneLineListItem(text=preset["name"])
             item.bind(on_release=lambda inst, name=preset["name"]: self.select_preset(name, inst))


### PR DESCRIPTION
## Summary
- remove print statement from PresetsScreen.populate

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: unable to open database file)*

------
https://chatgpt.com/codex/tasks/task_e_6866284d1fb48332b4420b23fcb8e50d