### PR TITLE
Fix ScreenManager tab switching

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -392,6 +392,7 @@ ScreenManager:
     sections_box: sections_box
     exercise_panel: exercise_panel
     panel_visible: False
+    on_current_tab: edit_tabs.current = self.current_tab
     FloatLayout:
         MDBoxLayout:
             id: main_content
@@ -415,7 +416,6 @@ ScreenManager:
                 id: edit_tabs
                 size_hint_y: 1
                 on_kv_post: self.current = root.current_tab
-                on_current_tab: self.current = root.current_tab
                 Screen:
                     name: "sections"
                     BoxLayout:


### PR DESCRIPTION
## Summary
- listen for `current_tab` changes on the EditPresetScreen root widget
- remove invalid event binding on `ScreenManager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e465ff98c8332ba0c466eb2c37a1f