### PR TITLE
Implement preset saving feature

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -535,9 +535,16 @@ ScreenManager:
                                     size_hint_y: None
                                     height: "48dp"  # Give it space to render properly
 
-                        MDRaisedButton:
-                            text: "Back to Presets"
-                            on_release: app.root.current = "presets"
+            MDBoxLayout:
+                size_hint_y: None
+                height: "40dp"
+                spacing: "10dp"
+                MDRaisedButton:
+                    text: "Save"
+                    on_release: root.save_preset()
+                MDRaisedButton:
+                    text: "Back"
+                    on_release: root.go_back()
 
         ExerciseSelectionPanel:
             id: exercise_panel


### PR DESCRIPTION
## Summary
- extend `PresetEditor` with tracking and save support
- add save controls in `EditPresetScreen`
- expose Save and Back buttons in kv layout
- add tests for saving presets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8c9952dc83328a9105f3778a02d4