### PR TITLE
Refactor metric overrides to new schema

### DIFF
--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -196,9 +196,13 @@ def test_save_preserves_metric_overrides(db_copy):
     # apply override for this metric
     cur.execute(
         """
-        INSERT INTO library_exercise_metric_overrides
-            (exercise_metric_id, input_type, source_type, input_timing, is_required, scope)
-        VALUES (?, 'int', 'manual_text', 'pre_workout', 1, 'set')
+        UPDATE library_exercise_metrics
+           SET input_type = 'int',
+               source_type = 'manual_text',
+               input_timing = 'pre_workout',
+               is_required = 1,
+               scope = 'set'
+         WHERE id = ?
         """,
         (em_id,),
     )

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -181,6 +181,7 @@ def test_save_exercise_duplicate_name(monkeypatch, tmp_path):
     assert opened["value"]
     assert screen.name_field.error
 
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_edit_metric_duplicate_name(monkeypatch):
     class DummyExercise:
         def __init__(self):
@@ -203,6 +204,7 @@ def test_edit_metric_duplicate_name(monkeypatch):
     assert not DummyScreen.exercise_obj.updated
     assert popup.input_widgets["name"].error
 
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_preset_select_button_color(monkeypatch):
     """Selecting a preset updates the select button color."""
     from kivy.lang import Builder


### PR DESCRIPTION
## Summary
- update code to use override columns in `library_exercise_metrics`
- modify preset saving and exercise functions for new schema
- adjust metric override tests for new behavior
- skip UI tests when Kivy/KivyMD unavailable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f639f7788332a472761d645751d3