### PR TITLE
Fix screen init crash

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -414,7 +414,8 @@ ScreenManager:
             ScreenManager:
                 id: edit_tabs
                 size_hint_y: 1
-                current: root.current_tab
+                on_kv_post: self.current = root.current_tab
+                on_current_tab: self.current = root.current_tab
                 Screen:
                     name: "sections"
                     BoxLayout:


### PR DESCRIPTION
## Summary
- ensure EditPresetScreen's ScreenManager sets current screen after being built

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e455dbcd88332b0c234ade48e15db