### PR TITLE
Add new exercise FAB without DB modifications

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -116,21 +116,27 @@ ScreenManager:
 <ExerciseLibraryScreen@MDScreen>:
     on_pre_enter: root.populate()
     exercise_list: exercise_list
-    BoxLayout:
-        orientation: "vertical"
-        spacing: "10dp"
-        padding: "20dp"
-        MDLabel:
-            text: "Exercise Library - browse all exercises"
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
-        ScrollView:
-            MDList:
-                id: exercise_list
-        MDRaisedButton:
-            text: "Back"
-            on_release: root.go_back()
+    FloatLayout:
+        MDBoxLayout:
+            orientation: "vertical"
+            spacing: "10dp"
+            padding: "20dp"
+            MDLabel:
+                text: "Exercise Library - browse all exercises"
+                halign: "center"
+                theme_text_color: "Custom"
+                text_color: 0.2, 0.6, 0.86, 1
+            ScrollView:
+                MDList:
+                    id: exercise_list
+            MDRaisedButton:
+                text: "Back"
+                on_release: root.go_back()
+        MDFloatingActionButton:
+            icon: "plus"
+            md_bg_color: app.theme_cls.primary_color
+            pos_hint: {"right": 0.98, "y": 0.02}
+            on_release: root.new_exercise()
 
 <ProgressScreen@MDScreen>:
     BoxLayout:
@@ -591,7 +597,7 @@ ScreenManager:
                 on_release: root.open_new_metric_popup()
         MDRaisedButton:
             text: "Back"
-            on_release: app.root.current = "edit_preset"
+            on_release: root.go_back()
 
 <PreviousWorkoutsScreen@MDScreen>:
     BoxLayout:

--- a/main.py
+++ b/main.py
@@ -437,6 +437,18 @@ class ExerciseLibraryScreen(MDScreen):
         )
         dialog.open()
 
+    def new_exercise(self):
+        """Open ``EditExerciseScreen`` to create a new exercise."""
+        app = MDApp.get_running_app()
+        if not app or not app.root:
+            return
+        screen = app.root.get_screen("edit_exercise")
+        screen.exercise_name = ""
+        screen.section_index = -1
+        screen.exercise_index = -1
+        screen.previous_screen = "exercise_library"
+        app.root.current = "edit_exercise"
+
     def go_back(self):
         if self.manager:
             self.manager.current = self.previous_screen
@@ -666,6 +678,7 @@ class SelectedExerciseItem(MDBoxLayout):
         screen.exercise_name = self.text
         screen.section_index = self.section_index
         screen.exercise_index = self.exercise_index
+        screen.previous_screen = "edit_preset"
         app.editing_section_index = self.section_index
         app.editing_exercise_index = self.exercise_index
         app.root.current = "edit_exercise"
@@ -1019,6 +1032,7 @@ class EditExerciseScreen(MDScreen):
     exercise_name = StringProperty("")
     section_index = NumericProperty(-1)
     exercise_index = NumericProperty(-1)
+    previous_screen = StringProperty("edit_preset")
     metrics_list = ObjectProperty(None)
 
     def on_pre_enter(self, *args):
@@ -1132,6 +1146,10 @@ class EditExerciseScreen(MDScreen):
     def open_edit_metric_popup(self, metric):
         popup = EditMetricPopup(self, metric)
         popup.open()
+
+    def go_back(self):
+        if self.manager:
+            self.manager.current = self.previous_screen
 
 
 class WorkoutApp(MDApp):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).parent))
+from utils import create_sample_db
+
+
+@pytest.fixture(scope="session")
+def seeded_db_path(tmp_path_factory):
+    """Return a temporary database populated with sample data."""
+    src_db = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+    db_dir = tmp_path_factory.mktemp("db")
+    db_path = db_dir / "workout.db"
+    db_path.write_bytes(src_db.read_bytes())
+    create_sample_db(db_path)
+    return db_path

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,14 +1,15 @@
 from pathlib import Path
 import sys
 import sqlite3
+import pytest
 
 # Ensure the project root is on the import path so `core` can be imported
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import core
 
 
-def test_load_workout_presets_updates_global():
-    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+def test_load_workout_presets_updates_global(seeded_db_path):
+    db_path = seeded_db_path
     presets = core.load_workout_presets(db_path)
 
     assert presets == core.WORKOUT_PRESETS
