### PR TITLE
Fix EditPresetScreen scroll with panel

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -361,6 +361,7 @@ ScreenManager:
                     orientation: "vertical"
                     size_hint_y: None
                     height: self.minimum_height
+                    padding: 0, 0, 0, root.exercise_panel.height if root.panel_visible else 0
             MDRaisedButton:
                 text: "Add Section"
                 on_release: root.add_section()


### PR DESCRIPTION
## Summary
- adjust `sections_box` padding in `EditPresetScreen` so the list can be scrolled fully when the exercise selection panel is open

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cede13c448332a72dfe7414ceff61