### PR TITLE
Switch exercise list to RecycleView

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -113,6 +113,22 @@ ScreenManager:
             text: "Back to Presets"
             on_release: app.root.current = "presets"
 
+<ExerciseRow@OneLineRightIconListItem>:
+    name: ""
+    is_user_created: False
+    edit_callback: None
+    delete_callback: None
+    IconRightWidget:
+        icon: "pencil"
+        on_release: root.edit_callback(root.name, root.is_user_created) if root.edit_callback else None
+    IconRightWidget:
+        icon: "delete"
+        theme_text_color: "Custom"
+        text_color: 1, 0, 0, 1
+        on_release: root.delete_callback(root.name) if root.delete_callback else None
+        opacity: 1 if root.is_user_created else 0
+        disabled: not root.is_user_created
+
 <ExerciseLibraryScreen@MDScreen>:
     on_pre_enter: root.populate()
     exercise_list: exercise_list
@@ -141,9 +157,15 @@ ScreenManager:
                 MDIconButton:
                     icon: "filter-variant"
                     on_release: root.open_filter_popup()
-            ScrollView:
-                MDList:
-                    id: exercise_list
+            MDRecycleView:
+                id: exercise_list
+                viewclass: "ExerciseRow"
+                RecycleBoxLayout:
+                    default_size: None, dp(56)
+                    default_size_hint: 1, None
+                    size_hint_y: None
+                    height: self.minimum_height
+                    orientation: "vertical"
             MDRaisedButton:
                 text: "Back"
                 on_release: root.go_back()

--- a/main.py
+++ b/main.py
@@ -18,8 +18,6 @@ from kivy.uix.scrollview import ScrollView
 from kivymd.uix.label import MDLabel
 from kivymd.uix.list import (
     OneLineListItem,
-    OneLineRightIconListItem,
-    IconRightWidget,
     MDList,
 )
 from kivymd.uix.selectioncontrol import MDCheckbox
@@ -416,7 +414,7 @@ class ExerciseLibraryScreen(MDScreen):
     def populate(self):
         if not self.exercise_list:
             return
-        self.exercise_list.clear_widgets()
+        self.exercise_list.data = []
         db_path = Path(__file__).resolve().parent / "data" / "workout.db"
         exercises = core.get_all_exercises(db_path, include_user_created=True)
         if self.filter_mode == "user":
@@ -426,21 +424,20 @@ class ExerciseLibraryScreen(MDScreen):
         if self.search_text:
             s = self.search_text.lower()
             exercises = [ex for ex in exercises if s in ex[0].lower()]
+        data = []
         for name, is_user in exercises:
-            item = OneLineRightIconListItem(text=name)
+            item = {
+                "name": name,
+                "text": name,
+                "is_user_created": is_user,
+                "edit_callback": self.open_edit_popup,
+                "delete_callback": self.confirm_delete_exercise,
+            }
             if is_user:
-                item.theme_text_color = "Custom"
-                item.text_color = (0.6, 0.2, 0.8, 1)
-            icon = IconRightWidget(icon="pencil")
-            icon.bind(on_release=lambda inst, n=name, u=is_user: self.open_edit_popup(n, u))
-            item.add_widget(icon)
-            if is_user:
-                del_icon = IconRightWidget(icon="delete")
-                del_icon.theme_text_color = "Custom"
-                del_icon.text_color = (1, 0, 0, 1)
-                del_icon.bind(on_release=lambda inst, n=name: self.confirm_delete_exercise(n))
-                item.add_widget(del_icon)
-            self.exercise_list.add_widget(item)
+                item["theme_text_color"] = "Custom"
+                item["text_color"] = (0.6, 0.2, 0.8, 1)
+            data.append(item)
+        self.exercise_list.data = data
 
     def open_filter_popup(self):
         list_view = MDList()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -15,7 +15,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import core
 from main import ExerciseLibraryScreen, EditExerciseScreen
-from kivymd.uix.list import MDList, OneLineRightIconListItem
+from kivymd.uix.list import MDList
+from kivymd.uix.recycleview import MDRecycleView
 
 
 @pytest.fixture
@@ -36,13 +37,13 @@ def test_db(tmp_path):
     patch.undo()
 
 
-def _get_names(list_widget):
-    return [w.text for w in list_widget.children if isinstance(w, OneLineRightIconListItem)]
+def _get_names(rv):
+    return [item.get("text") for item in rv.data]
 
 
 def test_search_filtering(test_db):
     screen = ExerciseLibraryScreen()
-    screen.exercise_list = MDList()
+    screen.exercise_list = MDRecycleView()
     screen.search_text = "bench"
     screen.populate()
     names = _get_names(screen.exercise_list)
@@ -56,7 +57,7 @@ def test_filter_options(test_db):
     core.save_exercise(ex)
 
     screen = ExerciseLibraryScreen()
-    screen.exercise_list = MDList()
+    screen.exercise_list = MDRecycleView()
     screen.filter_mode = "user"
     screen.populate()
     user_names = _get_names(screen.exercise_list)
@@ -88,7 +89,7 @@ def test_edit_and_save_updates_list(test_db, monkeypatch):
     screen.save_exercise()
 
     lib = ExerciseLibraryScreen()
-    lib.exercise_list = MDList()
+    lib.exercise_list = MDRecycleView()
     lib.filter_mode = "user"
     lib.populate()
     names = _get_names(lib.exercise_list)
@@ -99,12 +100,11 @@ def test_delete_button_for_user_exercise(test_db):
     ex = core.Exercise("Bench Press")
     core.save_exercise(ex)
     screen = ExerciseLibraryScreen()
-    screen.exercise_list = MDList()
+    screen.exercise_list = MDRecycleView()
     screen.filter_mode = "user"
     screen.populate()
-    items = [w for w in screen.exercise_list.children if isinstance(w, OneLineRightIconListItem)]
-    assert items
-    icons = [c for c in items[0].children if hasattr(c, "icon")]
-    assert any(getattr(i, "icon", "") == "delete" for i in icons)
+    data = screen.exercise_list.data
+    assert data
+    assert data[0].get("is_user_created")
 
 


### PR DESCRIPTION
## Summary
- swap ScrollView/MDList for MDRecycleView in `ExerciseLibraryScreen`
- provide data items when populating exercises
- update UI tests for new `MDRecycleView`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kivymd')*

------
https://chatgpt.com/codex/tasks/task_e_68767c94c85c83329d4dd3dd0073d0b3