### PR TITLE
Set default tab based on entry point

### DIFF
--- a/main.py
+++ b/main.py
@@ -1535,6 +1535,10 @@ class EditExerciseScreen(MDScreen):
             if "exercise_tabs" in self.ids:
                 self.ids.exercise_tabs.current = tab
     def on_pre_enter(self, *args):
+        if self.previous_screen == "edit_preset":
+            self.switch_tab("config")
+        else:
+            self.switch_tab("metrics")
         if os.environ.get("KIVY_UNITTEST"):
             self._load_exercise()
         else:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -17,7 +17,13 @@ if kivy_available:
     from kivy.app import App
     from kivy.properties import ObjectProperty
 
-    from main import RestScreen, MetricInputScreen, WorkoutActiveScreen, AddMetricPopup
+    from main import (
+        RestScreen,
+        MetricInputScreen,
+        WorkoutActiveScreen,
+        AddMetricPopup,
+        EditExerciseScreen,
+    )
     import time
 
     class _DummyApp:
@@ -74,3 +80,19 @@ def test_enum_values_accepts_spaces():
     popup.input_widgets["input_type"].text = "str"
     filtered = popup.enum_values_field.input_filter("A B,C", False)
     assert filtered == "A B,C"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_edit_exercise_default_tab():
+    screen = EditExerciseScreen()
+    screen.previous_screen = "exercise_library"
+    screen.on_pre_enter()
+    assert screen.current_tab == "metrics"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_edit_exercise_preset_tab():
+    screen = EditExerciseScreen()
+    screen.previous_screen = "edit_preset"
+    screen.on_pre_enter()
+    assert screen.current_tab == "config"


### PR DESCRIPTION
## Summary
- switch EditExerciseScreen tab based on previous screen
- test the tab selection logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687faab3e5588332b83aec08154c4f05