### PR TITLE
Fix rest timer start time

### DIFF
--- a/core.py
+++ b/core.py
@@ -305,6 +305,11 @@ class WorkoutSession:
         self.last_set_time = self.start_time
         self.rest_target_time = self.last_set_time + self.rest_duration
 
+    def mark_set_completed(self) -> None:
+        """Record the completion time for the current set."""
+        self.last_set_time = time.time()
+        self.rest_target_time = self.last_set_time + self.rest_duration
+
     def next_exercise_name(self):
         if self.current_exercise < len(self.exercises):
             return self.exercises[self.current_exercise]["name"]
@@ -353,8 +358,6 @@ class WorkoutSession:
         ex["results"].append(metrics)
         self.current_set += 1
 
-        self.last_set_time = time.time()
-        self.rest_target_time = self.last_set_time + self.rest_duration
 
         if self.current_set >= ex["sets"]:
             self.current_set = 0

--- a/main.kv
+++ b/main.kv
@@ -235,7 +235,9 @@ ScreenManager:
             text_color: 0.2, 0.6, 0.86, 1
         MDRaisedButton:
             text: "End Set"
-            on_release: app.root.current = "metric_input"
+            on_release:
+                app.mark_set_complete();
+                app.root.current = "metric_input"
 
 <MetricInputScreen>:
     on_pre_enter: root.populate_metrics()

--- a/main.py
+++ b/main.py
@@ -867,6 +867,10 @@ class WorkoutApp(MDApp):
         else:
             self.workout_session = None
 
+    def mark_set_complete(self):
+        if self.workout_session:
+            self.workout_session.mark_set_completed()
+
 
 if __name__ == "__main__":
     WorkoutApp().run()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,6 +77,7 @@ def test_workout_session_loads_preset_and_records(monkeypatch):
     total_sets = sum(ex["sets"] for ex in session.exercises)
     finished = False
     for i in range(total_sets):
+        session.mark_set_completed()
         finished = session.record_metrics({"Reps": i})
     assert finished
 
@@ -113,6 +114,7 @@ def test_workout_session_summary_contains_details():
 
     total_sets = sum(ex["sets"] for ex in session.exercises)
     for i in range(total_sets):
+        session.mark_set_completed()
         session.record_metrics({"Reps": i + 1})
 
     summary = session.summary()
@@ -139,6 +141,7 @@ def test_rest_timer_updates_on_record(monkeypatch):
     assert session.rest_target_time == fake_time[0] + core.DEFAULT_REST_DURATION
 
     fake_time[0] += 30
+    session.mark_set_completed()
     session.record_metrics({"Reps": 1})
     assert session.last_set_time == 1030.0
     assert session.rest_target_time == 1030.0 + core.DEFAULT_REST_DURATION


### PR DESCRIPTION
## Summary
- track set completion time in `WorkoutSession`
- expose `mark_set_complete` on `WorkoutApp`
- update `End Set` button to call the new method
- adjust tests to call `mark_set_completed`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4bc061d883328cb61f21a7042a0d