### PR TITLE
Fix metric override crash when editing unsaved metric

### DIFF
--- a/core.py
+++ b/core.py
@@ -888,6 +888,16 @@ class Exercise:
 
         self._original = self.to_dict()
 
+    def had_metric(self, metric_name: str) -> bool:
+        """Return ``True`` if ``metric_name`` existed when loaded."""
+
+        if not self._original:
+            return False
+        for m in self._original.get("metrics", []):
+            if m.get("name") == metric_name:
+                return True
+        return False
+
 
 def save_exercise(exercise: Exercise) -> None:
     """Persist ``exercise`` to the database as a user-defined copy."""

--- a/main.py
+++ b/main.py
@@ -1467,6 +1467,9 @@ class EditMetricPopup(MDDialog):
             content.add_widget(label)
 
             def on_save(*a):
+                metric_saved = self.screen.exercise_obj.had_metric(
+                    self.metric["name"]
+                )
                 if checkbox.active:
                     core.update_metric_type(
                         self.metric["name"],
@@ -1478,22 +1481,24 @@ class EditMetricPopup(MDDialog):
                         is_required=updates.get("is_required"),
                         db_path=db_path,
                     )
-                    core.set_exercise_metric_override(
-                        self.screen.exercise_obj.name,
-                        self.metric["name"],
-                        db_path=db_path,
-                    )
+                    if metric_saved:
+                        core.set_exercise_metric_override(
+                            self.screen.exercise_obj.name,
+                            self.metric["name"],
+                            db_path=db_path,
+                        )
                 else:
-                    core.set_exercise_metric_override(
-                        self.screen.exercise_obj.name,
-                        self.metric["name"],
-                        input_type=updates.get("input_type"),
-                        source_type=updates.get("source_type"),
-                        input_timing=updates.get("input_timing"),
-                        is_required=updates.get("is_required"),
-                        scope=updates.get("scope"),
-                        db_path=db_path,
-                    )
+                    if metric_saved:
+                        core.set_exercise_metric_override(
+                            self.screen.exercise_obj.name,
+                            self.metric["name"],
+                            input_type=updates.get("input_type"),
+                            source_type=updates.get("source_type"),
+                            input_timing=updates.get("input_timing"),
+                            is_required=updates.get("is_required"),
+                            scope=updates.get("scope"),
+                            db_path=db_path,
+                        )
                 cancel_action()
                 apply_updates()
 

--- a/tests/test_exercise_model.py
+++ b/tests/test_exercise_model.py
@@ -20,3 +20,13 @@ def test_exercise_load_modify_save(sample_db):
     names = [m["name"] for m in loaded.metrics]
     assert "Weight" in names
     assert loaded.is_user_created
+
+
+def test_had_metric(sample_db):
+    ex = core.Exercise("Push-up", db_path=sample_db)
+    assert ex.had_metric("Reps")
+    ex.add_metric({"name": "Weight"})
+    assert not ex.had_metric("Weight")
+    core.save_exercise(ex)
+    loaded = core.Exercise("Push-up", db_path=sample_db, is_user_created=True)
+    assert loaded.had_metric("Weight")


### PR DESCRIPTION
## Summary
- prevent calling `set_exercise_metric_override` for metrics that are not yet saved
- expose `Exercise.had_metric` to check if a metric existed when loaded
- unit test for `Exercise.had_metric`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fbc6068608332b03e1f05ca44607d