### PR TITLE
Fix PresetEditor metric overrides

### DIFF
--- a/core.py
+++ b/core.py
@@ -1298,15 +1298,38 @@ class PresetEditor:
 
                 if lib_id is not None:
                     cursor.execute(
-                        "SELECT metric_type_id, position FROM library_exercise_metrics WHERE exercise_id = ? ORDER BY position",
+                        "SELECT id, metric_type_id, position FROM library_exercise_metrics WHERE exercise_id = ? ORDER BY position",
                         (lib_id,),
                     )
-                    for mt_id, mpos in cursor.fetchall():
+                    for em_id, mt_id, mpos in cursor.fetchall():
                         cursor.execute(
                             "SELECT name, input_type, source_type, input_timing, is_required, scope FROM library_metric_types WHERE id = ?",
                             (mt_id,),
                         )
                         (mt_name, m_input, m_source, m_timing, m_req, m_scope) = cursor.fetchone()
+                        cursor.execute(
+                            "SELECT input_type, source_type, input_timing, is_required, scope FROM library_exercise_metric_overrides WHERE exercise_metric_id = ?",
+                            (em_id,),
+                        )
+                        override = cursor.fetchone()
+                        if override:
+                            (
+                                o_input,
+                                o_source,
+                                o_timing,
+                                o_req,
+                                o_scope,
+                            ) = override
+                            if o_input is not None:
+                                m_input = o_input
+                            if o_source is not None:
+                                m_source = o_source
+                            if o_timing is not None:
+                                m_timing = o_timing
+                            if o_req is not None:
+                                m_req = o_req
+                            if o_scope is not None:
+                                m_scope = o_scope
                         cursor.execute(
                             """INSERT INTO preset_section_exercise_metrics
                                 (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, position, library_metric_type_id)

--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -171,3 +171,55 @@ def test_save_duplicate_name(db_with_preset):
     editor.close()
 
 
+def test_save_preserves_metric_overrides(db_copy):
+    conn = sqlite3.connect(db_copy)
+    cur = conn.cursor()
+
+    # create a metric type and associate with the exercise
+    cur.execute(
+        """
+        INSERT INTO library_metric_types
+            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
+        VALUES ('Reps', 'int', 'manual_text', 'post_set', 0, 'set', '', 0)
+        """
+    )
+    mt_id = cur.lastrowid
+    ex_id = cur.execute(
+        "SELECT id FROM library_exercises WHERE name='Push ups'"
+    ).fetchone()[0]
+    cur.execute(
+        "INSERT INTO library_exercise_metrics (exercise_id, metric_type_id, position) VALUES (?, ?, 0)",
+        (ex_id, mt_id),
+    )
+    em_id = cur.lastrowid
+
+    # apply override for this metric
+    cur.execute(
+        """
+        INSERT INTO library_exercise_metric_overrides
+            (exercise_metric_id, input_type, source_type, input_timing, is_required, scope)
+        VALUES (?, 'int', 'manual_text', 'pre_workout', 1, 'set')
+        """,
+        (em_id,),
+    )
+    conn.commit()
+    conn.close()
+
+    editor = PresetEditor(db_path=db_copy)
+    editor.preset_name = "Override Preset"
+    editor.add_section("Warmup")
+    editor.add_exercise(0, "Push ups")
+    editor.save()
+
+    conn = sqlite3.connect(db_copy)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT metric_name, input_timing, is_required, scope FROM preset_section_exercise_metrics"
+    )
+    result = cur.fetchone()
+    conn.close()
+    editor.close()
+
+    assert result == ("Reps", "pre_workout", 1, "set")
+
+


### PR DESCRIPTION
## Summary
- handle per-exercise metric overrides when saving new presets
- test PresetEditor preserves metric overrides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880df3d2f4c83329ad1b4ffd55a5db8