### PR TITLE
Add validation for preset save exercises

### DIFF
--- a/core.py
+++ b/core.py
@@ -1279,7 +1279,9 @@ class PresetEditor:
                     (ex["name"],),
                 )
                 lr = cursor.fetchone()
-                lib_id = lr[0] if lr else None
+                if lr is None:
+                    raise ValueError(f"Exercise '{ex['name']}' does not exist")
+                lib_id = lr[0]
                 cursor.execute(
                     """INSERT INTO preset_section_exercises
                         (section_id, exercise_name, exercise_description, position, number_of_sets, library_exercise_id, rest_time)

--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -171,3 +171,14 @@ def test_save_duplicate_name(db_with_preset):
     editor.close()
 
 
+def test_save_missing_exercise_fails(db_copy):
+    editor = PresetEditor(db_path=db_copy)
+    editor.preset_name = "My Preset"
+    editor.add_section("Warmup")
+    editor.add_exercise(0, "Push ups")
+    editor.sections[0]["exercises"][0]["name"] = "DoesNotExist"
+    with pytest.raises(ValueError):
+        editor.save()
+    editor.close()
+
+


### PR DESCRIPTION
## Summary
- validate library exercise presence when saving a preset
- test that saving with missing exercise raises error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880df5cc0b48332bb1ef9768218841a