### PR TITLE
Fix navigation arrows in edit exercise screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -805,7 +805,7 @@ ScreenManager:
             MDIconButton:
                 icon: "chevron-left"
                 opacity: 1 if root.section_index >= 0 else 0
-                disabled: not root.can_go_prev()
+                disabled: root.section_index < 0 or not app.preset_editor or root.exercise_index <= 0
                 on_release: root.go_prev_exercise()
             MDLabel:
                 text: root.exercise_name if root.exercise_name else "Edit Exercise"
@@ -815,7 +815,7 @@ ScreenManager:
             MDIconButton:
                 icon: "chevron-right"
                 opacity: 1 if root.section_index >= 0 else 0
-                disabled: not root.can_go_next()
+                disabled: root.section_index < 0 or not app.preset_editor or root.exercise_index >= root.section_length - 1
                 on_release: root.go_next_exercise()
         MDBoxLayout:
             size_hint_y: None


### PR DESCRIPTION
## Summary
- fix logic for exercise navigation arrows so they're enabled correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68859ea9031083329a771a0e1199377a