### PR TITLE
Enable backend-driven preset editing

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -334,15 +334,17 @@ ScreenManager:
         id: exercises_box
         orientation: "vertical"
         size_hint_y: None
-        height: dp(40) if root.expanded else 0
+        height: self.minimum_height if root.expanded else 0
         opacity: 1 if root.expanded else 0
+        MDList:
+            id: exercise_list
+            size_hint_y: None
+            height: self.minimum_height
         MDRaisedButton:
             text: "Add Exercise"
             size_hint_y: None
             height: "40dp"
-            on_release:
-                app.root.transition.direction = "up"
-                app.root.current = "exercise_selection"
+            on_release: root.open_exercise_selection()
 
 <EditPresetScreen>:
     preset_name: app.selected_preset if app.selected_preset else "Preset"
@@ -417,9 +419,7 @@ ScreenManager:
             size_hint_y: None
             height: "40dp"
             pos_hint: {"center_x": 0.5}
-            on_release:
-                app.root.transition.direction = "down"
-                app.root.current = "edit_preset"
+            on_release: root.save_selection()
 
 <PresetOverviewScreen>:
     overview_list: overview_list


### PR DESCRIPTION
## Summary
- hook up `PresetEditor` to preset editing workflow
- track which section is being edited when adding exercises
- preload existing exercises and save selections back to the editor
- default section names increment automatically
- update kv layout for new editing capabilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc8a0a9ec8332b05cdf5f3e0fdec9