### PR TITLE
Inline exercise selector for presets

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -21,8 +21,6 @@ ScreenManager:
         name: "workout_active"
     MetricInputScreen:
         name: "metric_input"
-    ExerciseSelectionScreen:
-        name: "exercise_selection"
     WorkoutEditScreen:
         name: "workout_edit"
     WorkoutSettingsScreen:
@@ -349,27 +347,53 @@ ScreenManager:
 <EditPresetScreen>:
     preset_name: app.selected_preset if app.selected_preset else "Preset"
     sections_box: sections_box
-    BoxLayout:
-        orientation: "vertical"
-        spacing: "10dp"
-        padding: "20dp"
-        MDLabel:
-            text: root.preset_name
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
-        ScrollView:
+    exercise_panel: exercise_panel
+    exercise_list_panel: exercise_list_panel
+    FloatLayout:
+        BoxLayout:
+            orientation: "vertical"
+            spacing: "10dp"
+            padding: "20dp"
+            size_hint: 1, 1
+            MDLabel:
+                text: root.preset_name
+                halign: "center"
+                theme_text_color: "Custom"
+                text_color: 0.2, 0.6, 0.86, 1
+            ScrollView:
+                MDBoxLayout:
+                    id: sections_box
+                    orientation: "vertical"
+                    size_hint_y: None
+                    height: self.minimum_height
+            MDRaisedButton:
+                text: "Add Section"
+                on_release: root.add_section()
+            MDRaisedButton:
+                text: "Back to Presets"
+                on_release: app.root.current = "presets"
+        BoxLayout:
+            id: exercise_panel
+            orientation: "vertical"
+            size_hint_x: 1
+            size_hint_y: None
+            height: 0
+            pos_hint: {"x": 0, "y": 0}
+            md_bg_color: 1,1,1,1
             MDBoxLayout:
-                id: sections_box
-                orientation: "vertical"
                 size_hint_y: None
-                height: self.minimum_height
-        MDRaisedButton:
-            text: "Add Section"
-            on_release: root.add_section()
-        MDRaisedButton:
-            text: "Back to Presets"
-            on_release: app.root.current = "presets"
+                height: "40dp"
+                MDLabel:
+                    text: "Available Exercises"
+                    halign: "center"
+                MDIconButton:
+                    icon: "close"
+                    theme_text_color: "Custom"
+                    text_color: 1,0,0,1
+                    on_release: root.hide_exercise_panel()
+            ScrollView:
+                MDList:
+                    id: exercise_list_panel
 
 <SelectedExerciseItem>:
     orientation: "horizontal"
@@ -392,34 +416,6 @@ ScreenManager:
         icon: "close"
         on_release: root.remove_self()
 
-<ExerciseSelectionScreen>:
-    selected_list: selected_list
-    exercise_list: exercise_list
-    BoxLayout:
-        orientation: "vertical"
-        MDLabel:
-            text: "Selected Exercises"
-            halign: "center"
-            size_hint_y: None
-            height: "30dp"
-        ScrollView:
-            size_hint_y: 0.4
-            MDList:
-                id: selected_list
-        MDLabel:
-            text: "Available Exercises"
-            halign: "center"
-            size_hint_y: None
-            height: "30dp"
-        ScrollView:
-            MDList:
-                id: exercise_list
-        MDRaisedButton:
-            text: "Done"
-            size_hint_y: None
-            height: "40dp"
-            pos_hint: {"center_x": 0.5}
-            on_release: root.save_selection()
 
 <PresetOverviewScreen>:
     overview_list: overview_list


### PR DESCRIPTION
## Summary
- remove `ExerciseSelectionScreen` from the screen manager
- embed exercise selection panel in `EditPresetScreen`
- open/close panel when adding exercises to a section

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cd21df4308332addac9dec91ef8f1