### PR TITLE
Fix metric input screen advancing set

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -200,7 +200,9 @@ ScreenManager:
             height: "20dp"
         MDRaisedButton:
             text: "Record Metrics"
-            on_release: app.root.current = "metric_input"
+            on_release:
+                app.record_new_set = False
+                app.root.current = "metric_input"
         MDRaisedButton:
             text: "Edit Workout"
             on_release: app.root.current = "workout_edit"
@@ -236,6 +238,7 @@ ScreenManager:
         MDRaisedButton:
             text: "End Set"
             on_release:
+                app.record_new_set = True
                 app.mark_set_complete();
                 app.root.current = "metric_input"
 


### PR DESCRIPTION
## Summary
- add `record_new_set` flag to track whether metrics correspond to a completed set
- only advance the workout when metrics are saved from a set completion
- reset the flag when starting a workout or leaving the metric screen
- update buttons to set the flag appropriately

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d4db27c288332a4b74dd46533feff