### PR TITLE
Fix preset name visibility in details tab

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -654,6 +654,7 @@ ScreenManager:
                     BoxLayout:
                         orientation: "vertical"
                         ScrollView:
+                            id: details_scroll
                             do_scroll_x: False
                             MDBoxLayout:
                                 id: details_box

--- a/main.py
+++ b/main.py
@@ -1185,6 +1185,10 @@ class EditPresetScreen(MDScreen):
             row.add_widget(widget)
             self.details_box.add_widget(row)
 
+        # Ensure the preset name remains visible when entering the tab
+        if "details_scroll" in self.ids:
+            self.ids.details_scroll.scroll_y = 1
+
     def save_preset(self):
         app = MDApp.get_running_app()
         if not app.preset_editor:


### PR DESCRIPTION
## Summary
- keep the `ScrollView` scrolled to the top so the preset name field is visible
- give the details `ScrollView` an id for programmatic control

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688781c99f58833294b0e3436020ffae