### PR TITLE
Fix metric screen defaults

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -238,7 +238,7 @@ ScreenManager:
         spacing: "10dp"
         padding: "20dp"
         MDLabel:
-            text: "Metric Input - log the weight, reps and other info you just performed"
+            text: "Metric Input - log the metrics for the exercise you just performed"
             halign: "center"
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1

--- a/main.py
+++ b/main.py
@@ -148,7 +148,6 @@ class MetricInputScreen(MDScreen):
     """Screen for entering workout metrics."""
 
     metric_list = ObjectProperty(None)
-    default_metrics = ["Weight", "Reps", "RPE"]
 
     def populate_metrics(self, metrics=None):
         """Populate the metric list based on the current exercise."""
@@ -156,7 +155,9 @@ class MetricInputScreen(MDScreen):
         if app.workout_session:
             exercise = app.workout_session.next_exercise_name()
             metrics = get_metrics_for_exercise(exercise)
-        metrics = metrics or self.default_metrics
+        # Do not fall back to default metrics if none are defined
+        if metrics is None:
+            metrics = []
         if not self.metric_list:
             return
         self.metric_list.clear_widgets()


### PR DESCRIPTION
## Summary
- remove hard-coded metrics in MetricInputScreen
- tweak wording of Metric Input label

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868052da6b083328a9cde7e94d0f27e