### PR TITLE
Implement per-exercise metric override option

### DIFF
--- a/main.py
+++ b/main.py
@@ -1478,11 +1478,30 @@ class EditMetricPopup(MDDialog):
                         is_required=updates.get("is_required"),
                         db_path=db_path,
                     )
-                    core.set_exercise_metric_override(
-                        self.screen.exercise_obj.name,
-                        self.metric["name"],
-                        db_path=db_path,
-                    )
+                    try:
+                        core.set_exercise_metric_override(
+                            self.screen.exercise_obj.name,
+                            self.metric["name"],
+                            db_path=db_path,
+                        )
+                    except ValueError as exc:
+                        if "not associated" not in str(exc):
+                            raise
+                else:
+                    try:
+                        core.set_exercise_metric_override(
+                            self.screen.exercise_obj.name,
+                            self.metric["name"],
+                            input_type=updates.get("input_type"),
+                            source_type=updates.get("source_type"),
+                            input_timing=updates.get("input_timing"),
+                            is_required=updates.get("is_required"),
+                            scope=updates.get("scope"),
+                            db_path=db_path,
+                        )
+                    except ValueError as exc:
+                        if "not associated" not in str(exc):
+                            raise
                 cancel_action()
                 apply_updates()
 


### PR DESCRIPTION
## Summary
- support applying metric edits to a single exercise or all exercises
- avoid crashing when a new metric hasn't been saved yet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fba7682448332b4265dd9d1130869