### PR TITLE
Add option step before selecting metric

### DIFF
--- a/main.py
+++ b/main.py
@@ -561,7 +561,7 @@ class ExerciseSelectionPanel(MDBoxLayout):
 
 
 class AddMetricPopup(MDDialog):
-    """Popup dialog for selecting metrics or creating a new one."""
+    """Popup dialog for choosing an action, selecting metrics or creating a new one."""
 
     def __init__(self, screen: 'EditExerciseScreen', mode: str = "select", **kwargs):
         self.screen = screen
@@ -569,8 +569,10 @@ class AddMetricPopup(MDDialog):
 
         if mode == "select":
             content, buttons, title = self._build_select_widgets()
-        else:
+        elif mode == "new":
             content, buttons, title = self._build_new_metric_widgets()
+        else:  # initial choice
+            content, buttons, title = self._build_choice_widgets()
 
         super().__init__(title=title, type="custom", content_cls=content, buttons=buttons, **kwargs)
 
@@ -584,8 +586,8 @@ class AddMetricPopup(MDDialog):
             item = OneLineListItem(text=m["name"])
             item.bind(on_release=lambda inst, name=m["name"]: self.add_metric(name))
             content.add_widget(item)
-        new_btn = MDRaisedButton(text="New Metric", on_release=self.show_new_metric_form)
-        buttons = [new_btn, MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())]
+        cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())
+        buttons = [cancel_btn]
         return content, buttons, "Select Metric"
 
     def _build_new_metric_widgets(self):
@@ -639,6 +641,16 @@ class AddMetricPopup(MDDialog):
         buttons = [save_btn, back_btn]
         return layout, buttons, "New Metric"
 
+    def _build_choice_widgets(self):
+        label = MDLabel(text="Choose an option", halign="center")
+        add_btn = MDRaisedButton(text="Add Metric", on_release=self.show_metric_list)
+        new_btn = MDRaisedButton(text="New Metric", on_release=self.show_new_metric_form)
+        cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())
+        content = MDBoxLayout(orientation="vertical", spacing="8dp")
+        content.add_widget(label)
+        buttons = [add_btn, new_btn, cancel_btn]
+        return content, buttons, "Metric Options"
+
     # ------------------------------------------------------------------
     # Mode switching helpers
     # ------------------------------------------------------------------
@@ -649,7 +661,8 @@ class AddMetricPopup(MDDialog):
 
     def show_metric_list(self, *args):
         self.dismiss()
-        self.screen.open_add_metric_popup()
+        popup = AddMetricPopup(self.screen, mode="select")
+        popup.open()
 
     def add_metric(self, name, *args):
         db_path = Path(__file__).resolve().parent / "data" / "workout.db"
@@ -772,7 +785,7 @@ class EditExerciseScreen(MDScreen):
         self.populate()
 
     def open_add_metric_popup(self):
-        popup = AddMetricPopup(self)
+        popup = AddMetricPopup(self, mode="choose")
         popup.open()
 
     def open_new_metric_popup(self):


### PR DESCRIPTION
## Summary
- extend `AddMetricPopup` to include an initial choice screen
- support modes `choose`, `select`, and `new`
- update popup button behavior
- adjust `EditExerciseScreen.open_add_metric_popup` to open the new choice step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d481b35b483329bf17867201b2894