@@ -25,8 +26,8 @@ def test_load_workout_presets_updates_global():
             assert "sets" in exercise
 
 
-def test_exercise_sets_are_positive_ints():
-    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+def test_exercise_sets_are_positive_ints(seeded_db_path):
+    db_path = seeded_db_path
     presets = core.load_workout_presets(db_path)
 
     for preset in presets:
@@ -35,8 +36,8 @@ def test_exercise_sets_are_positive_ints():
             assert exercise["sets"] > 0
 
 
-def test_get_metrics_for_exercise():
-    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+def test_get_metrics_for_exercise(seeded_db_path):
+    db_path = seeded_db_path
     metrics = core.get_metrics_for_exercise("Bench Press", db_path)
 
     assert isinstance(metrics, list)
@@ -51,8 +52,8 @@ def test_get_metrics_for_exercise():
             assert metric["values"]
 
 
-def test_get_all_exercises():
-    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+def test_get_all_exercises(seeded_db_path):
+    db_path = seeded_db_path
     exercises = core.get_all_exercises(db_path)
 
     assert isinstance(exercises, list)
@@ -61,8 +62,8 @@ def test_get_all_exercises():
         assert isinstance(name, str)
 
 
-def test_metric_type_schema():
-    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+def test_metric_type_schema(seeded_db_path):
+    db_path = seeded_db_path
     schema = core.get_metric_type_schema(db_path)
 
     names = [f["name"] for f in schema]
@@ -78,8 +79,8 @@ def test_metric_type_schema():
             assert field.get("options")
 
 
-def test_workout_session_loads_preset_and_records(monkeypatch):
-    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+def test_workout_session_loads_preset_and_records(seeded_db_path, monkeypatch):
+    db_path = seeded_db_path
 
     session = core.WorkoutSession("Push Day", db_path=db_path)
 
@@ -99,10 +100,9 @@ def test_workout_session_loads_preset_and_records(monkeypatch):
     assert finished
 
 
-def test_metric_type_crud(tmp_path):
-    db_src = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+def test_metric_type_crud(seeded_db_path, tmp_path):
     db_path = tmp_path / "workout.db"
