### PR TITLE
Add preset-level metric editing

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -587,6 +587,7 @@ ScreenManager:
 <EditPresetScreen>:
     sections_box: sections_box
     exercise_panel: exercise_panel
+    details_box: details_box
     panel_visible: False
     on_current_tab: edit_tabs.current = self.current_tab
     FloatLayout:
@@ -649,12 +650,13 @@ ScreenManager:
 
                 Screen:
                     name: "details"
-                    on_enter: preset_name.text = root.preset_name
+                    on_enter: root.populate_details()
                     BoxLayout:
                         orientation: "vertical"
                         ScrollView:
                             do_scroll_x: False
                             MDBoxLayout:
+                                id: details_box
                                 orientation: "vertical"
                                 size_hint_y: None
                                 height: self.minimum_height

--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -111,6 +111,7 @@ def test_to_dict_after_modifications(db_copy):
                 ],
             }
         ],
+        "metadata": {},
     }
     assert editor.to_dict() == expected
     editor.close()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -28,6 +28,7 @@ if kivy_available:
         EditExerciseScreen,
         ExerciseSelectionPanel,
         PresetsScreen,
+        EditPresetScreen,
     )
     import time
 
@@ -508,3 +509,28 @@ def test_preset_selected_text_color_and_clear(monkeypatch):
 
     assert dummy.theme_text_color == "Primary"
     assert screen.selected_item is None
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_edit_preset_populate_details(monkeypatch):
+    from kivy.lang import Builder
+    from pathlib import Path
+
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    metrics = [
+        {"name": "Focus", "input_type": "str", "source_type": "manual_text", "scope": "preset", "enum_values_json": None},
+        {"name": "Level", "input_type": "int", "source_type": "manual_text", "scope": "preset", "enum_values_json": None},
+    ]
+
+    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: metrics)
+
+    app = _DummyApp()
+    app.preset_editor = type("PE", (), {"metadata": {"Focus": "Legs", "Level": 2}, "is_modified": lambda self=None: False})()
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+
+    screen = EditPresetScreen()
+    screen.populate_details()
+
+    assert set(screen.preset_metric_widgets.keys()) == {"Focus", "Level"}
+    assert screen.preset_metric_widgets["Focus"].text == "Legs"


### PR DESCRIPTION
## Summary
- load/save preset metadata in `PresetEditor`
- display preset metrics in `EditPresetScreen`
- handle preset metric widgets in UI
- adjust tests for updated preset data structure
- test preset details population

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877b2af4188332abb028fa04ddb6ea