### PR TITLE
Use database data in exercise library

### DIFF
--- a/core.py
+++ b/core.py
@@ -53,6 +53,29 @@ def get_all_exercises(db_path: Path = Path(__file__).resolve().parent / "data" /
     return exercises
 
 
+def get_exercise_details(
+    exercise_name: str,
+    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+) -> dict | None:
+    """Return name and description for ``exercise_name``.
+
+    Returns ``None`` if the exercise does not exist.
+    """
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT name, description FROM exercises WHERE name = ?",
+        (exercise_name,),
+    )
+    row = cursor.fetchone()
+    conn.close()
+    if not row:
+        return None
+    name, description = row
+    return {"name": name, "description": description or ""}
+
+
 def get_metrics_for_exercise(
     exercise_name: str,
     db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",

--- a/main.py
+++ b/main.py
@@ -394,29 +394,6 @@ class ExerciseLibraryScreen(MDScreen):
     previous_screen = StringProperty("home")
     exercise_list = ObjectProperty(None)
 
-    _placeholders = [
-        {
-            "name": "Push-ups",
-            "description": "Placeholder description for push-ups.",
-        },
-        {
-            "name": "Squats",
-            "description": "Placeholder description for squats.",
-        },
-        {
-            "name": "Lunges",
-            "description": "Placeholder description for lunges.",
-        },
-        {
-            "name": "Plank",
-            "description": "Placeholder description for plank holds.",
-        },
-        {
-            "name": "Burpees",
-            "description": "Placeholder description for burpees.",
-        },
-    ]
-
     def on_pre_enter(self, *args):
         self.populate()
         return super().on_pre_enter(*args)
@@ -425,17 +402,20 @@ class ExerciseLibraryScreen(MDScreen):
         if not self.exercise_list:
             return
         self.exercise_list.clear_widgets()
-        for ex in self._placeholders:
-            item = OneLineRightIconListItem(text=ex["name"])
+        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+        for name in core.get_all_exercises(db_path):
+            item = OneLineRightIconListItem(text=name)
             icon = IconRightWidget(icon="pencil")
-            icon.bind(on_release=lambda inst, ex=ex: self.open_edit_popup(ex))
+            icon.bind(on_release=lambda inst, n=name: self.open_edit_popup(n))
             item.add_widget(icon)
             self.exercise_list.add_widget(item)
 
-    def open_edit_popup(self, exercise):
+    def open_edit_popup(self, exercise_name):
+        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+        details = core.get_exercise_details(exercise_name, db_path)
         dialog = MDDialog(
-            title=exercise["name"],
-            text=exercise["description"],
+            title=exercise_name,
+            text=details["description"] if details else "",
             buttons=[
                 MDRaisedButton(
                     text="Close",


### PR DESCRIPTION
## Summary
- load exercises from SQLite and remove placeholder list
- show exercise description popup with data from DB
- expose `get_exercise_details` helper

## Testing
- `python -m pytest -q` *(fails: Preset 'Push Day' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873735f4b408332841262c4896af40d