### PR TITLE
Support exercise specific set counts

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,6 @@ from pathlib import Path
 # Import core so we can always reference the up-to-date WORKOUT_PRESETS list
 import core
 from core import (
-    DEFAULT_SETS_PER_EXERCISE,
     WorkoutSession,
     load_workout_presets,
 )
@@ -249,7 +248,7 @@ class PresetOverviewScreen(MDScreen):
             if p["name"] == preset_name:
                 for ex in p["exercises"]:
                     self.overview_list.add_widget(
-                        OneLineListItem(text=f"{ex} - sets: {DEFAULT_SETS_PER_EXERCISE}")
+                        OneLineListItem(text=f"{ex['name']} - sets: {ex['sets']}")
                     )
                 break
 
@@ -298,10 +297,9 @@ class WorkoutApp(MDApp):
         return Builder.load_file("main.kv")
 
     def start_workout(self, exercises):
+        """Initialize a workout session from a list of exercise dicts."""
         if exercises:
-            self.workout_session = WorkoutSession(
-                exercises, sets_per_exercise=DEFAULT_SETS_PER_EXERCISE
-            )
+            self.workout_session = WorkoutSession(exercises)
         else:
             self.workout_session = None
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,4 +1,5 @@
 import sqlite3
+from pathlib import Path
 
 def show_workout_structure(db_path):
     conn = sqlite3.connect(db_path)
@@ -37,5 +38,6 @@ def show_workout_structure(db_path):
 
     conn.close()
 
-# Example usage:
-show_workout_structure("../data/workout.db")
+if __name__ == "__main__":
+    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+    show_workout_structure(str(db_path))

--- a/tests/test_load_presets.py
+++ b/tests/test_load_presets.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import core
+
+
+def test_load_workout_presets_sets():
+    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+    presets = core.load_workout_presets(db_path)
+    assert presets, "No presets loaded"
+    first = presets[0]
+    assert "exercises" in first
+    assert isinstance(first["exercises"], list)
+    assert first["exercises"]
+    # All exercises in sample DB have 3 sets
+    for ex in first["exercises"]:
+        assert ex["sets"] == 3
+


### PR DESCRIPTION
## Summary
- expose `number_of_sets` when loading presets
- carry those set counts into workout sessions
- display exercise sets in preset overview
- initialize sessions with exercise specific sets
- add regression test for preset loading
- fix `tests/test_db.py` so pytest can run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662908bd44833295e31ba7ebf6dd62