### PR TITLE
Fix enum field visibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -2056,6 +2056,9 @@ class EditMetricTypePopup(MDDialog):
 
         for field in schema:
             name = field["name"]
+            if name == "enum_values_json":
+                # handled separately via ``enum_values_field``
+                continue
             options = field.get("options")
             if name == "is_required":
                 row = MDBoxLayout(


### PR DESCRIPTION
## Summary
- hide enum_values_json column when editing metric types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a52db1bc8332bb2fd42fe5d6b665