### PR TITLE
Fix unclickable buttons in preset editor

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -552,6 +552,7 @@ ScreenManager:
             height: root.height * 0.66 if root.panel_visible else 0
             y: 0
             opacity: 1 if root.panel_visible else 0
+            disabled: not root.panel_visible
 <SelectedExerciseItem>:
     orientation: "horizontal"
     size_hint_y: None


### PR DESCRIPTION
## Summary
- ensure the exercise selection panel can't block underlying buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dcfec534833297806d90c13ec162