### PR TITLE
Add workout summary output

### DIFF
--- a/core.py
+++ b/core.py
@@ -353,6 +353,25 @@ class WorkoutSession:
 
         return False
 
+    def summary(self) -> str:
+        """Return a formatted text summary of the session."""
+
+        end_time = self.end_time or time.time()
+        lines = [f"Workout: {self.preset_name}"]
+        start = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(self.start_time))
+        end = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(end_time))
+        dur = int(end_time - self.start_time)
+        m, s = divmod(dur, 60)
+        lines.append(f"Start: {start}")
+        lines.append(f"End:   {end}")
+        lines.append(f"Duration: {m}m {s}s")
+        for ex in self.exercises:
+            lines.append(f"\n{ex['name']}")
+            for idx, metrics in enumerate(ex['results'], 1):
+                metrics_text = ", ".join(f"{k}: {v}" for k, v in metrics.items())
+                lines.append(f"  Set {idx}: {metrics_text}")
+        return "\n".join(lines)
+
 
 
 class PresetEditor:

--- a/main.py
+++ b/main.py
@@ -371,6 +371,7 @@ class WorkoutSummaryScreen(MDScreen):
         session = app.workout_session
         if not session:
             return
+        print(session.summary())
         for exercise in session.exercises:
             self.summary_list.add_widget(OneLineListItem(text=exercise["name"]))
             for idx, metrics in enumerate(exercise["results"], 1):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -105,3 +105,21 @@ def test_metric_type_crud(tmp_path):
     core.remove_metric_from_exercise("Push-ups", name, db_path)
     metrics = core.get_metrics_for_exercise("Push-ups", db_path)
     assert not any(m["name"] == name for m in metrics)
+
+
+def test_workout_session_summary_contains_details():
+    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+    session = core.WorkoutSession("Push Day", db_path=db_path)
+
+    total_sets = sum(ex["sets"] for ex in session.exercises)
+    for i in range(total_sets):
+        session.record_metrics({"Reps": i + 1})
+
+    summary = session.summary()
+
+    assert "Workout: Push Day" in summary
+    for ex in session.exercises:
+        assert ex["name"] in summary
+    assert "Set 1" in summary
+    assert "Reps" in summary
+    assert "Duration:" in summary


### PR DESCRIPTION
## Summary
- add `WorkoutSession.summary()` helper for producing a formatted summary
- print the summary when showing the workout summary screen
- test new summary helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d420861788332b60a315f9798b647