### PR TITLE
Support metric overrides for user exercises

### DIFF
--- a/main.py
+++ b/main.py
@@ -1485,6 +1485,7 @@ class EditMetricPopup(MDDialog):
                         core.set_exercise_metric_override(
                             self.screen.exercise_obj.name,
                             self.metric["name"],
+                            is_user_created=self.screen.exercise_obj.is_user_created,
                             db_path=db_path,
                         )
                 else:
@@ -1497,6 +1498,7 @@ class EditMetricPopup(MDDialog):
                             input_timing=updates.get("input_timing"),
                             is_required=updates.get("is_required"),
                             scope=updates.get("scope"),
+                            is_user_created=self.screen.exercise_obj.is_user_created,
                             db_path=db_path,
                         )
                 cancel_action()


### PR DESCRIPTION
## Summary
- allow `core.set_exercise_metric_override` to target user-created exercises
- pass `is_user_created` when editing metrics from the UI
- test overriding metrics when both user and predefined exercises exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d79829f48332a442ba34a22a8c10