### PR TITLE
Fix library screen buttons layout

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -208,86 +208,90 @@ ScreenManager:
                 on_kv_post: self.current = root.current_tab
                 Screen:
                     name: "exercises"
-                    BoxLayout:
-                        orientation: "vertical"
-                        MDTextField:
-                            id: search_field
-                            hint_text: "Search exercises"
-                            text: root.search_text
-                            on_text: root.update_search(self.text)
-                            size_hint_y: None
-                            height: "40dp"
-                        MDBoxLayout:
-                            orientation: "horizontal"
-                            size_hint_y: None
-                            height: self.minimum_height
-                            MDLabel:
-                                text: "Exercise Library - browse all exercises"
-                                halign: "center"
-                                theme_text_color: "Custom"
-                                text_color: 0.2, 0.6, 0.86, 1
-                                size_hint_x: 0.9
-                            MDIconButton:
-                                icon: "filter-variant"
-                                on_release: root.open_filter_popup()
-                        MDRecycleView:
-                            id: exercise_list
-                            viewclass: "ExerciseRow"
-                            RecycleBoxLayout:
-                                default_size: None, dp(56)
-                                default_size_hint: 1, None
+                    FloatLayout:
+                        BoxLayout:
+                            orientation: "vertical"
+                            MDTextField:
+                                id: search_field
+                                hint_text: "Search exercises"
+                                text: root.search_text
+                                on_text: root.update_search(self.text)
+                                size_hint_y: None
+                                height: "40dp"
+                            MDBoxLayout:
+                                orientation: "horizontal"
                                 size_hint_y: None
                                 height: self.minimum_height
-                                orientation: "vertical"
+                                MDLabel:
+                                    text: "Exercise Library - browse all exercises"
+                                    halign: "center"
+                                    theme_text_color: "Custom"
+                                    text_color: 0.2, 0.6, 0.86, 1
+                                    size_hint_x: 0.9
+                                MDIconButton:
+                                    icon: "filter-variant"
+                                    on_release: root.open_filter_popup()
+                            MDRecycleView:
+                                id: exercise_list
+                                viewclass: "ExerciseRow"
+                                RecycleBoxLayout:
+                                    default_size: None, dp(56)
+                                    default_size_hint: 1, None
+                                    size_hint_y: None
+                                    height: self.minimum_height
+                                    orientation: "vertical"
                         MDRaisedButton:
                             text: "Back"
+                            pos_hint: {"x": 0.02, "y": 0.02}
                             on_release: root.go_back()
-                    MDFloatingActionButton:
-                        icon: "plus"
-                        md_bg_color: app.theme_cls.primary_color
-                        pos_hint: {"right": 0.98, "y": 0.02}
-                        on_release: root.new_exercise()
+                        MDFloatingActionButton:
+                            icon: "plus"
+                            md_bg_color: app.theme_cls.primary_color
+                            pos_hint: {"right": 0.98, "y": 0.02}
+                            on_release: root.new_exercise()
                 Screen:
                     name: "metrics"
-                    BoxLayout:
-                        orientation: "vertical"
-                        MDTextField:
-                            id: metric_search_field
-                            hint_text: "Search metrics"
-                            text: root.metric_search_text
-                            on_text: root.update_search(self.text)
-                            size_hint_y: None
-                            height: "40dp"
-                        MDBoxLayout:
-                            orientation: "horizontal"
-                            size_hint_y: None
-                            height: self.minimum_height
-                            MDLabel:
-                                text: "Metric Library - browse all metrics"
-                                halign: "center"
-                                theme_text_color: "Custom"
-                                text_color: 0.2, 0.6, 0.86, 1
-                                size_hint_x: 0.9
-                            MDIconButton:
-                                icon: "filter-variant"
-                                on_release: root.open_filter_popup()
-                        MDRecycleView:
-                            id: metric_list
-                            viewclass: "MetricRow"
-                            RecycleBoxLayout:
-                                default_size: None, dp(56)
-                                default_size_hint: 1, None
+                    FloatLayout:
+                        BoxLayout:
+                            orientation: "vertical"
+                            MDTextField:
+                                id: metric_search_field
+                                hint_text: "Search metrics"
+                                text: root.metric_search_text
+                                on_text: root.update_search(self.text)
+                                size_hint_y: None
+                                height: "40dp"
+                            MDBoxLayout:
+                                orientation: "horizontal"
                                 size_hint_y: None
                                 height: self.minimum_height
-                                orientation: "vertical"
+                                MDLabel:
+                                    text: "Metric Library - browse all metrics"
+                                    halign: "center"
+                                    theme_text_color: "Custom"
+                                    text_color: 0.2, 0.6, 0.86, 1
+                                    size_hint_x: 0.9
+                                MDIconButton:
+                                    icon: "filter-variant"
+                                    on_release: root.open_filter_popup()
+                            MDRecycleView:
+                                id: metric_list
+                                viewclass: "MetricRow"
+                                RecycleBoxLayout:
+                                    default_size: None, dp(56)
+                                    default_size_hint: 1, None
+                                    size_hint_y: None
+                                    height: self.minimum_height
+                                    orientation: "vertical"
                         MDRaisedButton:
                             text: "Back"
+                            pos_hint: {"x": 0.02, "y": 0.02}
                             on_release: root.go_back()
-                    MDFloatingActionButton:
-                        icon: "plus"
-                        md_bg_color: app.theme_cls.primary_color
-                        pos_hint: {"right": 0.98, "y": 0.02}
-                        on_release: root.new_metric()
+                        MDFloatingActionButton:
+                            icon: "plus"
+                            md_bg_color: app.theme_cls.primary_color
+                            pos_hint: {"right": 0.98, "y": 0.02}
+                            on_release: root.new_metric()
 
 <ProgressScreen@MDScreen>:
     BoxLayout:


### PR DESCRIPTION
## Summary
- keep add and back buttons outside of scroll views on library tabs
- adjust layout for both exercise and metric library screens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688103d525448332af080c454d0c63da