### PR TITLE
Fix new metric popup and generate fields from DB schema

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,6 +61,23 @@ def test_get_all_exercises():
         assert isinstance(name, str)
 
 
+def test_metric_type_schema():
+    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+    schema = core.get_metric_type_schema(db_path)
+
+    names = [f["name"] for f in schema]
+    assert "name" in names
+    assert "input_type" in names
+    assert "source_type" in names
+    assert "input_timing" in names
+    assert "is_required" in names
+    assert "scope" in names
+    assert "description" in names
+    for field in schema:
+        if field["name"] in {"input_type", "source_type", "input_timing", "scope"}:
+            assert field.get("options")
+
+
 def test_workout_session_loads_preset_and_records(monkeypatch):
     db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
 


### PR DESCRIPTION
## Summary
- introspect `metric_types` table via new `core.get_metric_type_schema`
- build the 'New Metric' popup dynamically based on the schema
- update saving logic to use created widgets
- add tests for schema helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4b4e7cfc8332a00c26abc2fbb262