### PR TITLE
Add config tab for preset exercise editing

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -663,6 +663,14 @@ ScreenManager:
             height: "40dp"
             spacing: "10dp"
             MDRaisedButton:
+                text: "Config"
+                opacity: 1 if root.section_index >= 0 else 0
+                disabled: root.section_index < 0
+                size_hint_x: None
+                width: self.texture_size[0] + dp(20) if root.section_index >= 0 else 0
+                md_bg_color: app.theme_cls.primary_color if root.current_tab == "config" else (.5, .5, .5, 1)
+                on_release: root.switch_tab("config") if root.section_index >= 0 else None
+            MDRaisedButton:
                 text: "Metrics"
                 md_bg_color: app.theme_cls.primary_color if root.current_tab == "metrics" else (.5, .5, .5, 1)
                 on_release: root.switch_tab("metrics")
@@ -675,6 +683,25 @@ ScreenManager:
             size_hint_y: 1
             transition: NoTransition()
             on_kv_post: self.current = root.current_tab
+            Screen:
+                name: "config"
+                BoxLayout:
+                    orientation: "vertical"
+                    spacing: "10dp"
+                    size_hint_y: None
+                    height: self.minimum_height
+                    MDTextField:
+                        id: sets_field
+                        hint_text: "Sets"
+                        text: str(root.exercise_sets)
+                        input_filter: "int"
+                        on_text: root.update_sets(self.text)
+                    MDTextField:
+                        id: rest_field
+                        hint_text: "Rest Time (s)"
+                        text: str(root.exercise_rest)
+                        input_filter: "int"
+                        on_text: root.update_rest(self.text)
             Screen:
                 name: "metrics"
                 FloatLayout:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -60,8 +60,8 @@ def test_load_workout_presets(sample_db):
         {
             "name": "Push Day",
             "exercises": [
-                {"name": "Push Up", "sets": 2},
-                {"name": "Bench Press", "sets": 3},
+                {"name": "Push Up", "sets": 2, "rest": 120},
+                {"name": "Bench Press", "sets": 3, "rest": 120},
             ],
         }
     ]

--- a/tests/test_database_helpers.py
+++ b/tests/test_database_helpers.py
@@ -40,8 +40,8 @@ def test_load_workout_presets(sample_db):
         {
             "name": "Push Day",
             "exercises": [
-                {"name": "Push-up", "sets": 2},
-                {"name": "Bench Press", "sets": 2},
+                {"name": "Push-up", "sets": 2, "rest": 120},
+                {"name": "Bench Press", "sets": 2, "rest": 120},
             ],
         }
     ]

--- a/tests/test_workout_db.py
+++ b/tests/test_workout_db.py
@@ -114,8 +114,8 @@ def test_load_workout_presets(sample_db: Path):
         {
             "name": "Push Day",
             "exercises": [
-                {"name": "Bench Press", "sets": 3},
-                {"name": "Push Up", "sets": 2},
+                {"name": "Bench Press", "sets": 3, "rest": 120},
+                {"name": "Push Up", "sets": 2, "rest": 120},
             ],
         }
     ]


### PR DESCRIPTION
## Summary
- load rest time from database when getting presets
- track rest values in `PresetEditor` and add update helper
- add config tab for exercise editing in presets
- allow editing sets and rest in the new tab
- update tests to cover rest times

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f940611988332879349993a5d141c