### PR TITLE
Fix metric save dialog button layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -1396,6 +1396,12 @@ class EditMetricPopup(MDDialog):
                     MDRaisedButton(text="Current Exercise", on_release=save_override),
                 ],
             )
+
+            def _on_open(instance):
+                if hasattr(instance, "ids") and "buttons" in instance.ids:
+                    instance.ids.buttons.orientation = "vertical"
+
+            dialog.bind(on_open=_on_open)
             dialog.open()
         else:
             apply_updates()


### PR DESCRIPTION
## Summary
- stack buttons vertically in the save metric confirmation dialog so all are visible on small screens

## Testing
- `pytest -q` *(fails: OperationalError: view library_view_exercise_metrics already exists)*

------
https://chatgpt.com/codex/tasks/task_e_6877cf48ea3c83329489e1758401f60f