### PR TITLE
Add DEFAULT_DB_PATH constant

### DIFF
--- a/core.py
+++ b/core.py
@@ -9,12 +9,15 @@ DEFAULT_SETS_PER_EXERCISE = 3
 # Default rest duration between sets in seconds
 DEFAULT_REST_DURATION = 120
 
+# Default path to the bundled SQLite database
+DEFAULT_DB_PATH = Path(__file__).resolve().parent / "data" / "workout.db"
+
 # Will hold preset data loaded from the database. Each item is a dict with
 #   {'name': <preset name>,
 #    'exercises': [{'name': <exercise name>, 'sets': <number_of_sets>}, ...]}
 WORKOUT_PRESETS = []
 
-def load_workout_presets(db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db"):
+def load_workout_presets(db_path: Path = DEFAULT_DB_PATH):
     """Load workout presets from the SQLite database into WORKOUT_PRESETS."""
     global WORKOUT_PRESETS
 
@@ -43,7 +46,7 @@ def load_workout_presets(db_path: Path = Path(__file__).resolve().parent / "data
 
 
 def get_all_exercises(
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
     *,
     include_user_created: bool = False,
 ) -> list:
@@ -70,7 +73,7 @@ def get_all_exercises(
 
 def get_exercise_details(
     exercise_name: str,
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
     is_user_created: bool | None = None,
 ) -> dict | None:
     """Return details for ``exercise_name``.
@@ -111,7 +114,7 @@ def get_exercise_details(
 
 def get_metrics_for_exercise(
     exercise_name: str,
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
     preset_name: str | None = None,
     is_user_created: bool | None = None,
 ) -> list:
@@ -227,7 +230,7 @@ def get_metrics_for_exercise(
 
 
 def get_all_metric_types(
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
     *,
     include_user_created: bool = False,
 ) -> list:
@@ -304,7 +307,7 @@ def get_all_metric_types(
 
 
 def get_metric_type_schema(
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
 ) -> list:
     """Return column definitions for the ``library_metric_types`` table.
 
@@ -356,7 +359,7 @@ def get_metric_type_schema(
 
 def is_metric_type_user_created(
     metric_type_name: str,
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
 ) -> bool:
     """Return ``True`` if ``metric_type_name`` is marked as user created."""
 
@@ -379,7 +382,7 @@ def add_metric_type(
     scope: str,
     description: str = "",
     is_required: bool = False,
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
 ) -> int:
     """Insert a new metric type and return its ID."""
 
@@ -411,7 +414,7 @@ def add_metric_type(
 def add_metric_to_exercise(
     exercise_name: str,
     metric_type_name: str,
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
 ) -> None:
     """Associate an existing metric type with an exercise."""
 
@@ -447,7 +450,7 @@ def add_metric_to_exercise(
 def remove_metric_from_exercise(
     exercise_name: str,
     metric_type_name: str,
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
 ) -> None:
     """Remove a metric association from an exercise."""
 
@@ -484,7 +487,7 @@ def update_metric_type(
     scope: str | None = None,
     description: str | None = None,
     is_required: bool | None = None,
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
 ) -> None:
     """Update fields of a metric type identified by ``metric_type_name``."""
 
@@ -531,7 +534,7 @@ def set_section_exercise_metric_override(
     input_timing: str,
     is_required: bool = False,
     scope: str = "set",
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
 ) -> None:
     """Apply an override for ``metric_type_name`` for a specific exercise in a preset."""
 
@@ -616,7 +619,7 @@ def set_exercise_metric_override(
     input_timing: str | None = None,
     is_required: bool | None = None,
     scope: str | None = None,
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
 ) -> None:
     """Apply an override for ``metric_type_name`` for a specific exercise.
 
@@ -730,7 +733,7 @@ class WorkoutSession:
     def __init__(
         self,
         preset_name: str,
-        db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+        db_path: Path = DEFAULT_DB_PATH,
         rest_duration: int = DEFAULT_REST_DURATION,
     ):
         """Load ``preset_name`` from ``db_path`` and prepare the session."""
@@ -866,7 +869,7 @@ class Exercise:
         self,
         name: str = "",
         *,
-        db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+        db_path: Path = DEFAULT_DB_PATH,
         is_user_created: bool | None = None,
     ) -> None:
         self.db_path = Path(db_path)
@@ -1036,7 +1039,7 @@ def save_exercise(exercise: Exercise) -> None:
 
 def delete_exercise(
     name: str,
-    db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+    db_path: Path = DEFAULT_DB_PATH,
     *,
     is_user_created: bool = True,
 ) -> bool:
@@ -1080,7 +1083,7 @@ class PresetEditor:
     def __init__(
         self,
         preset_name: str | None = None,
-        db_path: Path = Path(__file__).resolve().parent / "data" / "workout.db",
+        db_path: Path = DEFAULT_DB_PATH,
     ):
         """Create the editor and optionally load an existing preset."""
 

--- a/main.py
+++ b/main.py
@@ -43,10 +43,11 @@ from core import (
     PresetEditor,
     DEFAULT_SETS_PER_EXERCISE,
     DEFAULT_REST_DURATION,
+    DEFAULT_DB_PATH,
 )
 
 # Load workout presets from the database at startup
-load_workout_presets(Path(__file__).resolve().parent / "data" / "workout.db")
+load_workout_presets(DEFAULT_DB_PATH)
 import time
 import math
 
@@ -475,7 +476,7 @@ class ExerciseLibraryScreen(MDScreen):
             self.all_exercises is None
             or (app and self.cache_version != getattr(app, "exercise_library_version", 0))
         ):
-            db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+            db_path = DEFAULT_DB_PATH
             self.all_exercises = core.get_all_exercises(db_path, include_user_created=True)
             if app:
                 self.cache_version = app.exercise_library_version
@@ -484,7 +485,7 @@ class ExerciseLibraryScreen(MDScreen):
             self.all_metrics is None
             or (app and self.metric_cache_version != getattr(app, "metric_library_version", 0))
         ):
-            db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+            db_path = DEFAULT_DB_PATH
             self.all_metrics = core.get_all_metric_types(db_path, include_user_created=True)
             if app:
                 self.metric_cache_version = app.metric_library_version
@@ -519,7 +520,7 @@ class ExerciseLibraryScreen(MDScreen):
             self.all_exercises is None
             or (app and self.cache_version != getattr(app, "exercise_library_version", 0))
         ):
-            db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+            db_path = DEFAULT_DB_PATH
             self.all_exercises = core.get_all_exercises(db_path, include_user_created=True)
             if app:
                 self.cache_version = app.exercise_library_version
@@ -559,7 +560,7 @@ class ExerciseLibraryScreen(MDScreen):
             self.all_metrics is None
             or (app and self.metric_cache_version != getattr(app, "metric_library_version", 0))
         ):
-            db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+            db_path = DEFAULT_DB_PATH
             self.all_metrics = core.get_all_metric_types(db_path, include_user_created=True)
             if app:
                 self.metric_cache_version = app.metric_library_version
@@ -658,7 +659,7 @@ class ExerciseLibraryScreen(MDScreen):
         dialog = None
 
         def do_delete(*args):
-            db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+            db_path = DEFAULT_DB_PATH
             try:
                 core.delete_exercise(exercise_name, db_path=db_path, is_user_created=True)
                 app = MDApp.get_running_app()
@@ -1073,7 +1074,7 @@ class ExerciseSelectionPanel(MDBoxLayout):
             self.all_exercises is None
             or (app and self.cache_version != getattr(app, "exercise_library_version", 0))
         ):
-            db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+            db_path = DEFAULT_DB_PATH
             self.all_exercises = core.get_all_exercises(db_path, include_user_created=True)
             if app:
                 self.cache_version = app.exercise_library_version
@@ -1414,7 +1415,7 @@ class AddMetricPopup(MDDialog):
         if values:
             metric["values"] = values
 
-        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+        db_path = DEFAULT_DB_PATH
         try:
             core.add_metric_type(
                 metric["name"],
@@ -1614,7 +1615,7 @@ class EditMetricPopup(MDDialog):
             self.screen.populate()
             self.screen.save_enabled = self.screen.exercise_obj.is_modified()
 
-        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+        db_path = DEFAULT_DB_PATH
         if core.is_metric_type_user_created(self.metric["name"], db_path=db_path):
             dialog = None
 
@@ -1792,7 +1793,7 @@ class EditMetricTypePopup(MDDialog):
             else:
                 data[key] = widget.text
 
-        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+        db_path = DEFAULT_DB_PATH
         if self.metric and self.is_user_created:
             core.update_metric_type(
                 self.metric_name,
@@ -1869,7 +1870,7 @@ class EditExerciseScreen(MDScreen):
         return super().on_pre_enter(*args)
 
     def _load_exercise(self):
-        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+        db_path = DEFAULT_DB_PATH
         self.exercise_obj = core.Exercise(
             self.exercise_name,
             db_path=db_path,
@@ -2022,7 +2023,7 @@ class EditExerciseScreen(MDScreen):
             self.save_enabled = False
             return
 
-        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+        db_path = DEFAULT_DB_PATH
         conn = sqlite3.connect(str(db_path))
         cursor = conn.cursor()
         msg = "Save changes to this exercise?"
@@ -2148,7 +2149,7 @@ class WorkoutApp(MDApp):
 
     def init_preset_editor(self):
         """Create or reload the ``PresetEditor`` for the selected preset."""
-        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+        db_path = DEFAULT_DB_PATH
         if self.selected_preset:
             if not self.preset_editor or self.preset_editor.preset_name != self.selected_preset:
                 if self.preset_editor:


### PR DESCRIPTION
## Summary
- define DEFAULT_DB_PATH in `core.py`
- replace hard-coded DB paths with DEFAULT_DB_PATH
- update imports to include DEFAULT_DB_PATH

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880df63c6a88332921342f981189c4e