### PR TITLE
Add details tab and deletion in preset editor

### DIFF
--- a/core.py
+++ b/core.py
@@ -667,6 +667,12 @@ class PresetEditor:
         self.sections.append({"name": name, "exercises": []})
         return len(self.sections) - 1
 
+    def remove_section(self, index: int) -> None:
+        """Remove the section at ``index`` if it exists."""
+
+        if 0 <= index < len(self.sections):
+            self.sections.pop(index)
+
     def add_exercise(
         self,
         section_index: int,

--- a/main.kv
+++ b/main.kv
@@ -376,11 +376,17 @@ ScreenManager:
             id: exercise_list
             size_hint_y: None
             height: self.minimum_height
-        MDRaisedButton:
-            text: "Add Exercise"
+        MDBoxLayout:
             size_hint_y: None
             height: "40dp"
-            on_release: root.open_exercise_selection()
+            spacing: "10dp"
+            MDRaisedButton:
+                text: "Add Exercise"
+                on_release: root.open_exercise_selection()
+            MDRaisedButton:
+                text: "Delete"
+                md_bg_color: 1, 0, 0, 1
+                on_release: root.confirm_delete()
 
 <EditPresetScreen>:
     sections_box: sections_box
@@ -393,16 +399,46 @@ ScreenManager:
             spacing: "10dp"
             padding: "5dp"
             size_hint: 1, 1
-            ScrollView:
-                MDBoxLayout:
-                    id: sections_box
-                    orientation: "vertical"
+            MDBoxLayout:
+                size_hint_y: None
+                height: "40dp"
+                spacing: "10dp"
+                MDRaisedButton:
+                    text: "Sections"
+                    md_bg_color: app.theme_cls.primary_color if root.current_tab == "sections" else (.5, .5, .5, 1)
+                    on_release: root.switch_tab("sections")
+                MDRaisedButton:
+                    text: "Details"
+                    md_bg_color: app.theme_cls.primary_color if root.current_tab == "details" else (.5, .5, .5, 1)
+                    on_release: root.switch_tab("details")
+            MDBoxLayout:
+                id: sections_tab
+                orientation: "vertical"
+                size_hint_y: None
+                height: self.minimum_height if root.current_tab == "sections" else 0
+                opacity: 1 if root.current_tab == "sections" else 0
+                ScrollView:
+                    MDBoxLayout:
+                        id: sections_box
+                        orientation: "vertical"
+                        size_hint_y: None
+                        height: self.minimum_height
+                        padding: 0, 0, 0, root.exercise_panel.height if root.panel_visible else 0
+                MDRaisedButton:
+                    text: "Add Section"
+                    on_release: root.add_section()
+            MDBoxLayout:
+                id: details_tab
+                orientation: "vertical"
+                size_hint_y: None
+                height: self.minimum_height if root.current_tab == "details" else 0
+                opacity: 1 if root.current_tab == "details" else 0
+                MDTextField:
+                    text: root.preset_name
+                    hint_text: "Preset Name"
+                    on_text: root.update_preset_name(self.text)
                     size_hint_y: None
-                    height: self.minimum_height
-                    padding: 0, 0, 0, root.exercise_panel.height if root.panel_visible else 0
-            MDRaisedButton:
-                text: "Add Section"
-                on_release: root.add_section()
+                    height: "40dp"
             MDRaisedButton:
                 text: "Back to Presets"
                 on_release: app.root.current = "presets"

--- a/main.py
+++ b/main.py
@@ -478,6 +478,29 @@ class SectionWidget(MDBoxLayout):
                 )
             )
 
+    def confirm_delete(self):
+        dialog = None
+
+        def do_delete(*args):
+            app = MDApp.get_running_app()
+            if app.preset_editor:
+                app.preset_editor.remove_section(self.section_index)
+            if app.root:
+                edit = app.root.get_screen("edit_preset")
+                edit.refresh_sections()
+            if dialog:
+                dialog.dismiss()
+
+        dialog = MDDialog(
+            title="Remove Section?",
+            text=f"Delete {self.section_name}?",
+            buttons=[
+                MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
+                MDRaisedButton(text="Delete", on_release=do_delete),
+            ],
+        )
+        dialog.open()
+
 
 class EditPresetScreen(MDScreen):
     """Screen to edit a workout preset."""
@@ -486,6 +509,7 @@ class EditPresetScreen(MDScreen):
     sections_box = ObjectProperty(None)
     panel_visible = BooleanProperty(False)
     exercise_panel = ObjectProperty(None)
+    current_tab = StringProperty("sections")
 
     _colors = [
         (1, 0.9, 0.9, 1),
@@ -500,6 +524,7 @@ class EditPresetScreen(MDScreen):
         app = MDApp.get_running_app()
         app.init_preset_editor()
         self.preset_name = app.preset_editor.preset_name or "Preset"
+        self.current_tab = "sections"
         if self.sections_box:
             self.sections_box.clear_widgets()
             for idx, sec in enumerate(app.preset_editor.sections):
@@ -552,6 +577,18 @@ class EditPresetScreen(MDScreen):
         self.sections_box.add_widget(section)
         section.refresh_exercises()
         return section
+
+    def switch_tab(self, tab: str):
+        """Switch between the sections and details tabs."""
+        if tab in ("sections", "details"):
+            self.current_tab = tab
+
+    def update_preset_name(self, name: str):
+        """Update the preset name in the editor."""
+        self.preset_name = name
+        app = MDApp.get_running_app()
+        if app.preset_editor:
+            app.preset_editor.preset_name = name
 
 
 


### PR DESCRIPTION
## Summary
- support removing sections in `PresetEditor`
- add confirmation dialog to delete a section from the UI
- implement tabbed interface for editing presets (Sections and Details)
- add preset name field on Details tab
- include delete button next to Add Exercise in each section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e41831e848332bb5675b040f945b0