### PR TITLE
Fix preset item highlighting

### DIFF
--- a/main.py
+++ b/main.py
@@ -397,6 +397,7 @@ class PresetsScreen(MDScreen):
     _default_btn_color = ListProperty(None, allownone=True)
 
     def on_kv_post(self, base_widget):
+        # Store the default color of the "Select" button so it can be restored
         self._default_btn_color = self.ids.select_btn.md_bg_color
         return super().on_kv_post(base_widget)
 
@@ -431,15 +432,12 @@ class PresetsScreen(MDScreen):
             self.selected_item = None
             self.selected_preset = ""
             MDApp.get_running_app().selected_preset = ""
-            if self._default_btn_color is not None:
-                self.ids.select_btn.md_bg_color = self._default_btn_color
             return
 
         if self.selected_item:
             self.selected_item.md_bg_color = (0, 0, 0, 0)
         self.selected_item = item
         self.selected_item.md_bg_color = self._selected_color
-        self.ids.select_btn.md_bg_color = self._selected_color
         if any(p["name"] == name for p in core.WORKOUT_PRESETS):
             self.selected_preset = name
             MDApp.get_running_app().selected_preset = name

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -141,8 +141,8 @@ def test_preset_select_button_updates(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
-def test_preset_select_button_color(monkeypatch):
-    """Selecting a preset updates the select button color."""
+def test_preset_list_item_color(monkeypatch):
+    """Selecting a preset highlights the chosen list item."""
     from kivy.lang import Builder
     from pathlib import Path
     Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
@@ -157,4 +157,4 @@ def test_preset_select_button_color(monkeypatch):
     dummy = type("Obj", (), {"md_bg_color": (0, 0, 0, 0)})()
     screen.select_preset("Sample", dummy)
 
-    assert screen.ids.select_btn.md_bg_color == screen._selected_color
+    assert dummy.md_bg_color == screen._selected_color


### PR DESCRIPTION
## Summary
- highlight selected preset in the list instead of the Select button
- update UI tests for new preset selection behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dfede7608332a4a57908b1fee985