### PR TITLE
Fix Add Metric popup content

### DIFF
--- a/main.py
+++ b/main.py
@@ -598,7 +598,11 @@ class AddMetricPopup(MDDialog):
         self.desc_input = MDTextField(hint_text="Description")
         self.required_check = MDCheckbox()
 
-        layout = MDBoxLayout(orientation="vertical", spacing="8dp")
+        layout = MDBoxLayout(
+            orientation="vertical",
+            spacing="8dp",
+            adaptive_height=True,
+        )
         layout.add_widget(self.name_input)
         layout.add_widget(self.input_type)
         layout.add_widget(self.source_type)


### PR DESCRIPTION
## Summary
- ensure AddMetricPopup content adapts to its children so the dialog renders correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d42740a448332a74528bc36d5fb6d