### PR TITLE
Fix enum input spaces after comma

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,6 +33,7 @@ from kivy.uix.screenmanager import NoTransition
 from pathlib import Path
 import os
 import sys
+import re
 
 # Import core so we can always reference the up-to-date WORKOUT_PRESETS list
 import core
@@ -1345,7 +1346,8 @@ class AddMetricPopup(MDDialog):
                 allowed = string.ascii_letters + " ,"
 
             def _filter(value, from_undo):
-                return "".join(ch for ch in value if ch in allowed)
+                filtered = "".join(ch for ch in value if ch in allowed)
+                return re.sub(r",\s+", ",", filtered)
 
             self.enum_values_field.input_filter = _filter
         if "source_type" in self.input_widgets and "input_type" in self.input_widgets:
@@ -1613,7 +1615,8 @@ class EditMetricPopup(MDDialog):
                 allowed = string.ascii_letters + " ,"
 
             def _filter(value, from_undo):
-                return "".join(ch for ch in value if ch in allowed)
+                filtered = "".join(ch for ch in value if ch in allowed)
+                return re.sub(r",\s+", ",", filtered)
 
             self.enum_values_field.input_filter = _filter
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -86,6 +86,17 @@ def test_enum_values_accepts_spaces():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_enum_values_strip_spaces_after_comma():
+    class DummyScreen:
+        exercise_obj = type("obj", (), {"metrics": []})()
+
+    popup = AddMetricPopup(DummyScreen(), mode="new")
+    popup.input_widgets["input_type"].text = "str"
+    filtered = popup.enum_values_field.input_filter("A, B ,  C", False)
+    assert filtered == "A,B,C"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_edit_exercise_default_tab():
     screen = EditExerciseScreen()
     screen.previous_screen = "exercise_library"


### PR DESCRIPTION
## Summary
- allow spaces inside enum values but strip spaces following commas
- test that spaces are removed after commas in enum fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810f656b088332bc6e18510368e7db