### PR TITLE
Overlay slide transition for exercise selection

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -1,5 +1,4 @@
-#:import RiseInTransition kivy.uix.screenmanager.RiseInTransition
-#:import FallOutTransition kivy.uix.screenmanager.FallOutTransition
+#:import OverlaySlideTransition transitions.OverlaySlideTransition
 ScreenManager:
     WelcomeScreen:
         name: "welcome"
@@ -343,7 +342,7 @@ ScreenManager:
             size_hint_y: None
             height: "40dp"
             on_release:
-                app.root.transition = RiseInTransition()
+                app.root.transition = OverlaySlideTransition(direction="up")
                 app.root.current = "exercise_selection"
 
 <EditPresetScreen>:
@@ -399,7 +398,7 @@ ScreenManager:
             height: "40dp"
             pos_hint: {"center_x": 0.5}
             on_release:
-                app.root.transition = FallOutTransition()
+                app.root.transition = OverlaySlideTransition(direction="down")
                 app.root.current = "edit_preset"
 
 <PresetOverviewScreen>:

--- a/transitions.py
+++ b/transitions.py
@@ -1,0 +1,27 @@
+from kivy.uix.screenmanager import SlideTransition
+from kivy.animation import Animation
+
+class OverlaySlideTransition(SlideTransition):
+    """Slide transition that overlays the new screen without moving the
+    previous screen."""
+
+    def start(self, manager):
+        # Keep references to screens involved in the transition
+        self.manager = manager
+        self.screen_in = manager.next_screen
+        self.screen_out = manager.current_screen
+        width, height = manager.size
+
+        if self.direction == "up":
+            # New screen slides from the bottom over the current screen
+            self.screen_in.pos = (0, -height)
+            anim = Animation(y=0, duration=self.duration, t=self.t)
+            anim.bind(on_complete=lambda *a: self.dispatch("on_complete"))
+            anim.start(self.screen_in)
+        elif self.direction == "down":
+            # Current screen slides down revealing the screen below
+            anim = Animation(y=-height, duration=self.duration, t=self.t)
+            anim.bind(on_complete=lambda *a: self.dispatch("on_complete"))
+            anim.start(self.screen_out)
+        else:
+            super().start(manager)


### PR DESCRIPTION
## Summary
- implement `OverlaySlideTransition` for ScreenManager
- import and use this transition in `main.kv` so Edit Preset stays put when opening Exercise Selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc17e7ff88332ae49b97c6bfc0f5d