### PR TITLE
Add navigation arrows for exercise editing

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -798,12 +798,25 @@ ScreenManager:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
-        MDLabel:
-            text: root.exercise_name if root.exercise_name else "Edit Exercise"
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
-            size_hint_y:0.1
+        MDBoxLayout:
+            size_hint_y: 0.1
+            orientation: "horizontal"
+            spacing: "10dp"
+            MDIconButton:
+                icon: "chevron-left"
+                opacity: 1 if root.section_index >= 0 else 0
+                disabled: not root.can_go_prev()
+                on_release: root.go_prev_exercise()
+            MDLabel:
+                text: root.exercise_name if root.exercise_name else "Edit Exercise"
+                halign: "center"
+                theme_text_color: "Custom"
+                text_color: 0.2, 0.6, 0.86, 1
+            MDIconButton:
+                icon: "chevron-right"
+                opacity: 1 if root.section_index >= 0 else 0
+                disabled: not root.can_go_next()
+                on_release: root.go_next_exercise()
         MDBoxLayout:
             size_hint_y: None
             height: "40dp"

--- a/main.py
+++ b/main.py
@@ -24,6 +24,7 @@ from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.button import MDIconButton
 from kivymd.uix.card import MDSeparator
 from kivymd.uix.dialog import MDDialog
+
 try:
     from kivymd.uix.spinner import MDSpinner
 except Exception:  # pragma: no cover - fallback for tests without kivymd
@@ -56,7 +57,7 @@ from kivy.core.window import Window
 import string
 import sqlite3
 
-if os.name == 'nt' or sys.platform.startswith('win'):
+if os.name == "nt" or sys.platform.startswith("win"):
     Window.size = (280, 280 * (20 / 9))
 
 # Order of fields for metric editing popups
@@ -69,7 +70,6 @@ METRIC_FIELD_ORDER = [
     "scope",
     "is_required",
 ]
-
 
 
 class LoadingDialog(MDDialog):
@@ -123,8 +123,6 @@ class WorkoutActiveScreen(MDScreen):
         self.elapsed = time.time() - self.start_time
         minutes, seconds = divmod(int(self.elapsed), 60)
         self.formatted_time = f"{minutes:02d}:{seconds:02d}"
-
-
 
 
 class RestScreen(MDScreen):
@@ -288,11 +286,15 @@ class MetricInputScreen(MDScreen):
             all_metrics = get_metrics_for_exercise(
                 curr_ex, preset_name=app.workout_session.preset_name
             )
-            prev_metrics = [m for m in all_metrics if m.get("input_timing") == "post_set"]
+            prev_metrics = [
+                m for m in all_metrics if m.get("input_timing") == "post_set"
+            ]
 
             upcoming_ex = app.workout_session.upcoming_exercise_name()
             next_all = (
-                get_metrics_for_exercise(upcoming_ex, preset_name=app.workout_session.preset_name)
+                get_metrics_for_exercise(
+                    upcoming_ex, preset_name=app.workout_session.preset_name
+                )
                 if upcoming_ex
                 else []
             )
@@ -327,7 +329,10 @@ class MetricInputScreen(MDScreen):
 
             if source_type == "manual_slider":
                 widget = MDSlider(min=0, max=1, value=0)
-                widget.bind(on_touch_down=self.on_slider_touch_down, on_touch_up=self.on_slider_touch_up)
+                widget.bind(
+                    on_touch_down=self.on_slider_touch_down,
+                    on_touch_up=self.on_slider_touch_up,
+                )
             elif source_type == "manual_enum":
                 widget = Spinner(text=values[0] if values else "", values=values)
             else:  # manual_text
@@ -388,6 +393,7 @@ class MetricInputScreen(MDScreen):
         elif self.manager:
             self.manager.current = "rest"
 
+
 class PresetsScreen(MDScreen):
     """Screen to select a workout preset."""
 
@@ -432,7 +438,11 @@ class PresetsScreen(MDScreen):
         self.preset_list.clear_widgets()
         for preset in core.WORKOUT_PRESETS:
             item = OneLineListItem(text=preset["name"])
-            item.bind(on_release=lambda inst, name=preset["name"]: self.select_preset(name, inst))
+            item.bind(
+                on_release=lambda inst, name=preset["name"]: self.select_preset(
+                    name, inst
+                )
+            )
             self.preset_list.add_widget(item)
 
     def select_preset(self, name, item):
@@ -491,24 +501,26 @@ class ExerciseLibraryScreen(MDScreen):
     _search_event = None
     _metric_search_event = None
 
-
     def on_pre_enter(self, *args):
         app = MDApp.get_running_app()
