### PR TITLE
Add loading overlay for slow screens

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -114,7 +114,6 @@ ScreenManager:
             on_release: app.root.current = "presets"
 
 <ExerciseLibraryScreen@MDScreen>:
-    on_pre_enter: root.populate()
     exercise_list: exercise_list
     FloatLayout:
         MDBoxLayout:


### PR DESCRIPTION
## Summary
- add a `LoadingDialog` class with spinner
- show the dialog while populating ExerciseLibraryScreen
- show the dialog while EditExerciseScreen loads an exercise
- remove inline on_pre_enter binding in KV file

## Testing
- `pytest -q` *(fails: Could not find a version that satisfies the requirement certifi==2025.6.15)*

------
https://chatgpt.com/codex/tasks/task_e_68767cb8481483328dfd838753f22f78