### PR TITLE
Update preset selection button text

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -81,7 +81,8 @@ ScreenManager:
             text: "Selected: " + root.selected_preset if root.selected_preset else "Select a preset"
             halign: "center"
         MDRaisedButton:
-            text: "Select Preset"
+            id: select_btn
+            text: root.selected_preset if root.selected_preset else "Select Preset"
             disabled: not root.selected_preset
             on_release: root.confirm_selection()
         MDRaisedButton:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -25,6 +25,7 @@ if kivy_available:
         AddMetricPopup,
         EditExerciseScreen,
         ExerciseSelectionPanel,
+        PresetsScreen,
     )
     import time
 
@@ -117,3 +118,23 @@ def test_exercise_selection_panel_filters(monkeypatch):
     panel.apply_filter("user")
     assert len(panel.exercise_list.children) == 1
     assert panel.exercise_list.children[0].text == "Custom"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_preset_select_button_updates(monkeypatch):
+    """Selecting a preset updates the select button text."""
+    from kivy.lang import Builder
+    from pathlib import Path
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    monkeypatch.setattr(
+        core,
+        "WORKOUT_PRESETS",
+        [{"name": "Sample", "exercises": []}],
+    )
+
+    screen = PresetsScreen()
+    dummy = type("Obj", (), {"md_bg_color": (0, 0, 0, 0)})()
+    screen.select_preset("Sample", dummy)
+
+    assert screen.ids.select_btn.text == "Sample"


### PR DESCRIPTION
## Summary
- show the selected preset name directly on the selection button
- test that the button text updates when selecting a preset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dce9977c8332ab798b4ed0460632