### PR TITLE
Update metric editing workflow

### DIFF
--- a/core.py
+++ b/core.py
@@ -319,6 +319,23 @@ def get_metric_type_schema(
     return fields
 
 
+def is_metric_type_user_created(
+    metric_type_name: str,
+    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+) -> bool:
+    """Return ``True`` if ``metric_type_name`` is marked as user created."""
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT is_user_created FROM library_metric_types WHERE name = ?",
+        (metric_type_name,),
+    )
+    row = cursor.fetchone()
+    conn.close()
+    return bool(row[0]) if row else False
+
+
 def add_metric_type(
     name: str,
     input_type: str,


### PR DESCRIPTION
## Summary
- refresh exercise view after creating metrics
- include manual enum values in EditMetricPopup
- add per-metric saving options for user-created metrics
- expose helper to check if metric type is user created

## Testing
- `pytest -q` *(fails: view already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6877cb71d1f883329e91dfc9e5285ed7