### PR TITLE
Support preset sets

### DIFF
--- a/core.py
+++ b/core.py
@@ -5,7 +5,8 @@ from pathlib import Path
 DEFAULT_SETS_PER_EXERCISE = 2
 
 # Will hold preset data loaded from the database. Each item is a dict with
-#   {'name': <preset name>, 'exercises': [<exercise names>]}
+#   {'name': <preset name>,
+#    'exercises': [{'name': <exercise name>, 'sets': <number_of_sets>}, ...]}
 WORKOUT_PRESETS = []
 
 def load_workout_presets(db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db"):
@@ -19,7 +20,7 @@ def load_workout_presets(db_path: Path = Path(__file__).resolve().parent / "data
     for preset_id, preset_name in cursor.fetchall():
         cursor.execute(
             """
-            SELECT e.name
+            SELECT e.name, se.number_of_sets
             FROM sections s
             JOIN section_exercises se ON se.section_id = s.id
             JOIN exercises e ON se.exercise_id = e.id
@@ -28,7 +29,9 @@ def load_workout_presets(db_path: Path = Path(__file__).resolve().parent / "data
             """,
             (preset_id,),
         )
-        exercises = [row[0] for row in cursor.fetchall()]
+        exercises = [
+            {"name": row[0], "sets": row[1]} for row in cursor.fetchall()
+        ]
         presets.append({"name": preset_name, "exercises": exercises})
     conn.close()
     WORKOUT_PRESETS = presets
@@ -38,10 +41,11 @@ def load_workout_presets(db_path: Path = Path(__file__).resolve().parent / "data
 class WorkoutSession:
     """Simple in-memory representation of a workout session."""
 
-    def __init__(self, exercises, sets_per_exercise=1):
+    def __init__(self, exercises):
+        """Initialize with a list of ``{'name', 'sets'}`` dictionaries."""
         self.exercises = [
-            {"name": name, "sets": sets_per_exercise, "results": []}
-            for name in exercises
+            {"name": ex["name"], "sets": ex["sets"], "results": []}
+            for ex in exercises
         ]
         self.current_exercise = 0
         self.current_set = 0

--- a/main.py
+++ b/main.py
@@ -19,7 +19,6 @@ from pathlib import Path
 # Import core so we can always reference the up-to-date WORKOUT_PRESETS list
 import core
 from core import (
-    DEFAULT_SETS_PER_EXERCISE,
     WorkoutSession,
     load_workout_presets,
 )
@@ -247,7 +246,7 @@ class PresetOverviewScreen(MDScreen):
             if p["name"] == preset_name:
                 for ex in p["exercises"]:
                     self.overview_list.add_widget(
-                        OneLineListItem(text=f"{ex} - sets: {DEFAULT_SETS_PER_EXERCISE}")
+                        OneLineListItem(text=f"{ex['name']} - sets: {ex['sets']}")
                     )
                 break
 
@@ -297,9 +296,7 @@ class WorkoutApp(MDApp):
 
     def start_workout(self, exercises):
         if exercises:
-            self.workout_session = WorkoutSession(
-                exercises, sets_per_exercise=DEFAULT_SETS_PER_EXERCISE
-            )
+            self.workout_session = WorkoutSession(exercises)
         else:
             self.workout_session = None
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,28 +9,28 @@ EXPECTED_PRESETS = [
     {
         "name": "Push Day",
         "exercises": [
-            "Shoulder Circles",
-            "Push-ups",
-            "Bench Press",
-            "Overhead Press",
+            {"name": "Shoulder Circles", "sets": 3},
+            {"name": "Push-ups", "sets": 3},
+            {"name": "Bench Press", "sets": 3},
+            {"name": "Overhead Press", "sets": 3},
         ],
     },
     {
         "name": "Pull Day",
         "exercises": [
-            "Jumping Jacks",
-            "Front Lever",
-            "Pull-ups",
-            "Barbell Rows",
+            {"name": "Jumping Jacks", "sets": 3},
+            {"name": "Front Lever", "sets": 3},
+            {"name": "Pull-ups", "sets": 3},
+            {"name": "Barbell Rows", "sets": 3},
         ],
     },
     {
         "name": "Leg Day",
         "exercises": [
-            "Skipping Rope",
-            "Squats",
-            "Deadlifts",
-            "Lunges",
+            {"name": "Skipping Rope", "sets": 3},
+            {"name": "Squats", "sets": 3},
+            {"name": "Deadlifts", "sets": 3},
+            {"name": "Lunges", "sets": 3},
         ],
     },
 ]
@@ -40,3 +40,11 @@ def test_load_workout_presets_updates_global():
     presets = core.load_workout_presets(db_path)
     assert presets == EXPECTED_PRESETS
     assert core.WORKOUT_PRESETS == EXPECTED_PRESETS
+
+
+def test_exercise_set_counts():
+    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+    presets = core.load_workout_presets(db_path)
+    for preset in presets:
+        for exercise in preset["exercises"]:
+            assert exercise["sets"] == 3


### PR DESCRIPTION
## Summary
- load number of sets from DB and store with exercises
- allow WorkoutSession to take per-exercise set counts
- show each preset exercise's sets in UI
- pass exercises with sets into WorkoutSession
- adjust tests for new structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662ad894fc8332924ebd3c3c66fee2