### PR TITLE
Add exercise library UI without DB changes

### DIFF
--- a/core.py
+++ b/core.py
@@ -607,6 +607,24 @@ class WorkoutSession:
         return "\n".join(lines)
 
 
+class Exercise:
+    """Placeholder class for editing exercises.
+
+    Editing or creating an exercise will be performed using an instance
+    of this class. The database will only be queried when retrieving an
+    existing exercise and when saving it after editing.
+    """
+
+    def __init__(self, name: str = "", description: str = "") -> None:
+        self.name = name
+        self.description = description
+
+    def to_dict(self) -> dict:
+        """Return the exercise data in dictionary form."""
+
+        return {"name": self.name, "description": self.description}
+
+
 
 class PresetEditor:
     """Helper for creating or editing workout presets in memory."""

--- a/main.kv
+++ b/main.kv
@@ -51,6 +51,9 @@ ScreenManager:
             text: "Go to Presets"
             on_release: app.root.current = "presets"
         MDRaisedButton:
+            text: "Go to Exercises"
+            on_release: app.root.current = "exercise_library"
+        MDRaisedButton:
             text: "Go to Progress"
             on_release: app.root.current = "progress"
         MDRaisedButton:
@@ -111,6 +114,8 @@ ScreenManager:
             on_release: app.root.current = "presets"
 
 <ExerciseLibraryScreen@MDScreen>:
+    on_pre_enter: root.populate()
+    exercise_list: exercise_list
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -120,6 +125,9 @@ ScreenManager:
             halign: "center"
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1
+        ScrollView:
+            MDList:
+                id: exercise_list
         MDRaisedButton:
             text: "Back"
             on_release: root.go_back()

--- a/main.py
+++ b/main.py
@@ -16,7 +16,12 @@ from kivymd.uix.slider import MDSlider
 from kivy.uix.spinner import Spinner
 from kivy.uix.scrollview import ScrollView
 from kivymd.uix.label import MDLabel
-from kivymd.uix.list import OneLineListItem, MDList
+from kivymd.uix.list import (
+    OneLineListItem,
+    OneLineRightIconListItem,
+    IconRightWidget,
+    MDList,
+)
 from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.button import MDIconButton
 from kivymd.uix.card import MDSeparator
@@ -379,6 +384,58 @@ class PresetDetailScreen(MDScreen):
 
 class ExerciseLibraryScreen(MDScreen):
     previous_screen = StringProperty("home")
+    exercise_list = ObjectProperty(None)
+
+    _placeholders = [
+        {
+            "name": "Push-ups",
+            "description": "Placeholder description for push-ups.",
+        },
+        {
+            "name": "Squats",
+            "description": "Placeholder description for squats.",
+        },
+        {
+            "name": "Lunges",
+            "description": "Placeholder description for lunges.",
+        },
+        {
+            "name": "Plank",
+            "description": "Placeholder description for plank holds.",
+        },
+        {
+            "name": "Burpees",
+            "description": "Placeholder description for burpees.",
+        },
+    ]
+
+    def on_pre_enter(self, *args):
+        self.populate()
+        return super().on_pre_enter(*args)
+
+    def populate(self):
+        if not self.exercise_list:
+            return
+        self.exercise_list.clear_widgets()
+        for ex in self._placeholders:
+            item = OneLineRightIconListItem(text=ex["name"])
+            icon = IconRightWidget(icon="pencil")
+            icon.bind(on_release=lambda inst, ex=ex: self.open_edit_popup(ex))
+            item.add_widget(icon)
+            self.exercise_list.add_widget(item)
+
+    def open_edit_popup(self, exercise):
+        dialog = MDDialog(
+            title=exercise["name"],
+            text=exercise["description"],
+            buttons=[
+                MDRaisedButton(
+                    text="Close",
+                    on_release=lambda *a: dialog.dismiss(),
+                )
+            ],
+        )
+        dialog.open()
 
     def go_back(self):
         if self.manager:


### PR DESCRIPTION
## Summary
- add placeholder `Exercise` class for future editing
- implement ExerciseLibraryScreen with placeholder exercises and edit popups
- link the library from Home via a new button
- revert database files to previous state

## Testing
- `pytest -q` *(fails: Preset 'Push Day' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873609bc7d48332bf43cbb591f71f25