### PR TITLE
Add save handling for edit exercise

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -651,10 +651,16 @@ ScreenManager:
                             multiline: True
                             size_hint_x: 1
                             on_text: root.update_description(self.text)
-        MDRaisedButton:
-            size_hint_y:0.1
-            text: "Back"
-            on_release: root.go_back()
+        MDBoxLayout:
+            size_hint_y: 0.1
+            spacing: "10dp"
+            MDRaisedButton:
+                text: "Save"
+                disabled: not root.save_enabled
+                on_release: root.save_exercise()
+            MDRaisedButton:
+                text: "Back"
+                on_release: root.go_back()
 
 <PreviousWorkoutsScreen@MDScreen>:
     BoxLayout:


### PR DESCRIPTION
## Summary
- track original exercise details and detect modifications
- add save button to EditExerciseScreen
- disable save until edits occur and confirm save action with a dialog
- warn about unsaved changes when navigating back

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765a2f7e38833284d7f93a44eb89d1