### PR TITLE
Add filtering to exercise selection panel

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -602,6 +602,7 @@ ScreenManager:
 
 <ExerciseSelectionPanel@MDBoxLayout>:
     exercise_list: exercise_list
+    search_field: search_field
     orientation: "vertical"
     md_bg_color: 1, 1, 1, 1
     MDBoxLayout:
@@ -611,10 +612,20 @@ ScreenManager:
             text: "Select Exercises"
             halign: "center"
         MDIconButton:
+            icon: "filter-variant"
+            on_release: root.open_filter_popup()
+        MDIconButton:
             icon: "close"
             theme_text_color: "Custom"
             text_color: 1, 0, 0, 1
             on_release: app.root.get_screen("edit_preset").close_exercise_panel()
+    MDTextField:
+        id: search_field
+        hint_text: "Search exercises"
+        text: root.search_text
+        on_text: root.update_search(self.text)
+        size_hint_y: None
+        height: "40dp"
     ScrollView:
         MDList:
             id: exercise_list

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -16,6 +16,7 @@ if kivy_available:
 
     from kivy.app import App
     from kivy.properties import ObjectProperty
+    import core
 
     from main import (
         RestScreen,
@@ -23,6 +24,7 @@ if kivy_available:
         WorkoutActiveScreen,
         AddMetricPopup,
         EditExerciseScreen,
+        ExerciseSelectionPanel,
     )
     import time
 
@@ -96,3 +98,22 @@ def test_edit_exercise_preset_tab():
     screen.previous_screen = "edit_preset"
     screen.on_pre_enter()
     assert screen.current_tab == "config"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_exercise_selection_panel_filters(monkeypatch):
+    panel = ExerciseSelectionPanel()
+    panel.exercise_list = type("L", (), {"children": [], "clear_widgets": lambda self: self.children.clear(), "add_widget": lambda self, w: self.children.append(w)})()
+
+    monkeypatch.setattr(
+        core,
+        "get_all_exercises",
+        lambda *a, **k: [("Push Ups", False), ("Custom", True)],
+    )
+
+    panel.populate_exercises()
+    assert len(panel.exercise_list.children) == 2
+
+    panel.apply_filter("user")
+    assert len(panel.exercise_list.children) == 1
+    assert panel.exercise_list.children[0].text == "Custom"


### PR DESCRIPTION
## Summary
- match exercise selection panel filtering with the library screen
- update UI layout for search and filter controls
- test exercise selection panel filtering behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880daea89088332aa17460142ab1ce5