### PR TITLE
Add 'Add Section' button to preset editor

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -363,6 +363,9 @@ ScreenManager:
                 size_hint_y: None
                 height: self.minimum_height
         MDRaisedButton:
+            text: "Add Section"
+            on_release: root.add_section()
+        MDRaisedButton:
             text: "Back to Presets"
             on_release: app.root.current = "presets"
 


### PR DESCRIPTION
## Summary
- add a new button in `EditPresetScreen` for adding workout sections

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbf26ccc08332b0fc96f233d62551