### PR TITLE
Fix selecting correct metric copy

### DIFF
--- a/core.py
+++ b/core.py
@@ -485,17 +485,28 @@ def update_metric_type(
     scope: str | None = None,
     description: str | None = None,
     is_required: bool | None = None,
+    is_user_created: bool | None = None,
     db_path: Path = DEFAULT_DB_PATH,
 ) -> None:
     """Update fields of a metric type identified by ``metric_type_name``."""
 
     conn = sqlite3.connect(str(db_path))
     cursor = conn.cursor()
-    cursor.execute("SELECT id FROM library_metric_types WHERE name = ?", (metric_type_name,))
+    if is_user_created is None:
+        cursor.execute(
+            "SELECT id FROM library_metric_types WHERE name = ? ORDER BY is_user_created DESC LIMIT 1",
+            (metric_type_name,),
+        )
+    else:
+        cursor.execute(
+            "SELECT id FROM library_metric_types WHERE name = ? AND is_user_created = ?",
+            (metric_type_name, int(is_user_created)),
+        )
     row = cursor.fetchone()
     if not row:
         conn.close()
         raise ValueError(f"Metric type '{metric_type_name}' not found")
+    metric_id = row[0]
     updates = []
     params: list = []
     if input_type is not None:
@@ -517,8 +528,11 @@ def update_metric_type(
         updates.append("description = ?")
         params.append(description)
     if updates:
-        params.append(metric_type_name)
-        cursor.execute(f"UPDATE library_metric_types SET {', '.join(updates)} WHERE name = ?", params)
+        params.append(metric_id)
+        cursor.execute(
+            f"UPDATE library_metric_types SET {', '.join(updates)} WHERE id = ?",
+            params,
+        )
         conn.commit()
     conn.close()
 

--- a/main.py
+++ b/main.py
@@ -1684,6 +1684,7 @@ class EditMetricPopup(MDDialog):
                         scope=updates.get("scope"),
                         description=updates.get("description"),
                         is_required=updates.get("is_required"),
+                        is_user_created=self.metric.get("is_user_created"),
                         db_path=db_path,
                     )
                     if metric_saved:
@@ -1741,7 +1742,10 @@ class EditMetricTypePopup(MDDialog):
         self.metric = None
         if metric_name:
             for m in screen.all_metrics or []:
-                if m["name"] == metric_name:
+                if (
+                    m["name"] == metric_name
+                    and m.get("is_user_created", False) == is_user_created
+                ):
                     self.metric = m
                     break
         content, buttons, title = self._build_widgets()
@@ -1850,6 +1854,7 @@ class EditMetricTypePopup(MDDialog):
                 scope=data.get("scope"),
                 description=data.get("description"),
                 is_required=data.get("is_required"),
+                is_user_created=True,
                 db_path=db_path,
             )
         else:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -204,6 +204,18 @@ def test_edit_metric_duplicate_name(monkeypatch):
     assert not DummyScreen.exercise_obj.updated
     assert popup.input_widgets["name"].error
 
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_edit_metric_type_popup_selects_correct_metric():
+    class DummyScreen:
+        all_metrics = [
+            {"name": "Reps", "is_user_created": False, "description": "orig"},
+            {"name": "Reps", "is_user_created": True, "description": "copy"},
+        ]
+
+    popup = EditMetricTypePopup(DummyScreen(), "Reps", True)
+    assert popup.metric["description"] == "copy"
+
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_preset_select_button_color(monkeypatch):
     """Selecting a preset updates the select button color."""


### PR DESCRIPTION
## Summary
- ensure `EditMetricTypePopup` matches metric on `is_user_created`
- update `core.update_metric_type` to optionally target user-created variant
- send `is_user_created` flag when updating metrics
- add regression test for `EditMetricTypePopup`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881031b0f248332a12d35a61fbad5b8