### PR TITLE
Fix preset editing save detection

### DIFF
--- a/core.py
+++ b/core.py
@@ -2,6 +2,7 @@ import sqlite3
 from pathlib import Path
 import time
 import re
+import copy
 
 # Number of sets each exercise defaults to when starting a workout
 DEFAULT_SETS_PER_EXERCISE = 3
@@ -1247,7 +1248,7 @@ class PresetEditor:
     def to_dict(self) -> dict:
         """Return the preset data as a dictionary."""
 
-        return {"name": self.preset_name, "sections": self.sections}
+        return copy.deepcopy({"name": self.preset_name, "sections": self.sections})
 
     def close(self) -> None:
         self.conn.close()

--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -238,4 +238,20 @@ def test_save_missing_exercise_fails(db_copy):
     editor.close()
 
 
+def test_is_modified_tracking(db_copy):
+    editor = PresetEditor(db_path=db_copy)
+    # New editor should not be marked as modified
+    assert editor.is_modified() is False
+
+    editor.preset_name = "My Preset"
+    assert editor.is_modified() is True
+
+    editor.mark_saved()
+    assert editor.is_modified() is False
+
+    editor.add_section("Warmup")
+    assert editor.is_modified() is True
+    editor.close()
+
+
 


### PR DESCRIPTION
## Summary
- ensure PresetEditor tracks changes correctly using deep copies
- add regression test for is_modified handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d7b40978833293d210b08463a784