### PR TITLE
Fix edit exercise crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -1142,14 +1142,18 @@ class EditExerciseScreen(MDScreen):
     def update_name(self, name: str):
         if self.exercise_obj is not None:
             self.exercise_obj.name = name
+            self.save_enabled = self.exercise_obj.is_modified()
+        else:
+            self.save_enabled = False
         self.exercise_name = name
-        self.save_enabled = self.exercise_obj.is_modified()
 
     def update_description(self, desc: str):
         if self.exercise_obj is not None:
             self.exercise_obj.description = desc
+            self.save_enabled = self.exercise_obj.is_modified()
+        else:
+            self.save_enabled = False
         self.exercise_description = desc
-        self.save_enabled = self.exercise_obj.is_modified()
 
     def remove_metric(self, metric_name):
         if self.exercise_obj:


### PR DESCRIPTION
## Summary
- guard against `None` exercise object when updating name or description

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68765d3db4608332821616608c61b0d8