### PR TITLE
Limit add metric dialog to set/exercise scopes

### DIFF
--- a/main.py
+++ b/main.py
@@ -1284,7 +1284,12 @@ class AddMetricPopup(MDDialog):
     def _build_select_widgets(self):
         metrics = core.get_all_metric_types()
         existing = {m.get("name") for m in self.screen.exercise_obj.metrics}
-        metrics = [m for m in metrics if m["name"] not in existing]
+        metrics = [
+            m
+            for m in metrics
+            if m["name"] not in existing
+            and m.get("scope") in ("set", "exercise")
+        ]
         list_view = MDList()
         for m in metrics:
             item = OneLineListItem(text=m["name"])

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -97,6 +97,29 @@ def test_enum_values_strip_spaces_after_comma():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_add_metric_popup_filters_scope(monkeypatch):
+    class DummyScreen:
+        exercise_obj = type("obj", (), {"metrics": []})()
+
+    metrics = [
+        {"name": "Session", "scope": "session"},
+        {"name": "Section", "scope": "section"},
+        {"name": "Exercise", "scope": "exercise"},
+        {"name": "Set", "scope": "set"},
+    ]
+
+    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: metrics)
+
+    popup = AddMetricPopup(DummyScreen(), mode="select")
+    list_view = popup.content_cls.children[0]
+    names = {child.text for child in list_view.children}
+
+    assert "Session" not in names
+    assert "Section" not in names
+    assert {"Exercise", "Set"}.issubset(names)
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_edit_exercise_default_tab():
     screen = EditExerciseScreen()
     screen.previous_screen = "exercise_library"


### PR DESCRIPTION
## Summary
- filter metrics by scope in `AddMetricPopup`
- test that only set/exercise scoped metrics appear in add metric popup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e0da4e2083329abfadb8f998cb83