-        if (
-            self.all_exercises is None
-            or (app and self.cache_version != getattr(app, "exercise_library_version", 0))
+        if self.all_exercises is None or (
+            app and self.cache_version != getattr(app, "exercise_library_version", 0)
         ):
             db_path = DEFAULT_DB_PATH
-            self.all_exercises = core.get_all_exercises(db_path, include_user_created=True)
+            self.all_exercises = core.get_all_exercises(
+                db_path, include_user_created=True
+            )
             if app:
                 self.cache_version = app.exercise_library_version
 
-        if (
-            self.all_metrics is None
-            or (app and self.metric_cache_version != getattr(app, "metric_library_version", 0))
+        if self.all_metrics is None or (
+            app
+            and self.metric_cache_version != getattr(app, "metric_library_version", 0)
         ):
             db_path = DEFAULT_DB_PATH
-            self.all_metrics = core.get_all_metric_types(db_path, include_user_created=True)
+            self.all_metrics = core.get_all_metric_types(
+                db_path, include_user_created=True
+            )
             if app:
                 self.metric_cache_version = app.metric_library_version
 
@@ -538,12 +550,13 @@ class ExerciseLibraryScreen(MDScreen):
             return
         self.exercise_list.data = []
         app = MDApp.get_running_app()
-        if (
-            self.all_exercises is None
-            or (app and self.cache_version != getattr(app, "exercise_library_version", 0))
+        if self.all_exercises is None or (
+            app and self.cache_version != getattr(app, "exercise_library_version", 0)
         ):
             db_path = DEFAULT_DB_PATH
-            self.all_exercises = core.get_all_exercises(db_path, include_user_created=True)
+            self.all_exercises = core.get_all_exercises(
+                db_path, include_user_created=True
+            )
             if app:
                 self.cache_version = app.exercise_library_version
         exercises = self.all_exercises or []
@@ -558,13 +571,15 @@ class ExerciseLibraryScreen(MDScreen):
             exercises = [ex for ex in exercises if s in ex[0].lower()]
         data = []
         for name, is_user in exercises:
-            data.append({
-                "name": name,
-                "text": name,
-                "is_user_created": is_user,
-                "edit_callback": self.open_edit_exercise_popup,
-                "delete_callback": self.confirm_delete_exercise,
-            })
+            data.append(
+                {
+                    "name": name,
+                    "text": name,
+                    "is_user_created": is_user,
+                    "edit_callback": self.open_edit_exercise_popup,
+                    "delete_callback": self.confirm_delete_exercise,
+                }
+            )
         self.exercise_list.data = data
         if self.loading_dialog:
             self.loading_dialog.dismiss()
@@ -578,12 +593,14 @@ class ExerciseLibraryScreen(MDScreen):
             return
         self.metric_list.data = []
         app = MDApp.get_running_app()
-        if (
-            self.all_metrics is None
-            or (app and self.metric_cache_version != getattr(app, "metric_library_version", 0))
+        if self.all_metrics is None or (
+            app
+            and self.metric_cache_version != getattr(app, "metric_library_version", 0)
         ):
             db_path = DEFAULT_DB_PATH
-            self.all_metrics = core.get_all_metric_types(db_path, include_user_created=True)
+            self.all_metrics = core.get_all_metric_types(
+                db_path, include_user_created=True
+            )
             if app:
                 self.metric_cache_version = app.metric_library_version
         metrics = self.all_metrics or []
@@ -597,18 +614,19 @@ class ExerciseLibraryScreen(MDScreen):
             metrics = [m for m in metrics if s in m["name"].lower()]
         data = []
         for m in metrics:
-            data.append({
-                "name": m["name"],
-                "text": m["name"],
-                "is_user_created": m["is_user_created"],
-                "edit_callback": self.open_edit_metric_popup,
-                "delete_callback": self.confirm_delete_metric,
-            })
+            data.append(
+                {
+                    "name": m["name"],
+                    "text": m["name"],
+                    "is_user_created": m["is_user_created"],
+                    "edit_callback": self.open_edit_metric_popup,
+                    "delete_callback": self.confirm_delete_metric,
+                }
+            )
         self.metric_list.data = data
         if self.loading_dialog:
             self.loading_dialog.dismiss()
             self.loading_dialog = None
-
 
     def open_filter_popup(self):
         list_view = MDList()
@@ -626,7 +644,9 @@ class ExerciseLibraryScreen(MDScreen):
         close_btn = MDRaisedButton(
             text="Close", on_release=lambda *a: self.filter_dialog.dismiss()
         )
-        title = "Filter Exercises" if self.current_tab == "exercises" else "Filter Metrics"
+        title = (
+            "Filter Exercises" if self.current_tab == "exercises" else "Filter Metrics"
+        )
         self.filter_dialog = MDDialog(
             title=title, type="custom", content_cls=scroll, buttons=[close_btn]
         )
@@ -684,7 +704,9 @@ class ExerciseLibraryScreen(MDScreen):
         def do_delete(*args):
             db_path = DEFAULT_DB_PATH
             try:
-                core.delete_exercise(exercise_name, db_path=db_path, is_user_created=True)
+                core.delete_exercise(
+                    exercise_name, db_path=db_path, is_user_created=True
+                )
                 app = MDApp.get_running_app()
                 if app:
                     app.exercise_library_version += 1
@@ -711,7 +733,9 @@ class ExerciseLibraryScreen(MDScreen):
         def do_delete(*args):
             db_path = DEFAULT_DB_PATH
             try:
-                core.delete_metric_type(metric_name, db_path=db_path, is_user_created=True)
+                core.delete_metric_type(
+                    metric_name, db_path=db_path, is_user_created=True
+                )
                 app = MDApp.get_running_app()
                 if app:
                     app.metric_library_version += 1
@@ -780,7 +804,9 @@ class PresetOverviewScreen(MDScreen):
         app = MDApp.get_running_app()
         preset_name = app.selected_preset
         self.preset_label.text = (
-            preset_name if preset_name else "Preset Overview - summary of the chosen preset"
+            preset_name
+            if preset_name
+            else "Preset Overview - summary of the chosen preset"
         )
         for p in core.WORKOUT_PRESETS:
             if p["name"] == preset_name:
@@ -863,7 +889,9 @@ class SectionWidget(MDBoxLayout):
             return
         box = self.ids.exercise_list
         box.clear_widgets()
-        for idx, ex in enumerate(app.preset_editor.sections[self.section_index]["exercises"]):
+        for idx, ex in enumerate(
+            app.preset_editor.sections[self.section_index]["exercises"]
+        ):
             box.add_widget(
                 SelectedExerciseItem(
                     text=ex["name"],
@@ -1062,7 +1090,13 @@ class EditPresetScreen(MDScreen):
             # Validate before confirmation to show immediate error
             app.preset_editor.save()
         except ValueError as exc:
-            dialog = MDDialog(title="Error", text=str(exc), buttons=[MDRaisedButton(text="OK", on_release=lambda *a: dialog.dismiss())])
+            dialog = MDDialog(
+                title="Error",
+                text=str(exc),
+                buttons=[
+                    MDRaisedButton(text="OK", on_release=lambda *a: dialog.dismiss())
+                ],
+            )
             dialog.open()
             return
 
@@ -1078,7 +1112,15 @@ class EditPresetScreen(MDScreen):
                 if self.manager:
                     self.manager.current = "presets"
             except Exception as err:
-                err_dialog = MDDialog(title="Error", text=str(err), buttons=[MDRaisedButton(text="OK", on_release=lambda *a: err_dialog.dismiss())])
+                err_dialog = MDDialog(
+                    title="Error",
+                    text=str(err),
+                    buttons=[
+                        MDRaisedButton(
+                            text="OK", on_release=lambda *a: err_dialog.dismiss()
+                        )
+                    ],
+                )
                 err_dialog.open()
 
         dialog = MDDialog(
@@ -1107,7 +1149,9 @@ class EditPresetScreen(MDScreen):
                 title="Discard Changes?",
                 text="You have unsaved changes. Discard them?",
                 buttons=[
-                    MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
+                    MDRaisedButton(
+                        text="Cancel", on_release=lambda *a: dialog.dismiss()
+                    ),
                     MDRaisedButton(text="Discard", on_release=discard),
                 ],
             )
@@ -1115,7 +1159,6 @@ class EditPresetScreen(MDScreen):
         else:
             if self.manager:
                 self.manager.current = "presets"
-
 
 
 class SelectedExerciseItem(MDBoxLayout):
@@ -1151,8 +1194,13 @@ class SelectedExerciseItem(MDBoxLayout):
         edit = app.root.get_screen("edit_preset") if app.root else None
         if edit:
             for widget in edit.sections_box.children:
-                if isinstance(widget, SectionWidget) and widget.section_index == self.section_index:
-                    widget.move_exercise_widget(self.exercise_index, self.exercise_index - 1)
+                if (
+                    isinstance(widget, SectionWidget)
+                    and widget.section_index == self.section_index
+                ):
+                    widget.move_exercise_widget(
+                        self.exercise_index, self.exercise_index - 1
+                    )
                     break
             edit.update_save_enabled()
 
@@ -1169,8 +1217,13 @@ class SelectedExerciseItem(MDBoxLayout):
         edit = app.root.get_screen("edit_preset") if app.root else None
         if edit:
             for widget in edit.sections_box.children:
-                if isinstance(widget, SectionWidget) and widget.section_index == self.section_index:
-                    widget.move_exercise_widget(self.exercise_index, self.exercise_index + 1)
+                if (
+                    isinstance(widget, SectionWidget)
+                    and widget.section_index == self.section_index
+                ):
+                    widget.move_exercise_widget(
+                        self.exercise_index, self.exercise_index + 1
+                    )
                     break
             edit.update_save_enabled()
 
@@ -1180,11 +1233,16 @@ class SelectedExerciseItem(MDBoxLayout):
         def do_delete(*args):
             app = MDApp.get_running_app()
             if app and app.preset_editor:
-                app.preset_editor.remove_exercise(self.section_index, self.exercise_index)
+                app.preset_editor.remove_exercise(
+                    self.section_index, self.exercise_index
+                )
                 edit = app.root.get_screen("edit_preset") if app.root else None
                 if edit:
                     for widget in edit.sections_box.children:
-                        if isinstance(widget, SectionWidget) and widget.section_index == self.section_index:
+                        if (
+                            isinstance(widget, SectionWidget)
+                            and widget.section_index == self.section_index
+                        ):
                             widget.refresh_exercises()
                             break
                     edit.update_save_enabled()
@@ -1223,12 +1281,13 @@ class ExerciseSelectionPanel(MDBoxLayout):
         self.exercise_list.clear_widgets()
 
         app = MDApp.get_running_app()
-        if (
-            self.all_exercises is None
-            or (app and self.cache_version != getattr(app, "exercise_library_version", 0))
+        if self.all_exercises is None or (
+            app and self.cache_version != getattr(app, "exercise_library_version", 0)
         ):
             db_path = DEFAULT_DB_PATH
-            self.all_exercises = core.get_all_exercises(db_path, include_user_created=True)
+            self.all_exercises = core.get_all_exercises(
+                db_path, include_user_created=True
+            )
             if app:
                 self.cache_version = app.exercise_library_version
 
@@ -1285,7 +1344,10 @@ class ExerciseSelectionPanel(MDBoxLayout):
             text="Close", on_release=lambda *a: self.filter_dialog.dismiss()
         )
         self.filter_dialog = MDDialog(
-            title="Filter Exercises", type="custom", content_cls=scroll, buttons=[close_btn]
+            title="Filter Exercises",
+            type="custom",
+            content_cls=scroll,
+            buttons=[close_btn],
         )
         self.filter_dialog.open()
 
@@ -1311,7 +1373,7 @@ class ExerciseSelectionPanel(MDBoxLayout):
 class AddMetricPopup(MDDialog):
     """Popup dialog for choosing an action, selecting metrics or creating a new one."""
 
-    def __init__(self, screen: 'EditExerciseScreen', mode: str = "select", **kwargs):
+    def __init__(self, screen: "EditExerciseScreen", mode: str = "select", **kwargs):
         self.screen = screen
         self.mode = mode
 
@@ -1322,7 +1384,9 @@ class AddMetricPopup(MDDialog):
         else:  # initial choice
             content, buttons, title = self._build_choice_widgets()
 
-        super().__init__(title=title, type="custom", content_cls=content, buttons=buttons, **kwargs)
+        super().__init__(
+            title=title, type="custom", content_cls=content, buttons=buttons, **kwargs
+        )
 
     # ------------------------------------------------------------------
     # Building widgets for both modes
@@ -1333,8 +1397,7 @@ class AddMetricPopup(MDDialog):
         metrics = [
             m
             for m in metrics
-            if m["name"] not in existing
-            and m.get("scope") in ("set", "exercise")
+            if m["name"] not in existing and m.get("scope") in ("set", "exercise")
         ]
         list_view = MDList()
         for m in metrics:
@@ -1345,7 +1408,9 @@ class AddMetricPopup(MDDialog):
         scroll = ScrollView(do_scroll_y=True, size_hint_y=None, height=dp(400))
         scroll.add_widget(list_view)
 
-        new_btn = MDRaisedButton(text="New Metric", on_release=self.show_new_metric_form)
+        new_btn = MDRaisedButton(
+            text="New Metric", on_release=self.show_new_metric_form
+        )
         cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())
         buttons = [new_btn, cancel_btn]
         return scroll, buttons, "Select Metric"
@@ -1383,14 +1448,8 @@ class AddMetricPopup(MDDialog):
         else:
             order_map = {field["name"]: field for field in schema}
             schema = [
-                order_map[name]
-                for name in METRIC_FIELD_ORDER
-                if name in order_map
-            ] + [
-                field
-                for field in schema
-                if field["name"] not in METRIC_FIELD_ORDER
-            ]
+                order_map[name] for name in METRIC_FIELD_ORDER if name in order_map
+            ] + [field for field in schema if field["name"] not in METRIC_FIELD_ORDER]
 
         form = MDBoxLayout(
             orientation="vertical",
@@ -1401,7 +1460,9 @@ class AddMetricPopup(MDDialog):
 
         def enable_auto_resize(text_field: MDTextField):
             text_field.bind(
-                text=lambda inst, val: setattr(inst, "height", max(default_height, inst.minimum_height))
+                text=lambda inst, val: setattr(
+                    inst, "height", max(default_height, inst.minimum_height)
+                )
             )
 
         for field in schema:
@@ -1411,13 +1472,20 @@ class AddMetricPopup(MDDialog):
                 continue
             options = field.get("options")
             if name == "is_required":
-                row = MDBoxLayout(orientation="horizontal", size_hint_y=None, height="40dp")
+                row = MDBoxLayout(
+                    orientation="horizontal", size_hint_y=None, height="40dp"
+                )
                 widget = MDCheckbox(size_hint_y=None, height=default_height)
                 row.add_widget(widget)
                 row.add_widget(MDLabel(text="Required"))
                 form.add_widget(row)
             elif options:
-                widget = Spinner(text=options[0], values=options, size_hint_y=None, height=default_height)
+                widget = Spinner(
+                    text=options[0],
+                    values=options,
+                    size_hint_y=None,
+                    height=default_height,
+                )
                 form.add_widget(widget)
             else:
                 # Older versions of KivyMD do not accept the
@@ -1476,9 +1544,12 @@ class AddMetricPopup(MDDialog):
                 return re.sub(r",\s+", ",", filtered)
 
             self.enum_values_field.input_filter = _filter
+
         if "source_type" in self.input_widgets and "input_type" in self.input_widgets:
             self.input_widgets["input_type"].bind(text=lambda *a: update_enum_filter())
-            self.input_widgets["source_type"].bind(text=lambda *a: update_enum_visibility())
+            self.input_widgets["source_type"].bind(
+                text=lambda *a: update_enum_visibility()
+            )
             update_enum_visibility()
             update_enum_filter()
 
@@ -1493,7 +1564,9 @@ class AddMetricPopup(MDDialog):
     def _build_choice_widgets(self):
         label = MDLabel(text="Choose an option", halign="center")
         add_btn = MDRaisedButton(text="Add Metric", on_release=self.show_metric_list)
-        new_btn = MDRaisedButton(text="New Metric", on_release=self.show_new_metric_form)
+        new_btn = MDRaisedButton(
+            text="New Metric", on_release=self.show_new_metric_form
+        )
         cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())
         content = MDBoxLayout(orientation="vertical", spacing="8dp")
         content.add_widget(label)
@@ -1608,11 +1681,13 @@ class AddMetricPopup(MDDialog):
 class EditMetricPopup(MDDialog):
     """Popup for editing an existing metric."""
 
-    def __init__(self, screen: 'EditExerciseScreen', metric: dict, **kwargs):
+    def __init__(self, screen: "EditExerciseScreen", metric: dict, **kwargs):
         self.screen = screen
         self.metric = metric
         content, buttons, title = self._build_widgets()
-        super().__init__(title=title, type="custom", content_cls=content, buttons=buttons, **kwargs)
+        super().__init__(
+            title=title, type="custom", content_cls=content, buttons=buttons, **kwargs
+        )
 
     def _build_widgets(self):
         default_height = dp(48)
@@ -1647,14 +1722,8 @@ class EditMetricPopup(MDDialog):
         else:
             order_map = {field["name"]: field for field in schema}
             schema = [
-                order_map[name]
-                for name in METRIC_FIELD_ORDER
-                if name in order_map
-            ] + [
-                field
-                for field in schema
-                if field["name"] not in METRIC_FIELD_ORDER
-            ]
+                order_map[name] for name in METRIC_FIELD_ORDER if name in order_map
+            ] + [field for field in schema if field["name"] not in METRIC_FIELD_ORDER]
 
         form = MDBoxLayout(
             orientation="vertical",
@@ -1677,13 +1746,20 @@ class EditMetricPopup(MDDialog):
                 continue
             options = field.get("options")
             if name == "is_required":
-                row = MDBoxLayout(orientation="horizontal", size_hint_y=None, height="40dp")
+                row = MDBoxLayout(
+                    orientation="horizontal", size_hint_y=None, height="40dp"
+                )
                 widget = MDCheckbox(size_hint_y=None, height=default_height)
                 row.add_widget(widget)
                 row.add_widget(MDLabel(text="Required"))
                 form.add_widget(row)
             elif options:
-                widget = Spinner(text=options[0], values=options, size_hint_y=None, height=default_height)
+                widget = Spinner(
+                    text=options[0],
+                    values=options,
+                    size_hint_y=None,
+                    height=default_height,
+                )
                 form.add_widget(widget)
             else:
                 widget = MDTextField(
@@ -1755,7 +1831,9 @@ class EditMetricPopup(MDDialog):
 
         if "source_type" in self.input_widgets and "input_type" in self.input_widgets:
             self.input_widgets["input_type"].bind(text=lambda *a: update_enum_filter())
-            self.input_widgets["source_type"].bind(text=lambda *a: update_enum_visibility())
+            self.input_widgets["source_type"].bind(
+                text=lambda *a: update_enum_visibility()
+            )
             update_enum_visibility()
             update_enum_filter()
 
@@ -1836,9 +1914,7 @@ class EditMetricPopup(MDDialog):
             content.add_widget(label)
 
             def on_save(*a):
-                metric_saved = self.screen.exercise_obj.had_metric(
-                    self.metric["name"]
-                )
+                metric_saved = self.screen.exercise_obj.had_metric(self.metric["name"])
                 if checkbox.active:
                     core.update_metric_type(
                         self.metric["name"],
@@ -1899,7 +1975,13 @@ class EditMetricPopup(MDDialog):
 class EditMetricTypePopup(MDDialog):
     """Popup for editing or creating metric types from the library."""
 
-    def __init__(self, screen: 'ExerciseLibraryScreen', metric_name: str | None, is_user_created: bool, **kwargs):
+    def __init__(
+        self,
+        screen: "ExerciseLibraryScreen",
+        metric_name: str | None,
+        is_user_created: bool,
+        **kwargs,
+    ):
         self.screen = screen
         self.metric_name = metric_name
         self.is_user_created = is_user_created
@@ -1913,7 +1995,9 @@ class EditMetricTypePopup(MDDialog):
                     self.metric = m
                     break
         content, buttons, title = self._build_widgets()
-        super().__init__(title=title, type="custom", content_cls=content, buttons=buttons, **kwargs)
+        super().__init__(
+            title=title, type="custom", content_cls=content, buttons=buttons, **kwargs
+        )
 
     def _build_widgets(self):
         default_height = dp(48)
@@ -1924,35 +2008,65 @@ class EditMetricTypePopup(MDDialog):
                 {"name": "name"},
                 {"name": "description"},
                 {"name": "input_type", "options": ["int", "float", "str", "bool"]},
-                {"name": "source_type", "options": ["manual_text", "manual_enum", "manual_slider"]},
-                {"name": "input_timing", "options": ["preset", "pre_workout", "post_workout", "pre_set", "post_set"]},
+                {
+                    "name": "source_type",
+                    "options": ["manual_text", "manual_enum", "manual_slider"],
+                },
+                {
+                    "name": "input_timing",
+                    "options": [
+                        "preset",
+                        "pre_workout",
+                        "post_workout",
+                        "pre_set",
+                        "post_set",
+                    ],
+                },
                 {"name": "scope", "options": ["session", "section", "exercise", "set"]},
                 {"name": "is_required"},
             ]
         else:
             order_map = {field["name"]: field for field in schema}
-            schema = [order_map[name] for name in METRIC_FIELD_ORDER if name in order_map] + [field for field in schema if field["name"] not in METRIC_FIELD_ORDER]
+            schema = [
+                order_map[name] for name in METRIC_FIELD_ORDER if name in order_map
+            ] + [field for field in schema if field["name"] not in METRIC_FIELD_ORDER]
 
         form = MDBoxLayout(orientation="vertical", spacing="8dp", size_hint_y=None)
         form.bind(minimum_height=form.setter("height"))
 
         def enable_auto_resize(text_field: MDTextField):
-            text_field.bind(text=lambda inst, val: setattr(inst, "height", max(default_height, inst.minimum_height)))
+            text_field.bind(
+                text=lambda inst, val: setattr(
+                    inst, "height", max(default_height, inst.minimum_height)
+                )
+            )
 
         for field in schema:
             name = field["name"]
             options = field.get("options")
             if name == "is_required":
-                row = MDBoxLayout(orientation="horizontal", size_hint_y=None, height="40dp")
+                row = MDBoxLayout(
+                    orientation="horizontal", size_hint_y=None, height="40dp"
+                )
                 widget = MDCheckbox(size_hint_y=None, height=default_height)
                 row.add_widget(widget)
                 row.add_widget(MDLabel(text="Required"))
                 form.add_widget(row)
             elif options:
-                widget = Spinner(text=options[0], values=options, size_hint_y=None, height=default_height)
+                widget = Spinner(
+                    text=options[0],
+                    values=options,
+                    size_hint_y=None,
+                    height=default_height,
+                )
                 form.add_widget(widget)
             else:
-                widget = MDTextField(hint_text=name.replace("_", " ").title(), size_hint_y=None, height=default_height, multiline=True)
+                widget = MDTextField(
+                    hint_text=name.replace("_", " ").title(),
+                    size_hint_y=None,
+                    height=default_height,
+                    multiline=True,
+                )
                 widget.hint_text_font_size = "12sp"
                 enable_auto_resize(widget)
                 form.add_widget(widget)
@@ -2046,7 +2160,6 @@ class EditMetricTypePopup(MDDialog):
         self.dismiss()
 
 
-
 class EditExerciseScreen(MDScreen):
     """Screen for editing an individual exercise within a preset."""
 
@@ -2065,6 +2178,7 @@ class EditExerciseScreen(MDScreen):
     loading_dialog = ObjectProperty(None, allownone=True)
     exercise_sets = NumericProperty(DEFAULT_SETS_PER_EXERCISE)
     exercise_rest = NumericProperty(DEFAULT_REST_DURATION)
+    section_length = NumericProperty(0)
 
     def switch_tab(self, tab: str):
         """Switch between available tabs."""
@@ -2072,6 +2186,70 @@ class EditExerciseScreen(MDScreen):
             self.current_tab = tab
             if "exercise_tabs" in self.ids:
                 self.ids.exercise_tabs.current = tab
+
+    def can_go_prev(self) -> bool:
+        app = MDApp.get_running_app()
+        if (
+            not app
+            or not app.preset_editor
+            or self.section_index < 0
+            or self.exercise_index <= 0
+        ):
+            return False
+        return True
+
+    def can_go_next(self) -> bool:
+        app = MDApp.get_running_app()
+        if not app or not app.preset_editor or self.section_index < 0:
+            return False
+        sec = app.preset_editor.sections[self.section_index]
+        return self.exercise_index < len(sec["exercises"]) - 1
+
+    def _navigate_to(self, new_index: int) -> None:
+        app = MDApp.get_running_app()
+        if not app or not app.preset_editor or self.section_index < 0:
+            return
+        sec = app.preset_editor.sections[self.section_index]
+        if new_index < 0 or new_index >= len(sec["exercises"]):
+            return
+        self.exercise_index = new_index
+        self.exercise_name = sec["exercises"][new_index]["name"]
+        self._load_exercise()
+
+    def _confirm_navigation(self, new_index: int) -> None:
+        dialog = None
+
+        def do_nav(*args):
+            if dialog:
+                dialog.dismiss()
+            self._navigate_to(new_index)
+
+        dialog = MDDialog(
+            title="Discard Changes?",
+            text="You have unsaved changes. Discard them?",
+            buttons=[
+                MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
+                MDRaisedButton(text="Discard", on_release=do_nav),
+            ],
+        )
+        dialog.open()
+
+    def go_prev_exercise(self) -> None:
+        if not self.can_go_prev():
+            return
+        if self.save_enabled:
+            self._confirm_navigation(self.exercise_index - 1)
+        else:
+            self._navigate_to(self.exercise_index - 1)
+
+    def go_next_exercise(self) -> None:
+        if not self.can_go_next():
+            return
+        if self.save_enabled:
+            self._confirm_navigation(self.exercise_index + 1)
+        else:
+            self._navigate_to(self.exercise_index + 1)
+
     def on_pre_enter(self, *args):
         if self.previous_screen == "edit_preset":
             self.switch_tab("config")
@@ -2097,12 +2275,17 @@ class EditExerciseScreen(MDScreen):
         self.exercise_description = self.exercise_obj.description
         if self.section_index >= 0 and self.exercise_index >= 0:
             app = MDApp.get_running_app()
-            if app.preset_editor and self.section_index < len(app.preset_editor.sections):
+            if app.preset_editor and self.section_index < len(
+                app.preset_editor.sections
+            ):
                 exercises = app.preset_editor.sections[self.section_index]["exercises"]
+                self.section_length = len(exercises)
                 if self.exercise_index < len(exercises):
                     ex = exercises[self.exercise_index]
                     self.exercise_sets = ex.get("sets", DEFAULT_SETS_PER_EXERCISE)
                     self.exercise_rest = ex.get("rest", DEFAULT_REST_DURATION)
+            else:
+                self.section_length = 0
         self.save_enabled = False
         self.populate()
         if self.loading_dialog:
@@ -2123,7 +2306,9 @@ class EditExerciseScreen(MDScreen):
             lbl = MDLabel(text=m.get("name", ""), halign="left")
             row.add_widget(lbl)
             edit_btn = MDIconButton(icon="pencil")
-            edit_btn.bind(on_release=lambda inst, metric=m: self.open_edit_metric_popup(metric))
+            edit_btn.bind(
+                on_release=lambda inst, metric=m: self.open_edit_metric_popup(metric)
+            )
             row.add_widget(edit_btn)
             remove_btn = MDIconButton(
                 icon="delete",
@@ -2131,7 +2316,9 @@ class EditExerciseScreen(MDScreen):
                 text_color=(1, 0, 0, 1),
             )
             remove_btn.bind(
-                on_release=lambda inst, name=m.get("name", ""): self.confirm_remove_metric(name)
+                on_release=lambda inst, name=m.get(
+                    "name", ""
+                ): self.confirm_remove_metric(name)
             )
             row.add_widget(remove_btn)
             self.metrics_list.add_widget(row)
@@ -2256,7 +2443,9 @@ class EditExerciseScreen(MDScreen):
             dialog = MDDialog(
                 title="Error",
                 text="Name cannot be empty",
-                buttons=[MDRaisedButton(text="OK", on_release=lambda *a: dialog.dismiss())],
+                buttons=[
+                    MDRaisedButton(text="OK", on_release=lambda *a: dialog.dismiss())
+                ],
             )
             dialog.open()
             return
@@ -2276,7 +2465,9 @@ class EditExerciseScreen(MDScreen):
             dialog = MDDialog(
                 title="Error",
                 text="Duplicate name",
-                buttons=[MDRaisedButton(text="OK", on_release=lambda *a: dialog.dismiss())],
+                buttons=[
+                    MDRaisedButton(text="OK", on_release=lambda *a: dialog.dismiss())
+                ],
             )
             dialog.open()
             return
@@ -2289,13 +2480,9 @@ class EditExerciseScreen(MDScreen):
             )
             exists = cursor.fetchone()
             if exists:
-                msg = (
-                    f"A user-defined copy of {self.exercise_obj.name} exists and will be overwritten."
-                )
+                msg = f"A user-defined copy of {self.exercise_obj.name} exists and will be overwritten."
             else:
-                msg = (
-                    f"{self.exercise_obj.name} is predefined. A user-defined copy will be created."
-                )
+                msg = f"{self.exercise_obj.name} is predefined. A user-defined copy will be created."
         conn.close()
 
         dialog = None
@@ -2315,7 +2502,10 @@ class EditExerciseScreen(MDScreen):
                 )
                 if not update_library:
                     preset_name = app.preset_editor.preset_name
-                    orig = {m.get("name"): m for m in (self.exercise_obj._original or {}).get("metrics", [])}
+                    orig = {
+                        m.get("name"): m
+                        for m in (self.exercise_obj._original or {}).get("metrics", [])
+                    }
                     current = {m.get("name"): m for m in self.exercise_obj.metrics}
                     for name, metric in current.items():
                         old = orig.get(name)
@@ -2335,10 +2525,15 @@ class EditExerciseScreen(MDScreen):
 
                     removed = [name for name in orig if name not in current]
                     if removed:
-                        db_path = Path(__file__).resolve().parent / "data" / "workout.db"
+                        db_path = (
+                            Path(__file__).resolve().parent / "data" / "workout.db"
+                        )
                         conn = sqlite3.connect(str(db_path))
                         cur = conn.cursor()
-                        cur.execute("SELECT id FROM preset_presets WHERE name = ?", (preset_name,))
+                        cur.execute(
+                            "SELECT id FROM preset_presets WHERE name = ?",
+                            (preset_name,),
+                        )
                         row = cur.fetchone()
                         if row:
                             preset_id = row[0]
@@ -2399,7 +2594,9 @@ class EditExerciseScreen(MDScreen):
                 text=msg,
                 content_cls=content,
                 buttons=[
-                    MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
+                    MDRaisedButton(
+                        text="Cancel", on_release=lambda *a: dialog.dismiss()
+                    ),
                     MDRaisedButton(text="Save", on_release=do_save),
                 ],
             )
@@ -2409,7 +2606,9 @@ class EditExerciseScreen(MDScreen):
                 title="Confirm Save",
                 text=msg,
                 buttons=[
-                    MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
+                    MDRaisedButton(
+                        text="Cancel", on_release=lambda *a: dialog.dismiss()
+                    ),
                     MDRaisedButton(text="Save", on_release=do_save),
                 ],
             )
@@ -2441,6 +2640,7 @@ class EditExerciseScreen(MDScreen):
             if self.manager:
                 self.manager.current = self.previous_screen
 
+
 class WorkoutApp(MDApp):
     workout_session = None
     selected_preset = ""
@@ -2457,13 +2657,15 @@ class WorkoutApp(MDApp):
     def build(self):
         return Builder.load_file(str(Path(__file__).with_name("main.kv")))
 
-
     def init_preset_editor(self, force_reload: bool = False):
         """Create or reload the ``PresetEditor`` for the selected preset."""
 
         db_path = DEFAULT_DB_PATH
         if self.selected_preset:
-            if not self.preset_editor or self.preset_editor.preset_name != self.selected_preset:
+            if (
+                not self.preset_editor
+                or self.preset_editor.preset_name != self.selected_preset
+            ):
                 if self.preset_editor:
                     self.preset_editor.close()
                 self.preset_editor = PresetEditor(self.selected_preset, db_path)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -5,8 +5,8 @@ import pytest
 os.environ["KIVY_WINDOW"] = "mock"
 # Skip tests entirely if Kivy (and KivyMD) are not installed
 kivy_available = (
-    importlib.util.find_spec("kivy") is not None and
-    importlib.util.find_spec("kivymd") is not None
+    importlib.util.find_spec("kivy") is not None
+    and importlib.util.find_spec("kivymd") is not None
 )
 
 if kivy_available:
@@ -36,7 +36,6 @@ if kivy_available:
 
         def property(self, name, default=None):  # pragma: no cover - simple shim
             return ObjectProperty(None)
-
 
     @pytest.fixture(autouse=True)
     def _provide_app(monkeypatch):
@@ -104,7 +103,9 @@ def test_add_metric_popup_has_single_enum_field():
     popup = AddMetricPopup(DummyScreen(), mode="new")
     children = popup.content_cls.children[0].children
     enum_fields = [
-        c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
+        c
+        for c in children
+        if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
     ]
     assert len(enum_fields) == 1
 
@@ -132,7 +133,9 @@ def test_edit_metric_popup_has_single_enum_field():
     popup = EditMetricPopup(DummyScreen(), metric)
     children = popup.content_cls.children[0].children
     enum_fields = [
-        c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
+        c
+        for c in children
+        if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
     ]
     assert len(enum_fields) == 1
 
@@ -177,9 +180,59 @@ def test_edit_exercise_preset_tab():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_edit_exercise_navigation_flags(monkeypatch):
+    app = _DummyApp()
+    app.preset_editor = type(
+        "PE",
+        (),
+        {"sections": [{"name": "S1", "exercises": [{"name": "a"}, {"name": "b"}]}]},
+    )()
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+    screen = EditExerciseScreen()
+    screen.section_index = 0
+    screen.exercise_index = 0
+    assert not screen.can_go_prev()
+    assert screen.can_go_next()
+    screen.exercise_index = 1
+    assert screen.can_go_prev()
+    assert not screen.can_go_next()
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_edit_exercise_go_next(monkeypatch):
+    app = _DummyApp()
+    app.preset_editor = type(
+        "PE",
+        (),
+        {"sections": [{"name": "S1", "exercises": [{"name": "a"}, {"name": "b"}]}]},
+    )()
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+    screen = EditExerciseScreen()
+    screen.section_index = 0
+    screen.exercise_index = 0
+    screen.save_enabled = False
+    called = {"idx": None}
+
+    def nav(idx):
+        called["idx"] = idx
+
+    screen._navigate_to = nav
+    screen.go_next_exercise()
+    assert called["idx"] == 1
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_exercise_selection_panel_filters(monkeypatch):
     panel = ExerciseSelectionPanel()
-    panel.exercise_list = type("L", (), {"children": [], "clear_widgets": lambda self: self.children.clear(), "add_widget": lambda self, w: self.children.append(w)})()
+    panel.exercise_list = type(
+        "L",
+        (),
+        {
+            "children": [],
+            "clear_widgets": lambda self: self.children.clear(),
+            "add_widget": lambda self, w: self.children.append(w),
+        },
+    )()
 
     monkeypatch.setattr(
         core,
@@ -200,6 +253,7 @@ def test_preset_select_button_updates(monkeypatch):
     """Selecting a preset updates the select button text."""
     from kivy.lang import Builder
     from pathlib import Path
+
     Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
 
     monkeypatch.setattr(
@@ -216,7 +270,6 @@ def test_preset_select_button_updates(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
-
 def test_save_exercise_duplicate_name(monkeypatch, tmp_path):
     """Saving with a duplicate user-defined name shows an error."""
     import sqlite3
@@ -256,6 +309,7 @@ def test_save_exercise_duplicate_name(monkeypatch, tmp_path):
     assert opened["value"]
     assert screen.name_field.error
 
+
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_edit_metric_duplicate_name(monkeypatch):
     class DummyExercise:
@@ -291,11 +345,13 @@ def test_edit_metric_type_popup_selects_correct_metric():
     popup = EditMetricTypePopup(DummyScreen(), "Reps", True)
     assert popup.metric["description"] == "copy"
 
+
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_preset_select_button_color(monkeypatch):
     """Selecting a preset updates the select button color."""
     from kivy.lang import Builder
     from pathlib import Path
+
     Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
 
     monkeypatch.setattr(
@@ -308,7 +364,11 @@ def test_preset_select_button_color(monkeypatch):
     dummy = type(
         "Obj",
         (),
-        {"md_bg_color": (0, 0, 0, 0), "theme_text_color": "Primary", "text_color": (0, 0, 0, 1)},
+        {
+            "md_bg_color": (0, 0, 0, 0),
+            "theme_text_color": "Primary",
+            "text_color": (0, 0, 0, 1),
+        },
     )()
     screen.select_preset("Sample", dummy)
 
@@ -320,6 +380,7 @@ def test_preset_selected_text_color_and_clear(monkeypatch):
     """Selecting a preset changes text color and is cleared on leave."""
     from kivy.lang import Builder
     from pathlib import Path
+
     Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
 
     monkeypatch.setattr(
@@ -332,7 +393,11 @@ def test_preset_selected_text_color_and_clear(monkeypatch):
     dummy = type(
         "Obj",
         (),
-        {"md_bg_color": (0, 0, 0, 0), "theme_text_color": "Primary", "text_color": (0, 0, 0, 1)},
+        {
+            "md_bg_color": (0, 0, 0, 0),
+            "theme_text_color": "Primary",
+            "text_color": (0, 0, 0, 1),
+        },
     )()
     screen.select_preset("Sample", dummy)
 
@@ -343,4 +408,3 @@ def test_preset_selected_text_color_and_clear(monkeypatch):
 
     assert dummy.theme_text_color == "Primary"
     assert screen.selected_item is None
-


### PR DESCRIPTION
## Summary
- allow navigating between exercises within a preset section when editing
- show left/right arrows in EditExerciseScreen
- implement navigation logic with unsaved-change checks
- test navigation helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859c0c9dc08332bff87b1a6bd715a0