### PR TITLE
Adapt preset code to new DB schema

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,44 +101,60 @@ def sample_db(tmp_path: Path) -> Path:
     conn.execute(
         """
         INSERT INTO preset_section_exercises
-            (section_id, exercise_id, position, number_of_sets, exercise_name, exercise_description)
-        VALUES (?, ?, 0, 2, 'Push-up', '')
+            (section_id, exercise_name, exercise_description, position, number_of_sets, library_exercise_id)
+        VALUES (?, 'Push-up', '', 0, 2, ?)
         """,
         (section_id, pushup_id),
     )
     push_se_id = conn.execute(
-        "SELECT id FROM preset_section_exercises WHERE exercise_id=? AND section_id=?",
+        "SELECT id FROM preset_section_exercises WHERE library_exercise_id=? AND section_id=?",
         (pushup_id, section_id),
     ).fetchone()[0]
 
     conn.execute(
         """
         INSERT INTO preset_section_exercises
-            (section_id, exercise_id, position, number_of_sets, exercise_name, exercise_description)
-        VALUES (?, ?, 1, 2, 'Bench Press', '')
+            (section_id, exercise_name, exercise_description, position, number_of_sets, library_exercise_id)
+        VALUES (?, 'Bench Press', '', 1, 2, ?)
         """,
         (section_id, bench_id),
     )
     bench_se_id = conn.execute(
-        "SELECT id FROM preset_section_exercises WHERE exercise_id=? AND section_id=?",
+        "SELECT id FROM preset_section_exercises WHERE library_exercise_id=? AND section_id=?",
         (bench_id, section_id),
     ).fetchone()[0]
 
     # section exercise metrics (override reps timing for bench)
     conn.execute(
-        "INSERT INTO preset_section_exercise_metrics (section_exercise_id, metric_type_id, input_timing, is_required, scope) VALUES (?, ?, 'post_set', 1, 'set')",
+        """
+        INSERT INTO preset_section_exercise_metrics
+            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Reps', 'int', 'manual_text', 'post_set', 1, 'set', ?)
+        """,
         (push_se_id, reps_id),
     )
     conn.execute(
-        "INSERT INTO preset_section_exercise_metrics (section_exercise_id, metric_type_id, input_timing, is_required, scope) VALUES (?, ?, 'pre_set', 1, 'set')",
+        """
+        INSERT INTO preset_section_exercise_metrics
+            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Reps', 'int', 'manual_text', 'pre_set', 1, 'set', ?)
+        """,
         (bench_se_id, reps_id),
     )
     conn.execute(
-        "INSERT INTO preset_section_exercise_metrics (section_exercise_id, metric_type_id, input_timing, is_required, scope) VALUES (?, ?, 'pre_set', 0, 'set')",
+        """
+        INSERT INTO preset_section_exercise_metrics
+            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Weight', 'float', 'manual_text', 'pre_set', 0, 'set', ?)
+        """,
         (bench_se_id, weight_id),
     )
     conn.execute(
-        "INSERT INTO preset_section_exercise_metrics (section_exercise_id, metric_type_id, input_timing, is_required, scope) VALUES (?, ?, 'pre_workout', 0, 'exercise')",
+        """
+        INSERT INTO preset_section_exercise_metrics
+            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Machine', 'str', 'manual_enum', 'pre_workout', 0, 'exercise', ?)
+        """,
         (bench_se_id, machine_id),
     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,10 +35,18 @@ def sample_db(tmp_path):
     cur.execute("INSERT INTO preset_presets (name) VALUES ('Push Day')")
     cur.execute("INSERT INTO preset_sections (preset_id, name, position) VALUES (1, 'Main', 0)")
     cur.execute(
-        "INSERT INTO preset_section_exercises (section_id, exercise_id, position, number_of_sets) VALUES (1, 1, 0, 2)"
+        """
+        INSERT INTO preset_section_exercises
+            (section_id, exercise_name, exercise_description, position, number_of_sets, library_exercise_id)
+        VALUES (1, 'Push Up', '', 0, 2, 1)
+        """
     )
     cur.execute(
-        "INSERT INTO preset_section_exercises (section_id, exercise_id, position, number_of_sets) VALUES (1, 2, 1, 3)"
+        """
+        INSERT INTO preset_section_exercises
+            (section_id, exercise_name, exercise_description, position, number_of_sets, library_exercise_id)
+        VALUES (1, 'Bench Press', '', 1, 3, 2)
+        """
     )
     conn.commit()
     conn.close()

--- a/tests/test_workout_db.py
+++ b/tests/test_workout_db.py
@@ -54,11 +54,19 @@ def populate_sample_data(db_path: Path) -> None:
     )
     push_id = cur.fetchone()[0]
     cur.execute(
-        "INSERT INTO preset_section_exercises (section_id, exercise_id, position, number_of_sets) VALUES (?, ?, 0, 3)",
+        """
+        INSERT INTO preset_section_exercises
+            (section_id, exercise_name, exercise_description, position, number_of_sets, library_exercise_id)
+        VALUES (?, 'Bench Press', '', 0, 3, ?)
+        """,
         (section_id, bench_id),
     )
     cur.execute(
-        "INSERT INTO preset_section_exercises (section_id, exercise_id, position, number_of_sets) VALUES (?, ?, 1, 2)",
+        """
+        INSERT INTO preset_section_exercises
+            (section_id, exercise_name, exercise_description, position, number_of_sets, library_exercise_id)
+        VALUES (?, 'Push Up', '', 1, 2, ?)
+        """,
         (section_id, push_id),
     )
     conn.commit()


### PR DESCRIPTION
## Summary
- update preset queries for self-contained tables
- adjust preset metric override logic
- adapt PresetEditor and helpers to new columns
- update test fixtures and sample data for new schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f894905808332803ed11be48d88eb