### PR TITLE
Update EditExerciseScreen details

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -579,6 +579,8 @@ ScreenManager:
 
 <EditExerciseScreen>:
     metrics_list: metrics_list
+    name_field: name_field
+    description_field: description_field
     current_tab: "metrics"
     BoxLayout:
         orientation: "vertical"
@@ -601,11 +603,11 @@ ScreenManager:
                 text: "Details"
                 md_bg_color: app.theme_cls.primary_color if root.current_tab == "details" else (.5, .5, .5, 1)
                 on_release: root.switch_tab("details")
-        ScreenManager:
-            id: exercise_tabs
-            size_hint_y: 1
-            transition: NoTransition()
-            on_kv_post: self.current = root.current_tab
+            ScreenManager:
+                id: exercise_tabs
+                size_hint_y: 1
+                transition: NoTransition()
+                current: root.current_tab
             Screen:
                 name: "metrics"
                 FloatLayout:
@@ -625,6 +627,16 @@ ScreenManager:
                         orientation: "vertical"
                         size_hint_y: None
                         height: self.minimum_height
+                        MDTextField:
+                            id: name_field
+                            hint_text: "Name"
+                            text: root.exercise_name
+                            multiline: False
+                        MDTextField:
+                            id: description_field
+                            hint_text: "Description"
+                            text: root.exercise_description
+                            multiline: True
         MDRaisedButton:
             text: "Back"
             on_release: root.go_back()

--- a/main.py
+++ b/main.py
@@ -1019,22 +1019,31 @@ class EditExerciseScreen(MDScreen):
     """Screen for editing an individual exercise within a preset."""
 
     exercise_name = StringProperty("")
+    exercise_description = StringProperty("")
     section_index = NumericProperty(-1)
     exercise_index = NumericProperty(-1)
     previous_screen = StringProperty("edit_preset")
     metrics_list = ObjectProperty(None)
+    name_field = ObjectProperty(None)
+    description_field = ObjectProperty(None)
     current_tab = StringProperty("metrics")
 
     def switch_tab(self, tab: str):
         """Switch between the metrics and details tabs."""
         if tab in ("metrics", "details"):
             self.current_tab = tab
+            if "exercise_tabs" in self.ids:
+                self.ids.exercise_tabs.current = tab
 
     def on_pre_enter(self, *args):
         self.populate()
         return super().on_pre_enter(*args)
 
     def populate(self):
+        self.populate_metrics()
+        self.populate_details()
+
+    def populate_metrics(self):
         if not self.metrics_list or not self.exercise_name:
             return
         self.metrics_list.clear_widgets()
@@ -1122,6 +1131,24 @@ class EditExerciseScreen(MDScreen):
 
             self.metrics_list.add_widget(box)
             self.metrics_list.add_widget(MDSeparator())
+
+    def populate_details(self):
+        if not self.exercise_name:
+            if self.name_field:
+                self.name_field.text = ""
+            if self.description_field:
+                self.description_field.text = ""
+            return
+        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+        details = core.get_exercise_details(self.exercise_name, db_path)
+        if details:
+            self.exercise_description = details.get("description", "")
+        else:
+            self.exercise_description = ""
+        if self.name_field:
+            self.name_field.text = self.exercise_name
+        if self.description_field:
+            self.description_field.text = self.exercise_description
 
     def remove_metric(self, metric_name):
         if not self.exercise_name:


### PR DESCRIPTION
## Summary
- show plus button only in metrics tab
- add name and description inputs to EditExerciseScreen
- load exercise description when editing an exercise

## Testing
- `pytest -q` *(fails: Preset 'Push Day' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873766b3a308332afd0144d7be8c7c9