### PR TITLE
Fix tab initialization

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -608,7 +608,7 @@ ScreenManager:
                 id: exercise_tabs
                 size_hint_y: 1
                 transition: NoTransition()
-                current: root.current_tab
+                on_kv_post: self.current = root.current_tab
             Screen:
                 name: "metrics"
                 FloatLayout:


### PR DESCRIPTION
## Summary
- set `EditExerciseScreen` tab after widgets load to avoid missing screen error

## Testing
- `pytest -q` *(fails: Preset 'Push Day' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763de161548332ba2b4f796dc7269f