### PR TITLE
Add previous workouts placeholder screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -33,6 +33,8 @@ ScreenManager:
         name: "edit_preset"
     PresetOverviewScreen:
         name: "preset_overview"
+    PreviousWorkoutsScreen:
+        name: "previous_workouts"
 
 <HomeScreen@MDScreen>:
     BoxLayout:
@@ -205,6 +207,9 @@ ScreenManager:
         MDRaisedButton:
             text: "Workout Settings"
             on_release: app.root.current = "workout_settings"
+        MDRaisedButton:
+            text: "Previous Workouts"
+            on_release: app.root.current = "previous_workouts"
         MDRaisedButton:
             text: "Finish Workout"
             on_release: app.root.current = "workout_summary"
@@ -464,4 +469,26 @@ ScreenManager:
         MDRaisedButton:
             text: "Back"
             on_release: app.root.current = "edit_preset"
+
+<PreviousWorkoutsScreen@MDScreen>:
+    BoxLayout:
+        orientation: "vertical"
+        spacing: "10dp"
+        padding: "20dp"
+        MDLabel:
+            text: "Previous Workouts - guidance"
+            halign: "center"
+            theme_text_color: "Custom"
+            text_color: 0.2, 0.6, 0.86, 1
+        ScrollView:
+            do_scroll_x: True
+            do_scroll_y: True
+            MDBoxLayout:
+                id: previous_container
+                size_hint: None, None
+                width: self.minimum_width
+                height: self.minimum_height
+        MDRaisedButton:
+            text: "Back to Rest"
+            on_release: app.root.current = "rest"
 


### PR DESCRIPTION
## Summary
- create a new `PreviousWorkoutsScreen` placeholder with a 2D scroll view
- allow navigation to the new screen from `RestScreen`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d38c9a30c8332b4caca63f108351f