### PR TITLE
Fix metric edit popup info

### DIFF
--- a/main.py
+++ b/main.py
@@ -1806,7 +1806,15 @@ class EditMetricTypePopup(MDDialog):
         layout = ScrollView(do_scroll_y=True, size_hint_y=None, height=dp(400))
         info_box = None
         if self.metric and not self.is_user_created:
-            info_box = MDLabel(text="Built-in metric. Saving will create a copy.", halign="center")
+            info_box = MDLabel(
+                text="Built-in metric. Saving will create a copy.",
+                halign="center",
+            )
+        elif self.metric and self.is_user_created:
+            info_box = MDLabel(
+                text="Saving will update all exercises using this metric.",
+                halign="center",
+            )
         layout.add_widget(form)
         buttons = [
             MDRaisedButton(text="Save", on_release=self.save_metric),


### PR DESCRIPTION
## Summary
- improve edit metric popup logic for built‑in vs user metrics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kivy')*

------
https://chatgpt.com/codex/tasks/task_e_6880e56594a08332907eb84ad0625c1d