### PR TITLE
Refine preset editing UI

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -355,11 +355,6 @@ ScreenManager:
             spacing: "10dp"
             padding: "20dp"
             size_hint: 1, 1
-            MDLabel:
-                text: root.preset_name
-                halign: "center"
-                theme_text_color: "Custom"
-                text_color: 0.2, 0.6, 0.86, 1
             ScrollView:
                 MDBoxLayout:
                     id: sections_box
@@ -399,36 +394,15 @@ ScreenManager:
         halign: "center"
     MDIconButton:
         icon: "close"
+        theme_text_color: "Custom"
+        text_color: 1, 0, 0, 1
         on_release: root.remove_self()
 
 <ExerciseSelectionPanel@MDBoxLayout>:
-    selected_list: selected_list
     exercise_list: exercise_list
     orientation: "vertical"
     md_bg_color: 1, 1, 1, 1
     MDBoxLayout:
-        size_hint_y: None
-        height: "40dp"
-        MDLabel:
-            text: "Select Exercises"
-            halign: "center"
-        MDIconButton:
-            icon: "close"
-            theme_text_color: "Custom"
-            text_color: 1, 0, 0, 1
-            on_release: app.root.get_screen("edit_preset").close_exercise_panel()
-    MDLabel:
-        text: "Selected Exercises"
-        halign: "center"
-        size_hint_y: None
-        height: "30dp"
-    ScrollView:
-        size_hint_y: 0.4
-        MDList:
-            id: selected_list
-    MDLabel:
-        text: "Select Exercises"
-        halign: "center"
         size_hint_y: None
         height: "40dp"
         MDLabel:


### PR DESCRIPTION
## Summary
- simplify the exercise selection panel
- remove preset label from edit screen
- show red remove buttons for exercises

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ce9fe6fe08332a2e83ca5683d9e1c