### PR TITLE
Ensure library reflects new metrics

### DIFF
--- a/main.py
+++ b/main.py
@@ -1467,6 +1467,10 @@ class AddMetricPopup(MDDialog):
             self.input_widgets["name"].error = True
             return
 
+        app = MDApp.get_running_app()
+        if app:
+            app.metric_library_version += 1
+
         self.screen.exercise_obj.add_metric(metric)
         self.screen.populate()
         self.screen.save_enabled = self.screen.exercise_obj.is_modified()


### PR DESCRIPTION
## Summary
- increment `metric_library_version` when creating a new metric from the EditExercise screen
- keep metric library cache up to date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810c74e95483329780942e4ddab4b7