### PR TITLE
Fix exercise deletion in preset editor

### DIFF
--- a/core.py
+++ b/core.py
@@ -1245,6 +1245,36 @@ class PresetEditor:
         if rest is not None:
             exercise["rest"] = rest
 
+    def remove_exercise(self, section_index: int, exercise_index: int) -> None:
+        """Remove an exercise from ``section_index`` at ``exercise_index``."""
+
+        if (
+            section_index < 0
+            or section_index >= len(self.sections)
+            or exercise_index < 0
+            or exercise_index >= len(self.sections[section_index]["exercises"])
+        ):
+            raise IndexError("Exercise index out of range")
+
+        self.sections[section_index]["exercises"].pop(exercise_index)
+
+    def move_exercise(self, section_index: int, old_index: int, new_index: int) -> None:
+        """Move an exercise within a section to ``new_index``."""
+
+        if (
+            section_index < 0
+            or section_index >= len(self.sections)
+            or old_index < 0
+            or old_index >= len(self.sections[section_index]["exercises"])
+            or new_index < 0
+            or new_index >= len(self.sections[section_index]["exercises"])
+        ):
+            raise IndexError("Exercise index out of range")
+
+        exercises = self.sections[section_index]["exercises"]
+        ex = exercises.pop(old_index)
+        exercises.insert(new_index, ex)
+
     def to_dict(self) -> dict:
         """Return the preset data as a dictionary."""
 

--- a/main.py
+++ b/main.py
@@ -1081,30 +1081,54 @@ class SelectedExerciseItem(MDBoxLayout):
         app.root.current = "edit_exercise"
 
     def move_up(self):
-        parent = self.parent
-        if not parent:
+        app = MDApp.get_running_app()
+        if not app or not app.preset_editor:
             return
-        idx = parent.children.index(self)
-        if idx < len(parent.children) - 1:
-            parent.remove_widget(self)
-            parent.add_widget(self, index=idx + 1)
+        if self.exercise_index <= 0:
+            return
+        app.preset_editor.move_exercise(
+            self.section_index, self.exercise_index, self.exercise_index - 1
+        )
+        edit = app.root.get_screen("edit_preset") if app.root else None
+        if edit:
+            for widget in edit.sections_box.children:
+                if isinstance(widget, SectionWidget) and widget.section_index == self.section_index:
+                    widget.refresh_exercises()
+                    break
+            edit.update_save_enabled()
 
     def move_down(self):
-        parent = self.parent
-        if not parent:
+        app = MDApp.get_running_app()
+        if not app or not app.preset_editor:
             return
-        idx = parent.children.index(self)
-        if idx > 0:
-            parent.remove_widget(self)
-            parent.add_widget(self, index=idx - 1)
+        sec = app.preset_editor.sections[self.section_index]
+        if self.exercise_index >= len(sec["exercises"]) - 1:
+            return
+        app.preset_editor.move_exercise(
+            self.section_index, self.exercise_index, self.exercise_index + 1
+        )
+        edit = app.root.get_screen("edit_preset") if app.root else None
+        if edit:
+            for widget in edit.sections_box.children:
+                if isinstance(widget, SectionWidget) and widget.section_index == self.section_index:
+                    widget.refresh_exercises()
+                    break
+            edit.update_save_enabled()
 
     def remove_self(self):
         dialog = None
 
         def do_delete(*args):
-            parent = self.parent
-            if parent:
-                parent.remove_widget(self)
+            app = MDApp.get_running_app()
+            if app and app.preset_editor:
+                app.preset_editor.remove_exercise(self.section_index, self.exercise_index)
+                edit = app.root.get_screen("edit_preset") if app.root else None
+                if edit:
+                    for widget in edit.sections_box.children:
+                        if isinstance(widget, SectionWidget) and widget.section_index == self.section_index:
+                            widget.refresh_exercises()
+                            break
+                    edit.update_save_enabled()
             if dialog:
                 dialog.dismiss()
 

--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -254,4 +254,19 @@ def test_is_modified_tracking(db_copy):
     editor.close()
 
 
+def test_remove_exercise_and_save(db_with_preset):
+    editor = PresetEditor("Test Preset", db_path=db_with_preset)
+    editor.remove_exercise(0, 0)
+    assert editor.sections[0]["exercises"] == []
+    assert editor.is_modified() is True
+    editor.save()
+    conn = sqlite3.connect(db_with_preset)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM preset_section_exercises")
+    count = cur.fetchone()[0]
+    conn.close()
+    editor.close()
+    assert count == 0
+
+
 


### PR DESCRIPTION
## Summary
- allow PresetEditor to remove and reorder exercises
- sync exercise list updates from UI to PresetEditor
- test removing exercises from a preset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d90655bc8332a7e1f8560006394b