### PR TITLE
Add metrics/details tabs and updated metric popup

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -266,6 +266,11 @@ ScreenManager:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
+        MDLabel:
+            text: root.exercise_name if root.exercise_name else "Edit Exercise"
+            halign: "center"
+            theme_text_color: "Custom"
+            text_color: 0.2, 0.6, 0.86, 1
         MDBoxLayout:
             size_hint_y: None
             height: "40dp"
@@ -574,6 +579,7 @@ ScreenManager:
 
 <EditExerciseScreen>:
     metrics_list: metrics_list
+    current_tab: "metrics"
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -583,18 +589,42 @@ ScreenManager:
             halign: "center"
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1
-        ScrollView:
-            MDList:
-                id: metrics_list
         MDBoxLayout:
-            orientation: "horizontal"
+            size_hint_y: None
+            height: "40dp"
             spacing: "10dp"
             MDRaisedButton:
-                text: "Add Metric"
-                on_release: root.open_add_metric_popup()
+                text: "Metrics"
+                md_bg_color: app.theme_cls.primary_color if root.current_tab == "metrics" else (.5, .5, .5, 1)
+                on_release: root.switch_tab("metrics")
             MDRaisedButton:
-                text: "New Metric"
-                on_release: root.open_new_metric_popup()
+                text: "Details"
+                md_bg_color: app.theme_cls.primary_color if root.current_tab == "details" else (.5, .5, .5, 1)
+                on_release: root.switch_tab("details")
+        ScreenManager:
+            id: exercise_tabs
+            size_hint_y: 1
+            transition: NoTransition()
+            on_kv_post: self.current = root.current_tab
+            Screen:
+                name: "metrics"
+                FloatLayout:
+                    ScrollView:
+                        MDList:
+                            id: metrics_list
+                    MDFloatingActionButton:
+                        icon: "plus"
+                        md_bg_color: app.theme_cls.primary_color
+                        pos_hint: {"right": 0.98, "y": 0.02}
+                        tooltip_text: "Add Metric"
+                        on_release: root.open_add_metric_popup()
+            Screen:
+                name: "details"
+                ScrollView:
+                    MDBoxLayout:
+                        orientation: "vertical"
+                        size_hint_y: None
+                        height: self.minimum_height
         MDRaisedButton:
             text: "Back"
             on_release: root.go_back()

--- a/main.py
+++ b/main.py
@@ -786,8 +786,9 @@ class AddMetricPopup(MDDialog):
         scroll = ScrollView(do_scroll_y=True, size_hint_y=None, height=dp(400))
         scroll.add_widget(list_view)
 
+        new_btn = MDRaisedButton(text="New Metric", on_release=self.show_new_metric_form)
         cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())
-        buttons = [cancel_btn]
+        buttons = [new_btn, cancel_btn]
         return scroll, buttons, "Select Metric"
 
     def _build_new_metric_widgets(self):
@@ -1034,6 +1035,12 @@ class EditExerciseScreen(MDScreen):
     exercise_index = NumericProperty(-1)
     previous_screen = StringProperty("edit_preset")
     metrics_list = ObjectProperty(None)
+    current_tab = StringProperty("metrics")
+
+    def switch_tab(self, tab: str):
+        """Switch between the metrics and details tabs."""
+        if tab in ("metrics", "details"):
+            self.current_tab = tab
 
     def on_pre_enter(self, *args):
         self.populate()


### PR DESCRIPTION
## Summary
- add tab buttons and floating action button to EditExerciseScreen
- move `New Metric` option into the AddMetricPopup

## Testing
- `pytest -q` *(fails: Preset 'Push Day' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68736abcb1508332a899ce89d2c8c251