### PR TITLE
Allow spaces in enum values input

### DIFF
--- a/main.py
+++ b/main.py
@@ -1064,7 +1064,7 @@ class AddMetricPopup(MDDialog):
             elif input_type == "float":
                 allowed = string.digits + ".,"
             else:  # default to str
-                allowed = string.ascii_letters + ","
+                allowed = string.ascii_letters + " ,"
 
             def _filter(value, from_undo):
                 return "".join(ch for ch in value if ch in allowed)
@@ -1317,7 +1317,7 @@ class EditMetricPopup(MDDialog):
             elif input_type == "float":
                 allowed = string.digits + ".,"
             else:
-                allowed = string.ascii_letters + ","
+                allowed = string.ascii_letters + " ,"
 
             def _filter(value, from_undo):
                 return "".join(ch for ch in value if ch in allowed)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -16,7 +16,7 @@ if kivy_available:
     from kivy.app import App
     from kivy.properties import ObjectProperty
 
-    from main import RestScreen, MetricInputScreen, WorkoutActiveScreen
+    from main import RestScreen, MetricInputScreen, WorkoutActiveScreen, AddMetricPopup
     import time
 
     class _DummyApp:
@@ -62,3 +62,14 @@ def test_update_elapsed_formats_time(monkeypatch):
     screen._update_elapsed(0)
     assert screen.elapsed == pytest.approx(75.0, abs=1e-3)
     assert screen.formatted_time == "01:15"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_enum_values_accepts_spaces():
+    class DummyScreen:
+        exercise_obj = type("obj", (), {"metrics": []})()
+
+    popup = AddMetricPopup(DummyScreen(), mode="new")
+    popup.input_widgets["input_type"].text = "str"
+    filtered = popup.enum_values_field.input_filter("A B,C", False)
+    assert filtered == "A B,C"


### PR DESCRIPTION
## Summary
- permit spaces when filtering enum values
- test that enum field accepts spaces

## Testing
- `pytest -q` *(fails: view library_view_exercise_metrics already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6877cec598648332b6dfa11c2209834b