### PR TITLE
Add exercise selection screen

### DIFF
--- a/core.py
+++ b/core.py
@@ -38,6 +38,16 @@ def load_workout_presets(db_path: Path = Path(__file__).resolve().parent / "data
     return presets
 
 
+def get_all_exercises(db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db") -> list:
+    """Return a list of all exercise names in the database."""
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM exercises ORDER BY name")
+    exercises = [row[0] for row in cursor.fetchall()]
+    conn.close()
+    return exercises
+
+
 def get_metrics_for_exercise(
     exercise_name: str,
     db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",

--- a/main.kv
+++ b/main.kv
@@ -21,8 +21,8 @@ ScreenManager:
         name: "workout_active"
     MetricInputScreen:
         name: "metric_input"
-    ExerciseScreen:
-        name: "exercise_screen"
+    ExerciseSelectionScreen:
+        name: "exercise_selection"
     WorkoutEditScreen:
         name: "workout_edit"
     WorkoutSettingsScreen:
@@ -342,7 +342,7 @@ ScreenManager:
             height: "40dp"
             on_release:
                 app.root.transition.direction = "up"
-                app.root.current = "exercise_screen"
+                app.root.current = "exercise_selection"
 
 <EditPresetScreen>:
     preset_name: app.selected_preset if app.selected_preset else "Preset"
@@ -366,19 +366,28 @@ ScreenManager:
             text: "Back to Presets"
             on_release: app.root.current = "presets"
 
-<ExerciseScreen>:
+<ExerciseSelectionScreen>:
+    selected_list: selected_list
+    exercise_list: exercise_list
     BoxLayout:
         orientation: "vertical"
-        BoxLayout:
-            size_hint_y: 0.33
-            MDLabel:
-                text: "Top Section"
-                halign: "center"
-        BoxLayout:
-            size_hint_y: 0.67
-            MDLabel:
-                text: "Bottom Section"
-                halign: "center"
+        MDLabel:
+            text: "Selected Exercises"
+            halign: "center"
+            size_hint_y: None
+            height: "30dp"
+        ScrollView:
+            size_hint_y: 0.4
+            MDList:
+                id: selected_list
+        MDLabel:
+            text: "Available Exercises"
+            halign: "center"
+            size_hint_y: None
+            height: "30dp"
+        ScrollView:
+            MDList:
+                id: exercise_list
         MDRaisedButton:
             text: "Done"
             size_hint_y: None

--- a/main.py
+++ b/main.py
@@ -401,10 +401,29 @@ class EditPresetScreen(MDScreen):
         return section
 
 
-class ExerciseScreen(MDScreen):
-    """Placeholder screen for choosing an exercise."""
+class ExerciseSelectionScreen(MDScreen):
+    """Screen for selecting exercises to add to a preset section."""
 
-    pass
+    selected_list = ObjectProperty(None)
+    exercise_list = ObjectProperty(None)
+
+    def on_pre_enter(self, *args):
+        self.populate_exercises()
+        return super().on_pre_enter(*args)
+
+    def populate_exercises(self):
+        if not self.exercise_list:
+            return
+        self.exercise_list.clear_widgets()
+        for name in core.get_all_exercises():
+            item = OneLineListItem(text=name)
+            item.bind(on_release=lambda inst, n=name: self.add_selected(n))
+            self.exercise_list.add_widget(item)
+
+    def add_selected(self, name):
+        if not self.selected_list:
+            return
+        self.selected_list.add_widget(OneLineListItem(text=name))
 
 
 class WorkoutApp(MDApp):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -48,3 +48,13 @@ def test_get_metrics_for_exercise():
         if metric["source_type"] == "manual_enum":
             assert isinstance(metric["values"], list)
             assert metric["values"]
+
+
+def test_get_all_exercises():
+    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+    exercises = core.get_all_exercises(db_path)
+
+    assert isinstance(exercises, list)
+    assert exercises
+    for name in exercises:
+        assert isinstance(name, str)


### PR DESCRIPTION
## Summary
- rename `exercise_screen` to `exercise_selection`
- add `get_all_exercises` helper
- implement `ExerciseSelectionScreen` with selectable exercises
- update kv layout for new screen
- test getting exercises

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbee4717c8332ad690bb5963a2303