### PR TITLE
Add PresetEditor class for preset editing

### DIFF
--- a/core.py
+++ b/core.py
@@ -140,3 +140,91 @@ class WorkoutSession:
             self.current_set = 0
             self.current_exercise += 1
         return self.current_exercise >= len(self.exercises)
+
+
+class PresetEditor:
+    """Helper for creating or editing workout presets in memory."""
+
+    def __init__(
+        self,
+        preset_name: str | None = None,
+        db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    ):
+        """Create the editor and optionally load an existing preset."""
+
+        self.db_path = Path(db_path)
+        self.conn = sqlite3.connect(str(self.db_path))
+
+        self.preset_name: str = preset_name or ""
+        self.sections: list[dict] = []
+
+        if preset_name:
+            self.load(preset_name)
+
+    def load(self, preset_name: str) -> None:
+        """Load ``preset_name`` from the database into memory."""
+
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT id FROM presets WHERE name = ?", (preset_name,))
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Preset '{preset_name}' not found")
+
+        preset_id = row[0]
+        cursor.execute(
+            "SELECT id, name FROM sections WHERE preset_id = ? ORDER BY position",
+            (preset_id,),
+        )
+
+        self.preset_name = preset_name
+        self.sections.clear()
+
+        for section_id, name in cursor.fetchall():
+            cursor.execute(
+                """
+                SELECT e.name, se.number_of_sets
+                FROM section_exercises se
+                JOIN exercises e ON se.exercise_id = e.id
+                WHERE se.section_id = ?
+                ORDER BY se.position
+                """,
+                (section_id,),
+            )
+            exercises = [
+                {"name": ex_name, "sets": sets} for ex_name, sets in cursor.fetchall()
+            ]
+            self.sections.append({"name": name, "exercises": exercises})
+
+    def add_section(self, name: str = "Section") -> int:
+        """Add a new section and return its index."""
+
+        self.sections.append({"name": name, "exercises": []})
+        return len(self.sections) - 1
+
+    def add_exercise(
+        self,
+        section_index: int,
+        exercise_name: str,
+        sets: int = DEFAULT_SETS_PER_EXERCISE,
+    ) -> dict:
+        """Add an exercise to the specified section."""
+
+        if section_index < 0 or section_index >= len(self.sections):
+            raise IndexError("Section index out of range")
+
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT 1 FROM exercises WHERE name = ?", (exercise_name,))
+        if cursor.fetchone() is None:
+            raise ValueError(f"Exercise '{exercise_name}' does not exist")
+
+        ex = {"name": exercise_name, "sets": sets}
+        self.sections[section_index]["exercises"].append(ex)
+        return ex
+
+    def to_dict(self) -> dict:
+        """Return the preset data as a dictionary."""
+
+        return {"name": self.preset_name, "sections": self.sections}
+
+    def close(self) -> None:
+        self.conn.close()

--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import sys
+import pytest
+
+# ensure project root in path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core import PresetEditor, DEFAULT_SETS_PER_EXERCISE
+
+DB_PATH = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+
+
+def test_load_existing_preset():
+    editor = PresetEditor("Push Day", DB_PATH)
+    try:
+        assert editor.preset_name == "Push Day"
+        assert editor.sections
+        for sec in editor.sections:
+            assert "name" in sec
+            assert isinstance(sec["exercises"], list)
+            for ex in sec["exercises"]:
+                assert "name" in ex
+                assert "sets" in ex
+    finally:
+        editor.close()
+
+
+def test_add_section_and_exercise():
+    editor = PresetEditor(db_path=DB_PATH)
+    try:
+        idx = editor.add_section("My Section")
+        assert idx == 0
+        added = editor.add_exercise(idx, "Push-ups")
+        assert added == {"name": "Push-ups", "sets": DEFAULT_SETS_PER_EXERCISE}
+        assert editor.sections[0]["exercises"] == [added]
+    finally:
+        editor.close()
+
+
+def test_add_exercise_validates_name():
+    editor = PresetEditor(db_path=DB_PATH)
+    try:
+        idx = editor.add_section()
+        with pytest.raises(ValueError):
+            editor.add_exercise(idx, "NotReal")
+    finally:
+        editor.close()


### PR DESCRIPTION
## Summary
- add `PresetEditor` to manage preset editing in memory
- unit test for `PresetEditor` behaviors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc70beec48332bf8f093bbf68906f