### PR TITLE
Add Edit Exercise screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -27,6 +27,8 @@ ScreenManager:
         name: "workout_settings"
     WorkoutSummaryScreen:
         name: "workout_summary"
+    EditExerciseScreen:
+        name: "edit_exercise"
     EditPresetScreen:
         name: "edit_preset"
     PresetOverviewScreen:
@@ -394,6 +396,9 @@ ScreenManager:
         text: root.text
         halign: "center"
     MDIconButton:
+        icon: "pencil"
+        on_release: root.edit()
+    MDIconButton:
         icon: "close"
         theme_text_color: "Custom"
         text_color: 1, 0, 0, 1
@@ -441,4 +446,22 @@ ScreenManager:
         MDRaisedButton:
             text: "Start Workout"
             on_release: root.start_workout()
+
+<EditExerciseScreen>:
+    metrics_list: metrics_list
+    BoxLayout:
+        orientation: "vertical"
+        spacing: "10dp"
+        padding: "20dp"
+        MDLabel:
+            text: root.exercise_name if root.exercise_name else "Edit Exercise"
+            halign: "center"
+            theme_text_color: "Custom"
+            text_color: 0.2, 0.6, 0.86, 1
+        ScrollView:
+            MDList:
+                id: metrics_list
+        MDRaisedButton:
+            text: "Back"
+            on_release: app.root.current = "edit_preset"
 

--- a/main.py
+++ b/main.py
@@ -469,6 +469,15 @@ class SelectedExerciseItem(MDBoxLayout):
 
     text = StringProperty("")
 
+    def edit(self):
+        """Open the EditExerciseScreen for this exercise."""
+        app = MDApp.get_running_app()
+        if not app.root:
+            return
+        screen = app.root.get_screen("edit_exercise")
+        screen.exercise_name = self.text
+        app.root.current = "edit_exercise"
+
     def move_up(self):
         parent = self.parent
         if not parent:
@@ -525,6 +534,25 @@ class ExerciseSelectionPanel(MDBoxLayout):
     def save_selection(self):
         """No-op kept for API compatibility."""
         pass
+
+
+class EditExerciseScreen(MDScreen):
+    """Screen for editing an individual exercise within a preset."""
+
+    exercise_name = StringProperty("")
+    metrics_list = ObjectProperty(None)
+
+    def on_pre_enter(self, *args):
+        self.populate()
+        return super().on_pre_enter(*args)
+
+    def populate(self):
+        if not self.metrics_list or not self.exercise_name:
+            return
+        self.metrics_list.clear_widgets()
+        metrics = core.get_metrics_for_exercise(self.exercise_name)
+        for m in metrics:
+            self.metrics_list.add_widget(OneLineListItem(text=m.get("name", "")))
 
 
 class WorkoutApp(MDApp):


### PR DESCRIPTION
## Summary
- add an edit option for each exercise in EditPresetScreen
- implement EditExerciseScreen to show metrics of the selected exercise

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf865ac0883329ee3c8d1c0852dfd