### PR TITLE
Use in-memory object on edit screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -643,12 +643,14 @@ ScreenManager:
                             text: root.exercise_name
                             multiline: False
                             size_hint_x: 1
+                            on_text: root.update_name(self.text)
                         MDTextField:
                             id: description_field
                             hint_text: "Description"
                             text: root.exercise_description
                             multiline: True
                             size_hint_x: 1
+                            on_text: root.update_description(self.text)
         MDRaisedButton:
             size_hint_y:0.1
             text: "Back"


### PR DESCRIPTION
## Summary
- load exercise data into an `Exercise` object when opening the edit screen
- modify metrics in memory without touching the database
- update text fields to write changes to the exercise object
- fix regression in presets screen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687654214b948332be8dd6248d143be4