### PR TITLE
Fix exercise library display

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -129,7 +129,7 @@ ScreenManager:
         opacity: 1 if root.is_user_created else 0
         disabled: not root.is_user_created
 
-<ExerciseLibraryScreen@MDScreen>:
+<ExerciseLibraryScreen>:
     exercise_list: exercise_list
     FloatLayout:
         MDBoxLayout:

--- a/main.py
+++ b/main.py
@@ -468,7 +468,10 @@ class ExerciseLibraryScreen(MDScreen):
                 self.loading_dialog.dismiss()
                 self.loading_dialog = None
             return
-        self.exercise_list.clear_widgets()
+        # Clearing widgets directly can remove the internal layout manager of
+        # ``RecycleView``. Reset the data list instead so the manager stays
+        # intact and items refresh correctly.
+        self.exercise_list.data = []
         app = MDApp.get_running_app()
         if (
             self.all_exercises is None


### PR DESCRIPTION
## Summary
- ensure ExerciseLibraryScreen uses Python class
- preserve RecycleView layout when clearing data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876854d13f48332bc38bc1f01d8f878