### PR TITLE
Order exercises by user flag

### DIFF
--- a/core.py
+++ b/core.py
@@ -57,7 +57,9 @@ def get_all_exercises(
     conn = sqlite3.connect(str(db_path))
     cursor = conn.cursor()
     if include_user_created:
-        cursor.execute("SELECT name, is_user_created FROM exercises ORDER BY name")
+        cursor.execute(
+            "SELECT name, is_user_created FROM exercises ORDER BY is_user_created, name"
+        )
         rows = cursor.fetchall()
         exercises = [(name, bool(flag)) for name, flag in rows]
     else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -237,3 +237,27 @@ def test_exercise_save_persists_changes(tmp_path):
 
     reloaded = core.Exercise("Push-ups", db_path=db_path)
     assert reloaded.is_user_created
+
+
+def test_exercise_list_ordering(tmp_path):
+    db_src = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+    db_path = tmp_path / "workout.db"
+    db_path.write_bytes(db_src.read_bytes())
+
+    # Create user copies of two exercises
+    ex = core.Exercise("Bench Press", db_path=db_path)
+    core.save_exercise(ex)
+
+    ex = core.Exercise("Push-ups", db_path=db_path)
+    core.save_exercise(ex)
+
+    exercises = core.get_all_exercises(db_path, include_user_created=True)
+    names = [name for name, _ in exercises]
+
+    assert names == [
+        "Bench Press",
+        "Pull-ups",
+        "Push-ups",
+        "Bench Press",
+        "Push-ups",
+    ]


### PR DESCRIPTION
## Summary
- sort exercise library by `is_user_created` and name
- test ordering logic

## Testing
- `pytest -q` *(fails: No module named 'kivymd')*

------
https://chatgpt.com/codex/tasks/task_e_687675247f74833296410002409546ae