### PR TITLE
Add reorder/remove controls in exercise selection screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -369,6 +369,27 @@ ScreenManager:
             text: "Back to Presets"
             on_release: app.root.current = "presets"
 
+<SelectedExerciseItem>:
+    orientation: "horizontal"
+    size_hint_y: None
+    height: "40dp"
+    MDBoxLayout:
+        size_hint_x: None
+        width: "60dp"
+        orientation: "vertical"
+        MDIconButton:
+            icon: "arrow-up"
+            on_release: root.move_up()
+        MDIconButton:
+            icon: "arrow-down"
+            on_release: root.move_down()
+    MDLabel:
+        text: root.text
+        halign: "center"
+    MDIconButton:
+        icon: "close"
+        on_release: root.remove_self()
+
 <ExerciseSelectionScreen>:
     selected_list: selected_list
     exercise_list: exercise_list

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from kivymd.uix.slider import MDSlider
 from kivy.uix.spinner import Spinner
 from kivymd.uix.label import MDLabel
 from kivymd.uix.list import OneLineListItem
+from kivymd.uix.button import MDIconButton
 from pathlib import Path
 
 # Import core so we can always reference the up-to-date WORKOUT_PRESETS list
@@ -401,6 +402,35 @@ class EditPresetScreen(MDScreen):
         return section
 
 
+class SelectedExerciseItem(MDBoxLayout):
+    """Widget representing a selected exercise with reorder controls."""
+
+    text = StringProperty("")
+
+    def move_up(self):
+        parent = self.parent
+        if not parent:
+            return
+        idx = parent.children.index(self)
+        if idx < len(parent.children) - 1:
+            parent.remove_widget(self)
+            parent.add_widget(self, index=idx + 1)
+
+    def move_down(self):
+        parent = self.parent
+        if not parent:
+            return
+        idx = parent.children.index(self)
+        if idx > 0:
+            parent.remove_widget(self)
+            parent.add_widget(self, index=idx - 1)
+
+    def remove_self(self):
+        parent = self.parent
+        if parent:
+            parent.remove_widget(self)
+
+
 class ExerciseSelectionScreen(MDScreen):
     """Screen for selecting exercises to add to a preset section."""
 
@@ -423,7 +453,8 @@ class ExerciseSelectionScreen(MDScreen):
     def add_selected(self, name):
         if not self.selected_list:
             return
-        self.selected_list.add_widget(OneLineListItem(text=name))
+        item = SelectedExerciseItem(text=name)
+        self.selected_list.add_widget(item)
 
 
 class WorkoutApp(MDApp):


### PR DESCRIPTION
## Summary
- implement `SelectedExerciseItem` widget with move up/down/remove methods
- use the new widget when selecting exercises
- add kv layout for the reorder and remove buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc0fdb4b48332bce58bba76ae0ef3