### PR TITLE
Add metric editing features

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -493,6 +493,9 @@ ScreenManager:
             MDList:
                 id: metrics_list
         MDRaisedButton:
+            text: "Add Metric"
+            on_release: root.open_add_metric_popup()
+        MDRaisedButton:
             text: "Back"
             on_release: app.root.current = "edit_preset"
 


### PR DESCRIPTION
## Summary
- allow viewing and editing metric types
- support creating and deleting metrics for an exercise
- expose DB helpers for metric management
- test CRUD operations on metric types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3d33758c8332bc8fec7732cb1ea5