-    db_path.write_bytes(db_src.read_bytes())
+    db_path.write_bytes(seeded_db_path.read_bytes())
 
     name = "TestMetric"
     core.add_metric_type(
@@ -125,8 +125,8 @@ def test_metric_type_crud(tmp_path):
     assert not any(m["name"] == name for m in metrics)
 
 
-def test_workout_session_summary_contains_details():
-    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+def test_workout_session_summary_contains_details(seeded_db_path):
+    db_path = seeded_db_path
     session = core.WorkoutSession("Push Day", db_path=db_path)
 
     total_sets = sum(ex["sets"] for ex in session.exercises)
@@ -144,8 +144,8 @@ def test_workout_session_summary_contains_details():
     assert "Duration:" in summary
 
 
-def test_rest_timer_updates_on_record(monkeypatch):
-    db_path = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+def test_rest_timer_updates_on_record(seeded_db_path, monkeypatch):
+    db_path = seeded_db_path
 
     fake_time = [1000.0]
 

--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -7,11 +7,9 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from core import PresetEditor, DEFAULT_SETS_PER_EXERCISE
 
-DB_PATH = Path(__file__).resolve().parents[1] / "data" / "workout.db"
 
-
-def test_load_existing_preset():
-    editor = PresetEditor("Push Day", DB_PATH)
+def test_load_existing_preset(seeded_db_path):
+    editor = PresetEditor("Push Day", seeded_db_path)
     try:
         assert editor.preset_name == "Push Day"
         assert editor.sections
@@ -25,8 +23,8 @@ def test_load_existing_preset():
         editor.close()
 
 
-def test_add_section_and_exercise():
-    editor = PresetEditor(db_path=DB_PATH)
+def test_add_section_and_exercise(seeded_db_path):
+    editor = PresetEditor(db_path=seeded_db_path)
     try:
         idx = editor.add_section("My Section")
         assert idx == 0
@@ -37,8 +35,8 @@ def test_add_section_and_exercise():
         editor.close()
 
 
-def test_add_exercise_validates_name():
-    editor = PresetEditor(db_path=DB_PATH)
+def test_add_exercise_validates_name(seeded_db_path):
+    editor = PresetEditor(db_path=seeded_db_path)
     try:
         idx = editor.add_section()
         with pytest.raises(ValueError):

--- a/tests/test_workout_db.py
+++ b/tests/test_workout_db.py
@@ -1,5 +1,6 @@
 import sqlite3
 from pathlib import Path
+import pytest
 
 def show_workout_structure(db_path):
     conn = sqlite3.connect(str(db_path))
@@ -39,8 +40,8 @@ def show_workout_structure(db_path):
     conn.close()
 
 
-def test_show_workout_structure(capsys):
-    db_path = Path(__file__).resolve().parent / ".." / "data" / "workout.db"
+def test_show_workout_structure(seeded_db_path, capsys):
+    db_path = seeded_db_path
     show_workout_structure(db_path)
     captured = capsys.readouterr()
     assert "Workout:" in captured.out

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+import sqlite3
+
+
+def create_sample_db(db_path: Path) -> None:
+    """Populate ``db_path`` with basic sample data for tests."""
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+
+    # Exercises
+    cur.executemany(
+        "INSERT INTO exercises (id, name, description, is_user_created) VALUES (?, ?, ?, 0)",
+        [
+            (1, "Bench Press", "Chest exercise"),
+            (2, "Push-ups", "Bodyweight push exercise"),
+            (3, "Shoulder Circles", "Warm up shoulder mobility"),
+            (4, "Jumping Jacks", "Warm up cardio"),
+        ],
+    )
+
+    # Metric types
+    cur.executemany(
+        "INSERT INTO metric_types (id, name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)",
+        [
+            (1, "Weight", "float", "manual_text", "post_set", 1, "set", "Weight used"),
+            (2, "Reps", "int", "manual_text", "post_set", 1, "set", "Repetitions"),
+        ],
+    )
+
+    # Exercises to metric types
+    cur.executemany(
+        "INSERT INTO exercise_metrics (id, exercise_id, metric_type_id, position) VALUES (?, ?, ?, ?)",
+        [
+            (1, 1, 1, 0),
+            (2, 1, 2, 1),
+            (3, 2, 2, 0),
+        ],
+    )
+
+    # Preset
+    cur.execute("INSERT INTO presets (id, name) VALUES (1, 'Push Day')")
+
+    # Sections
+    cur.executemany(
+        "INSERT INTO sections (id, preset_id, name, position) VALUES (?, ?, ?, ?)",
+        [
+            (1, 1, "Warm-up", 0),
+            (2, 1, "Workout", 1),
+        ],
+    )
+
+    # Section exercises
+    cur.executemany(
+        "INSERT INTO section_exercises (id, section_id, exercise_id, position, number_of_sets, exercise_name, exercise_description)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1, 1, 3, 0, 1, "Shoulder Circles", "Warm up shoulder mobility"),
+            (2, 1, 4, 1, 1, "Jumping Jacks", "Warm up cardio"),
+            (3, 2, 1, 0, 3, "Bench Press", "Chest exercise"),
+            (4, 2, 2, 1, 2, "Push-ups", "Bodyweight push exercise"),
+        ],
+    )
+
+    # Metrics for section exercises
+    cur.executemany(
+        "INSERT INTO section_exercise_metrics (id, section_exercise_id, metric_type_id, input_timing, is_required, scope, default_exercise_metric_id)"
+        " VALUES (?, ?, ?, ?, ?, ?, NULL)",
+        [
+            (1, 3, 1, "post_set", 1, "set"),
+            (2, 3, 2, "post_set", 1, "set"),
+            (3, 4, 2, "post_set", 1, "set"),
+        ],
+    )
+
+    conn.commit()
+    conn.close()


### PR DESCRIPTION
## Summary
- add floating action button in `ExerciseLibraryScreen`
- open EditExerciseScreen for new exercises via `new_exercise`
- track calling screen with `previous_screen`
- return to correct screen when going back
- create test fixture to seed a temporary database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687366dc34a08332ab31ada61107f393