### PR TITLE
Add section rename support in preset editor

### DIFF
--- a/core.py
+++ b/core.py
@@ -1200,6 +1200,13 @@ class PresetEditor:
         if 0 <= index < len(self.sections):
             self.sections.pop(index)
 
+    def rename_section(self, index: int, name: str) -> None:
+        """Rename the section at ``index`` to ``name``."""
+
+        if index < 0 or index >= len(self.sections):
+            raise IndexError("Section index out of range")
+        self.sections[index]["name"] = name
+
     def add_exercise(
         self,
         section_index: int,

--- a/main.py
+++ b/main.py
@@ -822,6 +822,18 @@ class SectionWidget(MDBoxLayout):
     expanded = BooleanProperty(True)
     visible = BooleanProperty(True)
 
+    def on_section_name(self, instance, value):
+        """Update the section name in the preset editor."""
+        app = MDApp.get_running_app()
+        if app and app.preset_editor:
+            try:
+                app.preset_editor.rename_section(self.section_index, value)
+            except IndexError:
+                return
+            edit = app.root.get_screen("edit_preset") if app.root else None
+            if edit:
+                edit.update_save_enabled()
+
     def toggle(self):
         self.expanded = not self.expanded
 


### PR DESCRIPTION
## Summary
- allow the preset editor to rename a section
- update section name in presets when the user edits it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881dfb181e88332880da8d22dbe51c3