### PR TITLE
Improve metric management in EditExercise

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -492,9 +492,15 @@ ScreenManager:
         ScrollView:
             MDList:
                 id: metrics_list
-        MDRaisedButton:
-            text: "Add Metric"
-            on_release: root.open_add_metric_popup()
+        MDBoxLayout:
+            orientation: "horizontal"
+            spacing: "10dp"
+            MDRaisedButton:
+                text: "Add Metric"
+                on_release: root.open_add_metric_popup()
+            MDRaisedButton:
+                text: "New Metric"
+                on_release: root.open_new_metric_popup()
         MDRaisedButton:
             text: "Back"
             on_release: app.root.current = "edit_preset"

--- a/main.py
+++ b/main.py
@@ -821,7 +821,7 @@ class EditExerciseScreen(MDScreen):
         self.populate()
 
     def open_add_metric_popup(self):
-        popup = AddMetricPopup(self, mode="choose")
+        popup = AddMetricPopup(self, mode="select")
         popup.open()
 
     def open_new_metric_popup(self):


### PR DESCRIPTION
## Summary
- show Select Metric popup directly from Edit Exercise
- add a New Metric button beside Add Metric

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d49f4fa1c83329c8a7378877335e9