### PR TITLE
Add enum value loading for metric type edits

### DIFF
--- a/core.py
+++ b/core.py
@@ -247,7 +247,8 @@ def get_all_metric_types(
         cursor.execute(
             """
             SELECT name, input_type, source_type, input_timing,
-                   is_required, scope, description, is_user_created
+                   is_required, scope, description, is_user_created,
+                   enum_values_json
             FROM library_metric_types
             WHERE deleted = 0
             ORDER BY id
@@ -263,6 +264,7 @@ def get_all_metric_types(
                 "scope": scope,
                 "description": description,
                 "is_user_created": bool(flag),
+                "enum_values_json": enum_json,
             }
             for (
                 name,
@@ -273,13 +275,14 @@ def get_all_metric_types(
                 scope,
                 description,
                 flag,
+                enum_json,
             ) in cursor.fetchall()
         ]
     else:
         cursor.execute(
             """
             SELECT name, input_type, source_type, input_timing,
-                   is_required, scope, description
+                   is_required, scope, description, enum_values_json
             FROM library_metric_types
             WHERE deleted = 0
             ORDER BY id
@@ -294,6 +297,7 @@ def get_all_metric_types(
                 "is_required": bool(is_required),
                 "scope": scope,
                 "description": description,
+                "enum_values_json": enum_json,
             }
             for (
                 name,
@@ -303,6 +307,7 @@ def get_all_metric_types(
                 is_required,
                 scope,
                 description,
+                enum_json,
             ) in cursor.fetchall()
         ]
     conn.close()

--- a/main.py
+++ b/main.py
@@ -1813,7 +1813,7 @@ class EditMetricPopup(MDDialog):
         if self.metric.get("source_type") == "manual_enum":
             if self.enum_values_field.parent is None:
                 form.add_widget(self.enum_values_field)
-            values = ",".join(self.metric.get("values", []))
+            values = ", ".join(self.metric.get("values", []))
             self.enum_values_field.text = values
         else:
             if self.enum_values_field.parent is not None:
@@ -2123,7 +2123,7 @@ class EditMetricTypePopup(MDDialog):
                     values = json.loads(self.metric["enum_values_json"])
                 except Exception:
                     values = []
-            self.enum_values_field.text = ",".join(values)
+            self.enum_values_field.text = ", ".join(values)
 
         def update_enum_visibility(*args):
             show = self.input_widgets["source_type"].text == "manual_enum"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -429,6 +429,23 @@ def test_edit_metric_type_popup_enum_field_visibility():
     ]
     assert len(enum_fields) == 1
 
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_edit_metric_type_popup_loads_enum_values():
+    class DummyScreen:
+        all_metrics = [
+            {
+                "name": "Side",
+                "input_type": "str",
+                "source_type": "manual_enum",
+                "is_user_created": True,
+                "enum_values_json": "[\"Left\", \"Right\", \"None\"]",
+            }
+        ]
+
+    popup = EditMetricTypePopup(DummyScreen(), "Side", True)
+    assert popup.enum_values_field.text == "Left, Right, None"
+
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_preset_select_button_color(monkeypatch):
     """Selecting a preset updates the select button color."""


### PR DESCRIPTION
## Summary
- include `enum_values_json` when fetching metric types
- populate enum values for exercise and library metric popups with comma+space separators
- add UI test for showing saved enum values in library editor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a91619e48332bb03363f93ea5d11