### PR TITLE
Add metrics tab in exercise library

### DIFF
--- a/core.py
+++ b/core.py
@@ -228,39 +228,77 @@ def get_metrics_for_exercise(
 
 def get_all_metric_types(
     db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    *,
+    include_user_created: bool = False,
 ) -> list:
-    """Return all metric type definitions from the database."""
+    """Return all metric type definitions from the database.
+
+    If ``include_user_created`` is ``True`` the returned dictionaries include an
+    ``is_user_created`` flag.
+    """
 
     conn = sqlite3.connect(str(db_path))
     cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT name, input_type, source_type, input_timing,
-               is_required, scope, description
-        FROM library_metric_types
-        ORDER BY id
-        """
-    )
-    metric_types = [
-        {
-            "name": name,
-            "input_type": input_type,
-            "source_type": source_type,
-            "input_timing": input_timing,
-            "is_required": bool(is_required),
-            "scope": scope,
-            "description": description,
-        }
-        for (
-            name,
-            input_type,
-            source_type,
-            input_timing,
-            is_required,
-            scope,
-            description,
-        ) in cursor.fetchall()
-    ]
+    if include_user_created:
+        cursor.execute(
+            """
+            SELECT name, input_type, source_type, input_timing,
+                   is_required, scope, description, is_user_created
+            FROM library_metric_types
+            ORDER BY id
+            """
+        )
+        metric_types = [
+            {
+                "name": name,
+                "input_type": input_type,
+                "source_type": source_type,
+                "input_timing": input_timing,
+                "is_required": bool(is_required),
+                "scope": scope,
+                "description": description,
+                "is_user_created": bool(flag),
+            }
+            for (
+                name,
+                input_type,
+                source_type,
+                input_timing,
+                is_required,
+                scope,
+                description,
+                flag,
+            ) in cursor.fetchall()
+        ]
+    else:
+        cursor.execute(
+            """
+            SELECT name, input_type, source_type, input_timing,
+                   is_required, scope, description
+            FROM library_metric_types
+            ORDER BY id
+            """
+        )
+        metric_types = [
+            {
+                "name": name,
+                "input_type": input_type,
+                "source_type": source_type,
+                "input_timing": input_timing,
+                "is_required": bool(is_required),
+                "scope": scope,
+                "description": description,
+            }
+            for (
+                name,
+                input_type,
+                source_type,
+                input_timing,
+                is_required,
+                scope,
+                description,
+            ) in cursor.fetchall()
+        ]
     conn.close()
     return metric_types
 

--- a/main.kv
+++ b/main.kv
@@ -152,50 +152,142 @@ ScreenManager:
             disabled: not root.is_user_created
             on_touch_down: if self.collide_point(*args[1].pos) and root.delete_callback: root.delete_callback(root.name)
 
+<MetricRow@MDBoxLayout>:
+    name: ""
+    text: ""
+    is_user_created: False
+    edit_callback: None
+    orientation: "horizontal"
+    size_hint_y: None
+    height: "56dp"
+    padding: "8dp"
+    MDLabel:
+        text: root.text
+        size_hint_x: 1
+        theme_text_color: "Custom"
+        text_color: (0.6, 0.2, 0.8, 1) if root.is_user_created else (0, 0, 0, 1)
+        halign: "left"
+        valign: "center"
+    MDBoxLayout:
+        size_hint_x: None
+        width: "36dp"
+        orientation: "horizontal"
+        spacing: "5dp"
+        valign: "center"
+        MDIcon:
+            icon: "pencil"
+            font_size: "20sp"
+            pos_hint: {"center_y": 0.5}
+            on_touch_down: if self.collide_point(*args[1].pos) and root.edit_callback: root.edit_callback(root.name, root.is_user_created)
+
 <ExerciseLibraryScreen>:
     exercise_list: exercise_list
+    metric_list: metric_list
+    current_tab: "exercises"
     FloatLayout:
         MDBoxLayout:
             orientation: "vertical"
             spacing: "10dp"
             padding: "20dp"
-            MDTextField:
-                id: search_field
-                hint_text: "Search exercises"
-                text: root.search_text
-                on_text: root.update_search(self.text)
+            MDBoxLayout:
                 size_hint_y: None
                 height: "40dp"
-            MDBoxLayout:
-                orientation: "horizontal"
-                size_hint_y: None
-                height: self.minimum_height
-                MDLabel:
-                    text: "Exercise Library - browse all exercises"
-                    halign: "center"
-                    theme_text_color: "Custom"
-                    text_color: 0.2, 0.6, 0.86, 1
-                    size_hint_x: 0.9
-                MDIconButton:
-                    icon: "filter-variant"
-                    on_release: root.open_filter_popup()
-            MDRecycleView:
-                id: exercise_list
-                viewclass: "ExerciseRow"
-                RecycleBoxLayout:
-                    default_size: None, dp(56)
-                    default_size_hint: 1, None
-                    size_hint_y: None
-                    height: self.minimum_height
-                    orientation: "vertical"
-            MDRaisedButton:
-                text: "Back"
-                on_release: root.go_back()
-        MDFloatingActionButton:
-            icon: "plus"
-            md_bg_color: app.theme_cls.primary_color
-            pos_hint: {"right": 0.98, "y": 0.02}
-            on_release: root.new_exercise()
+                spacing: "10dp"
+                MDRaisedButton:
+                    text: "Exercises"
+                    md_bg_color: app.theme_cls.primary_color if root.current_tab == "exercises" else (.5, .5, .5, 1)
+                    on_release: root.switch_tab("exercises")
+                MDRaisedButton:
+                    text: "Metrics"
+                    md_bg_color: app.theme_cls.primary_color if root.current_tab == "metrics" else (.5, .5, .5, 1)
+                    on_release: root.switch_tab("metrics")
+            ScreenManager:
+                id: library_tabs
+                size_hint_y: 1
+                transition: NoTransition()
+                on_kv_post: self.current = root.current_tab
+                Screen:
+                    name: "exercises"
+                    BoxLayout:
+                        orientation: "vertical"
+                        MDTextField:
+                            id: search_field
+                            hint_text: "Search exercises"
+                            text: root.search_text
+                            on_text: root.update_search(self.text)
+                            size_hint_y: None
+                            height: "40dp"
+                        MDBoxLayout:
+                            orientation: "horizontal"
+                            size_hint_y: None
+                            height: self.minimum_height
+                            MDLabel:
+                                text: "Exercise Library - browse all exercises"
+                                halign: "center"
+                                theme_text_color: "Custom"
+                                text_color: 0.2, 0.6, 0.86, 1
+                                size_hint_x: 0.9
+                            MDIconButton:
+                                icon: "filter-variant"
+                                on_release: root.open_filter_popup()
+                        MDRecycleView:
+                            id: exercise_list
+                            viewclass: "ExerciseRow"
+                            RecycleBoxLayout:
+                                default_size: None, dp(56)
+                                default_size_hint: 1, None
+                                size_hint_y: None
+                                height: self.minimum_height
+                                orientation: "vertical"
+                        MDRaisedButton:
+                            text: "Back"
+                            on_release: root.go_back()
+                    MDFloatingActionButton:
+                        icon: "plus"
+                        md_bg_color: app.theme_cls.primary_color
+                        pos_hint: {"right": 0.98, "y": 0.02}
+                        on_release: root.new_exercise()
+                Screen:
+                    name: "metrics"
+                    BoxLayout:
+                        orientation: "vertical"
+                        MDTextField:
+                            id: metric_search_field
+                            hint_text: "Search metrics"
+                            text: root.metric_search_text
+                            on_text: root.update_search(self.text)
+                            size_hint_y: None
+                            height: "40dp"
+                        MDBoxLayout:
+                            orientation: "horizontal"
+                            size_hint_y: None
+                            height: self.minimum_height
+                            MDLabel:
+                                text: "Metric Library - browse all metrics"
+                                halign: "center"
+                                theme_text_color: "Custom"
+                                text_color: 0.2, 0.6, 0.86, 1
+                                size_hint_x: 0.9
+                            MDIconButton:
+                                icon: "filter-variant"
+                                on_release: root.open_filter_popup()
+                        MDRecycleView:
+                            id: metric_list
+                            viewclass: "MetricRow"
+                            RecycleBoxLayout:
+                                default_size: None, dp(56)
+                                default_size_hint: 1, None
+                                size_hint_y: None
+                                height: self.minimum_height
+                                orientation: "vertical"
+                        MDRaisedButton:
+                            text: "Back"
+                            on_release: root.go_back()
+                    MDFloatingActionButton:
+                        icon: "plus"
+                        md_bg_color: app.theme_cls.primary_color
+                        pos_hint: {"right": 0.98, "y": 0.02}
+                        on_release: root.new_metric()
 
 <ProgressScreen@MDScreen>:
     BoxLayout:


### PR DESCRIPTION
## Summary
- introduce `MetricRow` component and reorganize ExerciseLibraryScreen UI into Exercises and Metrics tabs
- allow filtering and searching metrics
- support editing metric types through new `EditMetricTypePopup`
- cache metric type list and add `metric_library_version` tracking
- extend `core.get_all_metric_types` to optionally include user flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dc246920833283f83759ed909f41