### PR TITLE
Fix preset editor reload when returning from exercise edit

### DIFF
--- a/main.py
+++ b/main.py
@@ -961,6 +961,16 @@ class EditPresetScreen(MDScreen):
             self.save_enabled = False
 
     def on_pre_enter(self, *args):
+        app = MDApp.get_running_app()
+        if app and app.editing_exercise_index >= 0:
+            self.preset_name = app.preset_editor.preset_name or "Preset"
+            self.current_tab = "sections"
+            self.refresh_sections()
+            self.update_save_enabled()
+            app.editing_section_index = -1
+            app.editing_exercise_index = -1
+            return super().on_pre_enter(*args)
+
         if os.environ.get("KIVY_UNITTEST"):
             self._load_preset()
         else:


### PR DESCRIPTION
## Summary
- preserve loaded preset widgets when returning from EditExerciseScreen
- avoid reinitializing PresetEditor unnecessarily

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859c9ec098833284f64d4ef81d9b7f