### PR TITLE
Implement exercise saving

### DIFF
--- a/main.py
+++ b/main.py
@@ -1302,9 +1302,7 @@ class EditExerciseScreen(MDScreen):
         dialog = None
 
         def do_save(*args):
-            # Placeholder for DB persistence; the final implementation will
-            # write the updated exercise details to the database
-            self.exercise_obj.mark_saved()
+            core.save_exercise(self.exercise_obj)
             self.save_enabled = False
             if dialog:
                 dialog.dismiss()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -189,3 +189,19 @@ def test_exercise_object_loads_and_edits_without_db_change(tmp_path):
     for m in ex.metrics:
         if m["name"] == "Reps":
             assert m["input_type"] == "float"
+
+
+def test_exercise_save_persists_changes(tmp_path):
+    db_src = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+    db_path = tmp_path / "workout.db"
+    db_path.write_bytes(db_src.read_bytes())
+
+    ex = core.Exercise("Push-ups", db_path=db_path)
+    ex.description = "Modified description"
+    assert not ex.is_user_created
+
+    core.save_exercise(ex)
+
+    details = core.get_exercise_details("Push-ups", db_path)
+    assert details["is_user_created"]
+    assert details["description"] == "Modified description"


### PR DESCRIPTION
## Summary
- prefer user-created exercises when fetching details
- persist exercise changes to the database
- update EditExerciseScreen to save through core
- test that saving an exercise writes to the DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876684c8164833297e9b4d7c4fddf88