### PR TITLE
Fix Edit Metric dialog button layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -1416,7 +1416,9 @@ class EditMetricPopup(MDDialog):
 
             def _on_open(instance):
                 if hasattr(instance, "ids") and "buttons" in instance.ids:
-                    instance.ids.buttons.orientation = "vertical"
+                    instance.ids.buttons.orientation = (
+                        "vertical" if Window.width < dp(400) else "horizontal"
+                    )
 
             dialog.bind(on_open=_on_open)
             dialog.open()


### PR DESCRIPTION
## Summary
- adjust button orientation in the Edit Metric confirmation dialog
  based on current window width

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877d17c95e88332a6e2f0f9c958642f