### PR TITLE
Add delete option for metric types

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -157,6 +157,7 @@ ScreenManager:
     text: ""
     is_user_created: False
     edit_callback: None
+    delete_callback: None
     orientation: "horizontal"
     size_hint_y: None
     height: "56dp"
@@ -179,6 +180,15 @@ ScreenManager:
             font_size: "20sp"
             pos_hint: {"center_y": 0.5}
             on_touch_down: if self.collide_point(*args[1].pos) and root.edit_callback: root.edit_callback(root.name, root.is_user_created)
+        MDIcon:
+            icon: "delete"
+            font_size: "20sp"
+            theme_text_color: "Custom"
+            text_color: 1, 0, 0, 1
+            pos_hint: {"center_y": 0.5}
+            opacity: 1 if root.is_user_created else 0
+            disabled: not root.is_user_created
+            on_touch_down: if self.collide_point(*args[1].pos) and root.delete_callback: root.delete_callback(root.name)
 
 <ExerciseLibraryScreen>:
     exercise_list: exercise_list

--- a/main.py
+++ b/main.py
@@ -588,6 +588,7 @@ class ExerciseLibraryScreen(MDScreen):
                 "text": m["name"],
                 "is_user_created": m["is_user_created"],
                 "edit_callback": self.open_edit_metric_popup,
+                "delete_callback": self.confirm_delete_metric,
             })
         self.metric_list.data = data
         if self.loading_dialog:
@@ -683,6 +684,33 @@ class ExerciseLibraryScreen(MDScreen):
         dialog = MDDialog(
             title="Delete Exercise?",
             text=f"Delete {exercise_name}?",
+            buttons=[
+                MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
+                MDRaisedButton(text="Delete", on_release=do_delete),
+            ],
+        )
+        dialog.open()
+
+    def confirm_delete_metric(self, metric_name):
+        dialog = None
+
+        def do_delete(*args):
+            db_path = DEFAULT_DB_PATH
+            try:
+                core.delete_metric_type(metric_name, db_path=db_path, is_user_created=True)
+                app = MDApp.get_running_app()
+                if app:
+                    app.metric_library_version += 1
+            except Exception:
+                pass
+            self.all_metrics = None
+            self.populate()
+            if dialog:
+                dialog.dismiss()
+
+        dialog = MDDialog(
+            title="Delete Metric?",
+            text=f"Delete {metric_name}?",
             buttons=[
                 MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
                 MDRaisedButton(text="Delete", on_release=do_delete),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -210,3 +210,19 @@ def test_override_with_user_flag(sample_db):
     default_metric = next(m for m in metrics_default if m["name"] == "Weight")
     assert default_metric["input_timing"] == "post_set"
 
+
+def test_delete_metric_type(sample_db):
+    metric_id = core.add_metric_type(
+        name="Tempo",
+        input_type="int",
+        source_type="manual_text",
+        input_timing="post_set",
+        scope="set",
+        db_path=sample_db,
+    )
+    assert isinstance(metric_id, int)
+    assert core.delete_metric_type("Tempo", db_path=sample_db, is_user_created=True)
+    metrics = core.get_all_metric_types(sample_db, include_user_created=True)
+    assert all(m["name"] != "Tempo" for m in metrics)
+    assert core.delete_metric_type("Tempo", db_path=sample_db, is_user_created=True) is False
+


### PR DESCRIPTION
## Summary
- enable deletion of metric types via new `delete_metric_type` helper
- show delete icon for user-created metric types in library
- wire library screen to call deletion popup
- test deleting metric types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881046a27d88332b1acaa51e8f8c2ec