### PR TITLE
Improve preset selection UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -396,6 +396,7 @@ class PresetsScreen(MDScreen):
     selected_item = ObjectProperty(None, allownone=True)
 
     _selected_color = (0, 1, 0, 1)
+    _selected_text_color = (0, 1, 0, 1)
     _default_btn_color = ListProperty(None, allownone=True)
 
     def on_kv_post(self, base_widget):
@@ -407,6 +408,7 @@ class PresetsScreen(MDScreen):
         """Reset any selected preset and remove highlight."""
         if self.selected_item:
             self.selected_item.md_bg_color = (0, 0, 0, 0)
+            self.selected_item.theme_text_color = "Primary"
         self.selected_item = None
         self.selected_preset = ""
         app = MDApp.get_running_app()
@@ -419,6 +421,10 @@ class PresetsScreen(MDScreen):
         self.clear_selection()
         self.populate()
         return super().on_pre_enter(*args)
+
+    def on_leave(self, *args):
+        self.clear_selection()
+        return super().on_leave(*args)
 
     def populate(self):
         if not self.preset_list:
@@ -434,6 +440,7 @@ class PresetsScreen(MDScreen):
         if self.selected_item is item:
             # Toggle off selection if tapping the already selected item
             item.md_bg_color = (0, 0, 0, 0)
+            item.theme_text_color = "Primary"
             self.selected_item = None
             self.selected_preset = ""
             MDApp.get_running_app().selected_preset = ""
@@ -441,8 +448,11 @@ class PresetsScreen(MDScreen):
 
         if self.selected_item:
             self.selected_item.md_bg_color = (0, 0, 0, 0)
+            self.selected_item.theme_text_color = "Primary"
         self.selected_item = item
         self.selected_item.md_bg_color = self._selected_color
+        self.selected_item.theme_text_color = "Custom"
+        self.selected_item.text_color = self._selected_text_color
         if any(p["name"] == name for p in core.WORKOUT_PRESETS):
             self.selected_preset = name
             MDApp.get_running_app().selected_preset = name

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -264,8 +264,42 @@ def test_preset_select_button_color(monkeypatch):
     )
 
     screen = PresetsScreen()
-    dummy = type("Obj", (), {"md_bg_color": (0, 0, 0, 0)})()
+    dummy = type(
+        "Obj",
+        (),
+        {"md_bg_color": (0, 0, 0, 0), "theme_text_color": "Primary", "text_color": (0, 0, 0, 1)},
+    )()
     screen.select_preset("Sample", dummy)
 
     assert dummy.md_bg_color == screen._selected_color
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_preset_selected_text_color_and_clear(monkeypatch):
+    """Selecting a preset changes text color and is cleared on leave."""
+    from kivy.lang import Builder
+    from pathlib import Path
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    monkeypatch.setattr(
+        core,
+        "WORKOUT_PRESETS",
+        [{"name": "Sample", "exercises": []}],
+    )
+
+    screen = PresetsScreen()
+    dummy = type(
+        "Obj",
+        (),
+        {"md_bg_color": (0, 0, 0, 0), "theme_text_color": "Primary", "text_color": (0, 0, 0, 1)},
+    )()
+    screen.select_preset("Sample", dummy)
+
+    assert dummy.theme_text_color == "Custom"
+    assert dummy.text_color == screen._selected_text_color
+
+    screen.on_leave()
+
+    assert dummy.theme_text_color == "Primary"
+    assert screen.selected_item is None
 


### PR DESCRIPTION
## Summary
- highlight selected preset text in green
- clear selection when leaving the Presets screen
- test text color changes and clearing behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688594dc662c8332a1bf7abcb84c610d