### PR TITLE
Fix enum value field visibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -1445,7 +1445,6 @@ class AddMetricPopup(MDDialog):
         )
         self.enum_values_field.hint_text_font_size = "12sp"
         enable_auto_resize(self.enum_values_field)
-        form.add_widget(self.enum_values_field)
 
         # Helper that toggles visibility based on ``source_type``.
 
@@ -1706,7 +1705,6 @@ class EditMetricPopup(MDDialog):
         )
         self.enum_values_field.hint_text_font_size = "12sp"
         enable_auto_resize(self.enum_values_field)
-        form.add_widget(self.enum_values_field)
 
         # populate values
         for key, widget in self.input_widgets.items():
@@ -1723,6 +1721,8 @@ class EditMetricPopup(MDDialog):
 
         # populate enum values
         if self.metric.get("source_type") == "manual_enum":
+            if self.enum_values_field.parent is None:
+                form.add_widget(self.enum_values_field)
             values = ",".join(self.metric.get("values", []))
             self.enum_values_field.text = values
         else:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -106,6 +106,12 @@ def test_add_metric_popup_has_single_enum_field():
     enum_fields = [
         c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
     ]
+    assert len(enum_fields) == 0
+    popup.input_widgets["source_type"].text = "manual_enum"
+    children = popup.content_cls.children[0].children
+    enum_fields = [
+        c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
+    ]
     assert len(enum_fields) == 1
 
 
@@ -130,6 +136,18 @@ def test_edit_metric_popup_has_single_enum_field():
 
     metric = DummyScreen.exercise_obj.metrics[0]
     popup = EditMetricPopup(DummyScreen(), metric)
+    children = popup.content_cls.children[0].children
+    enum_fields = [
+        c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
+    ]
+    assert len(enum_fields) == 1
+    popup.input_widgets["source_type"].text = "manual_text"
+    children = popup.content_cls.children[0].children
+    enum_fields = [
+        c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
+    ]
+    assert len(enum_fields) == 0
+    popup.input_widgets["source_type"].text = "manual_enum"
     children = popup.content_cls.children[0].children
     enum_fields = [
         c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"


### PR DESCRIPTION
## Summary
- show enum value entry only when `source_type` is `manual_enum`
- update UI tests for enum visibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859acdfdd88332881333c1ef50dc44