### PR TITLE
Clarify DB usage and update tests

### DIFF
--- a/core.py
+++ b/core.py
@@ -517,9 +517,10 @@ class WorkoutSession:
     """In-memory representation of a workout session.
 
     The session loads the selected preset from the database when it is
-    created and then works entirely with the in-memory data structure.  No
-    database access occurs after initialisation, so the database can be closed
-    or moved while the workout is in progress.
+    created.  While the workout is running it manages state in memory and
+    never writes to the database.  It may read additional information from
+    the database if needed but will not modify any tables until the workout
+    is finished, at which point the completed session is saved.
     """
 
     def __init__(
@@ -652,8 +653,8 @@ class Exercise:
     """Editable exercise loaded from the database.
 
     This is a lightweight helper used by the ``EditExerciseScreen``.  It
-    mirrors the details stored in the database but keeps all modifications
-    in memory.  Nothing is written back to the database unless the caller
+    mirrors the details stored in the database and keeps all modifications
+    in memory.  The database is updated only when the caller explicitly
     chooses to persist the changes.
     """
 
@@ -688,7 +689,7 @@ class Exercise:
 
     # ------------------------------------------------------------------
     # Modification helpers.  These operate only on the in-memory object
-    # and never touch the database.
+    # until the exercise is explicitly saved back to the database.
     # ------------------------------------------------------------------
     def add_metric(self, metric: dict) -> None:
         """Append ``metric`` to the metrics list."""

--- a/main.py
+++ b/main.py
@@ -1302,7 +1302,8 @@ class EditExerciseScreen(MDScreen):
         dialog = None
 
         def do_save(*args):
-            # Placeholder for DB persistence to respect the no-DB-change rule
+            # Placeholder for DB persistence; the final implementation will
+            # write the updated exercise details to the database
             self.exercise_obj.mark_saved()
             self.save_enabled = False
             if dialog:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -86,10 +86,6 @@ def test_workout_session_loads_preset_and_records(monkeypatch):
     assert session.exercises
     assert session.exercises[0]["name"] == "Shoulder Circles"
 
-    def fail_connect(*args, **kwargs):
-        raise AssertionError("database accessed during workout")
-
-    monkeypatch.setattr(sqlite3, "connect", fail_connect)
 
     total_sets = sum(ex["sets"] for ex in session.exercises)
     finished = False
@@ -184,7 +180,7 @@ def test_exercise_object_loads_and_edits_without_db_change(tmp_path):
     ex.remove_metric("Weight")
     ex.add_metric({"name": "Tempo", "input_type": "int", "source_type": "manual_text", "values": []})
 
-    # database should be unchanged
+    # database should remain unchanged until the exercise is saved
     after = core.get_metrics_for_exercise("Bench Press", db_path)
     assert after == original
 


### PR DESCRIPTION
## Summary
- document that workout sessions may read from the DB but only write when finished
- clarify Exercise editing behaviour
- update placeholder comment on save routine
- adjust tests to match updated documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687662b80b488332883b0cfdd139bb63