### PR TITLE
Enable save button after section changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -856,6 +856,7 @@ class SectionWidget(MDBoxLayout):
             if app.root:
                 edit = app.root.get_screen("edit_preset")
                 edit.refresh_sections()
+                edit.save_enabled = True
             if dialog:
                 dialog.dismiss()
 
@@ -947,6 +948,7 @@ class EditPresetScreen(MDScreen):
         section = SectionWidget(section_name=name, color=color, section_index=index)
         self.sections_box.add_widget(section)
         section.refresh_exercises()
+        self.save_enabled = True
         return section
 
     def switch_tab(self, tab: str):


### PR DESCRIPTION
## Summary
- keep save button active when sections are added or deleted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d16d691c8332b071e55caa8dc468