### PR TITLE
Add exercise search field and sync enum table name

### DIFF
--- a/DB_DESIGN.md
+++ b/DB_DESIGN.md
@@ -16,7 +16,7 @@ The database cleanly separates:
 ### 🔵 Global Exercise Library
 - `exercises`: Master list of all exercises
 - `exercise_metrics`: Default metrics for each exercise
-- `user_defined_enum_values`: Custom enums for enum-type metrics
+- `exercise_enum_values`: Custom enums for enum-type metrics
 
 This acts as a central repository of exercises and their typical metrics.
 
@@ -51,7 +51,7 @@ This enables descriptive presets without altering the core schema.
 | `exercises`                | Master list of all exercises (name, description, user-created flag)                            |
 | `exercise_metrics`         | Default metrics for each exercise (referencing `metric_types`)                                 |
 | `metric_types`             | Definitions of all possible metrics (e.g., Reps, Weight, RPE) and their input configurations   |
-| `user_defined_enum_values` | Custom enum values tied to specific metrics and exercises                                      |
+| `exercise_enum_values` | Custom enum values tied to specific metrics and exercises                                      |
 | `presets`                  | Workout templates containing ordered sections and exercises                                    |
 | `preset_metadata`          | Key-value pairs for preset-level information (e.g., “Day 1”, “Focus: Strength”)                |
 | `sections`                 | Logical divisions of a preset (e.g., Warm-up, Workout)                                         |
@@ -111,9 +111,9 @@ This enables descriptive presets without modifying core tables.
 
 ---
 
-## 📦 User Defined Enums
+## 📦 Exercise Enums
 
-`user_defined_enum_values` allows adding custom enum values to metrics of type `manual_enum`.
+`exercise_enum_values` allows adding custom enum values to metrics of type `manual_enum`.
 
 📌 Example:
 - Metric: Machine
@@ -168,7 +168,7 @@ Each exercise:
 | Presets & Sections      | `presets`, `sections`           |
 | Preset Exercises        | `section_exercises`             |
 | Preset Exercise Metrics | `section_exercise_metrics`      |
-| Custom Enums            | `user_defined_enum_values`      |
+| Custom Enums            | `exercise_enum_values`      |
 | Preset Metadata         | `preset_metadata`               |
 
 This schema provides a **powerful, modular system** for defining workouts while giving users the freedom to tweak and reuse exercises flexibly.

--- a/core.py
+++ b/core.py
@@ -140,7 +140,7 @@ def get_metrics_for_exercise(
             cursor.execute(
                 """
                 SELECT value
-                FROM user_defined_enum_values
+                FROM exercise_enum_values
                 WHERE metric_type_id = ? AND exercise_id = ?
                 ORDER BY position
                 """,

--- a/main.kv
+++ b/main.kv
@@ -121,6 +121,13 @@ ScreenManager:
             orientation: "vertical"
             spacing: "10dp"
             padding: "20dp"
+            MDTextField:
+                id: search_field
+                hint_text: "Search exercises"
+                text: root.search_text
+                on_text: root.update_search(self.text)
+                size_hint_y: None
+                height: "40dp"
             MDBoxLayout:
                 orientation: "horizontal"
                 size_hint_y: None

--- a/main.py
+++ b/main.py
@@ -395,6 +395,7 @@ class ExerciseLibraryScreen(MDScreen):
     exercise_list = ObjectProperty(None)
     filter_mode = StringProperty("both")
     filter_dialog = ObjectProperty(None, allownone=True)
+    search_text = StringProperty("")
 
     def on_pre_enter(self, *args):
         self.populate()
@@ -410,6 +411,9 @@ class ExerciseLibraryScreen(MDScreen):
             exercises = [ex for ex in exercises if ex[1]]
         elif self.filter_mode == "premade":
             exercises = [ex for ex in exercises if not ex[1]]
+        if self.search_text:
+            s = self.search_text.lower()
+            exercises = [ex for ex in exercises if s in ex[0].lower()]
         for name, is_user in exercises:
             item = OneLineRightIconListItem(text=name)
             if is_user:
@@ -440,6 +444,10 @@ class ExerciseLibraryScreen(MDScreen):
             title="Filter Exercises", type="custom", content_cls=scroll, buttons=[close_btn]
         )
         self.filter_dialog.open()
+
+    def update_search(self, text):
+        self.search_text = text
+        self.populate()
 
     def apply_filter(self, mode, *args):
         self.filter_mode = mode


### PR DESCRIPTION
## Summary
- add a search bar at the top of `ExerciseLibraryScreen`
- support searching exercises by name
- reference `exercise_enum_values` throughout the code and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765445e8448332b7e4b575c5642508