### PR TITLE
Align preset code with new DB schema

### DIFF
--- a/core.py
+++ b/core.py
@@ -26,13 +26,15 @@ def load_workout_presets(db_path: Path = DEFAULT_DB_PATH):
 
     conn = sqlite3.connect(str(db_path))
     cursor = conn.cursor()
-    cursor.execute("SELECT id, name FROM preset_presets WHERE deleted = 0 ORDER BY id")
+    cursor.execute(
+        "SELECT id, name FROM preset_presets WHERE deleted = 0 ORDER BY id"
+    )
     presets = []
     for preset_id, preset_name in cursor.fetchall():
         cursor.execute(
             """
             SELECT se.exercise_name, se.number_of_sets, se.rest_time
-            FROM preset_sections s
+            FROM preset_preset_sections s
             JOIN preset_section_exercises se ON se.section_id = s.id
             WHERE s.preset_id = ? AND s.deleted = 0 AND se.deleted = 0
             ORDER BY s.position, se.position
@@ -205,9 +207,9 @@ def get_metrics_for_exercise(
         cursor.execute(
             """
             SELECT sem.metric_name, sem.input_timing, sem.is_required, sem.scope
-            FROM preset_section_exercise_metrics sem
+            FROM preset_exercise_metrics sem
             JOIN preset_section_exercises se ON sem.section_exercise_id = se.id
-            JOIN preset_sections s ON se.section_id = s.id
+            JOIN preset_preset_sections s ON se.section_id = s.id
             JOIN preset_presets p ON s.preset_id = p.id
             WHERE p.name = ? AND se.exercise_name = ?
               AND sem.deleted = 0 AND se.deleted = 0 AND s.deleted = 0 AND p.deleted = 0
@@ -593,7 +595,7 @@ def set_section_exercise_metric_override(
     preset_id = row[0]
 
     cursor.execute(
-        "SELECT id FROM preset_sections WHERE preset_id = ? AND deleted = 0 ORDER BY position",
+        "SELECT id FROM preset_preset_sections WHERE preset_id = ? AND deleted = 0 ORDER BY position",
         (preset_id,),
     )
     sections = cursor.fetchall()
@@ -623,7 +625,7 @@ def set_section_exercise_metric_override(
     se_id = row[0]
 
     cursor.execute(
-        "SELECT id FROM preset_section_exercise_metrics WHERE section_exercise_id = ? AND metric_name = ? AND deleted = 0",
+        "SELECT id FROM preset_exercise_metrics WHERE section_exercise_id = ? AND metric_name = ? AND deleted = 0",
         (se_id, metric_type_name),
     )
     row = cursor.fetchone()
@@ -635,13 +637,13 @@ def set_section_exercise_metric_override(
             params.append(json.dumps(enum_values))
         params.append(row[0])
         cursor.execute(
-            f"UPDATE preset_section_exercise_metrics SET {', '.join(updates)} WHERE id = ?",
+            f"UPDATE preset_exercise_metrics SET {', '.join(updates)} WHERE id = ?",
             params,
         )
     else:
         cursor.execute(
             """
-            INSERT INTO preset_section_exercise_metrics
+            INSERT INTO preset_exercise_metrics
                 (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, enum_values_json, library_metric_type_id)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
@@ -1172,7 +1174,7 @@ def delete_metric_type(
         raise ValueError("Metric type is in use and cannot be deleted")
 
     cursor.execute(
-        "SELECT 1 FROM preset_metadata WHERE metric_type_id = ? AND deleted = 0 LIMIT 1",
+        "SELECT 1 FROM preset_preset_metrics WHERE library_metric_type_id = ? AND deleted = 0 LIMIT 1",
         (mt_id,),
     )
     if cursor.fetchone():
@@ -1226,7 +1228,7 @@ class PresetEditor:
 
         preset_id = row[0]
         cursor.execute(
-            "SELECT id, name FROM preset_sections WHERE preset_id = ? AND deleted = 0 ORDER BY position",
+            "SELECT id, name FROM preset_preset_sections WHERE preset_id = ? AND deleted = 0 ORDER BY position",
             (preset_id,),
         )
 
@@ -1253,8 +1255,8 @@ class PresetEditor:
         cursor.execute(
             """
             SELECT mt.name, pm.value, mt.input_type
-              FROM preset_metadata pm
-              JOIN library_metric_types mt ON mt.id = pm.metric_type_id
+              FROM preset_preset_metrics pm
+              JOIN library_metric_types mt ON mt.id = pm.library_metric_type_id
              WHERE pm.preset_id = ? AND pm.deleted = 0 AND mt.deleted = 0
             """,
             (preset_id,),
@@ -1417,7 +1419,7 @@ class PresetEditor:
             preset_id = row[0]
             self._preset_id = preset_id
             cursor.execute(
-                "SELECT id FROM preset_sections WHERE preset_id = ? AND deleted = 0",
+                "SELECT id FROM preset_preset_sections WHERE preset_id = ? AND deleted = 0",
                 (preset_id,),
             )
             sec_ids = [r[0] for r in cursor.fetchall()]
@@ -1429,7 +1431,7 @@ class PresetEditor:
                 ex_ids = [r[0] for r in cursor.fetchall()]
                 for eid in ex_ids:
                     cursor.execute(
-                        "UPDATE preset_section_exercise_metrics SET deleted = 1 WHERE section_exercise_id = ?",
+                        "UPDATE preset_exercise_metrics SET deleted = 1 WHERE section_exercise_id = ?",
                         (eid,),
                     )
                 cursor.execute(
@@ -1437,7 +1439,7 @@ class PresetEditor:
                     (sid,),
                 )
             cursor.execute(
-                "UPDATE preset_sections SET deleted = 1 WHERE preset_id = ?",
+                "UPDATE preset_preset_sections SET deleted = 1 WHERE preset_id = ?",
                 (preset_id,),
             )
             cursor.execute(
@@ -1454,7 +1456,7 @@ class PresetEditor:
 
         for sec_pos, sec in enumerate(self.sections):
             cursor.execute(
-                "INSERT INTO preset_sections (preset_id, name, position) VALUES (?, ?, ?)",
+                "INSERT INTO preset_preset_sections (preset_id, name, position) VALUES (?, ?, ?)",
                 (preset_id, sec.get("name", f"Section {sec_pos + 1}"), sec_pos),
             )
             section_id = cursor.lastrowid
@@ -1516,7 +1518,7 @@ class PresetEditor:
                         mt_id,
                     ) in cursor.fetchall():
                         cursor.execute(
-                            """INSERT INTO preset_section_exercise_metrics
+                            """INSERT INTO preset_exercise_metrics
                                 (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, enum_values_json, position, library_metric_type_id)
                                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                             (
@@ -1534,7 +1536,7 @@ class PresetEditor:
                         )
 
         cursor.execute(
-            "UPDATE preset_metadata SET deleted = 1 WHERE preset_id = ?",
+            "UPDATE preset_preset_metrics SET deleted = 1 WHERE preset_id = ?",
             (preset_id,),
         )
         for name, value in self.metadata.items():
@@ -1547,7 +1549,7 @@ class PresetEditor:
                 continue
             mt_id = row[0]
             cursor.execute(
-                "INSERT INTO preset_metadata (preset_id, metric_type_id, value) VALUES (?, ?, ?)",
+                "INSERT INTO preset_preset_metrics (preset_id, library_metric_type_id, value) VALUES (?, ?, ?)",
                 (preset_id, mt_id, str(value)),
             )
 

--- a/main.py
+++ b/main.py
@@ -2840,7 +2840,7 @@ class EditExerciseScreen(MDScreen):
                         if row:
                             preset_id = row[0]
                             cur.execute(
-                                "SELECT id FROM preset_sections WHERE preset_id = ? ORDER BY position",
+                                "SELECT id FROM preset_preset_sections WHERE preset_id = ? ORDER BY position",
                                 (preset_id,),
                             )
                             sections = cur.fetchall()
@@ -2855,11 +2855,7 @@ class EditExerciseScreen(MDScreen):
                                     se_id = se_row[0]
                                     for mname in removed:
                                         cur.execute(
-                                            "DELETE FROM preset_section_exercise_metric_enum_values WHERE section_exercise_metric_id IN (SELECT id FROM preset_section_exercise_metrics WHERE section_exercise_id = ? AND metric_name = ?)",
-                                            (se_id, mname),
-                                        )
-                                        cur.execute(
-                                            "DELETE FROM preset_section_exercise_metrics WHERE section_exercise_id = ? AND metric_name = ?",
+                                            "DELETE FROM preset_exercise_metrics WHERE section_exercise_id = ? AND metric_name = ?",
                                             (se_id, mname),
                                         )
                                     conn.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 def sample_db(tmp_path: Path) -> Path:
     """Create a temporary database populated with a minimal 'Push Day' preset."""
     db_path = tmp_path / "workout.db"
-    sql_path = Path(__file__).resolve().parent.parent / "data" / "workout.sql"
+    sql_path = Path(__file__).resolve().parent.parent / "data" / "workout_schema.sql"
 
     conn = sqlite3.connect(db_path)
     with open(sql_path, "r", encoding="utf-8") as fh:
@@ -39,7 +39,7 @@ def sample_db(tmp_path: Path) -> Path:
             (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
         VALUES (?, ?, ?, ?, ?, ?, '', 0)
         """,
-        ("Machine", "str", "manual_enum", "pre_workout", 0, "exercise"),
+        ("Machine", "str", "manual_enum", "pre_session", 0, "exercise"),
     )
 
     reps_id = conn.execute("SELECT id FROM library_metric_types WHERE name='Reps'").fetchone()[0]
@@ -81,11 +81,11 @@ def sample_db(tmp_path: Path) -> Path:
     conn.execute("INSERT INTO preset_presets (name) VALUES ('Push Day')")
     preset_id = conn.execute("SELECT id FROM preset_presets WHERE name='Push Day'").fetchone()[0]
     conn.execute(
-        "INSERT INTO preset_sections (preset_id, name, position) VALUES (?, 'Main', 0)",
+        "INSERT INTO preset_preset_sections (preset_id, name, position) VALUES (?, 'Main', 0)",
         (preset_id,),
     )
     section_id = conn.execute(
-        "SELECT id FROM preset_sections WHERE preset_id=?", (preset_id,)
+        "SELECT id FROM preset_preset_sections WHERE preset_id=?", (preset_id,)
     ).fetchone()[0]
 
     # section exercises
@@ -118,7 +118,7 @@ def sample_db(tmp_path: Path) -> Path:
     # section exercise metrics (override reps timing for bench)
     conn.execute(
         """
-        INSERT INTO preset_section_exercise_metrics
+        INSERT INTO preset_exercise_metrics
             (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
         VALUES (?, 'Reps', 'int', 'manual_text', 'post_set', 1, 'set', ?)
         """,
@@ -126,7 +126,7 @@ def sample_db(tmp_path: Path) -> Path:
     )
     conn.execute(
         """
-        INSERT INTO preset_section_exercise_metrics
+        INSERT INTO preset_exercise_metrics
             (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
         VALUES (?, 'Reps', 'int', 'manual_text', 'pre_set', 1, 'set', ?)
         """,
@@ -134,7 +134,7 @@ def sample_db(tmp_path: Path) -> Path:
     )
     conn.execute(
         """
-        INSERT INTO preset_section_exercise_metrics
+        INSERT INTO preset_exercise_metrics
             (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
         VALUES (?, 'Weight', 'float', 'manual_text', 'pre_set', 0, 'set', ?)
         """,
@@ -142,9 +142,9 @@ def sample_db(tmp_path: Path) -> Path:
     )
     conn.execute(
         """
-        INSERT INTO preset_section_exercise_metrics
+        INSERT INTO preset_exercise_metrics
             (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, enum_values_json, library_metric_type_id)
-        VALUES (?, 'Machine', 'str', 'manual_enum', 'pre_workout', 0, 'exercise', ?, ?)
+        VALUES (?, 'Machine', 'str', 'manual_enum', 'pre_session', 0, 'exercise', ?, ?)
         """,
         (bench_se_id, '["A","B"]', machine_id),
     )

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -334,7 +334,7 @@ def test_save_exercise_duplicate_name(monkeypatch, tmp_path):
     import sqlite3
     from pathlib import Path
 
-    schema = Path(__file__).resolve().parents[1] / "data" / "workout.sql"
+    schema = Path(__file__).resolve().parents[1] / "data" / "workout_schema.sql"
     db_path = tmp_path / "workout.db"
     conn = sqlite3.connect(db_path)
     with open(schema, "r", encoding="utf-8") as fh:

--- a/tests/test_workout_db.py
+++ b/tests/test_workout_db.py
@@ -9,7 +9,7 @@ import core
 
 def create_empty_db(path: Path) -> None:
     """Create a new database at *path* using the bundled schema."""
-    schema = Path("data/workout.sql").read_text()
+    schema = Path("data/workout_schema.sql").read_text()
     conn = sqlite3.connect(path)
     conn.executescript(schema)
     conn.commit()
@@ -41,7 +41,7 @@ def populate_sample_data(db_path: Path) -> None:
     cur.execute("INSERT INTO preset_presets (name) VALUES ('Push Day')")
     preset_id = cur.lastrowid
     cur.execute(
-        "INSERT INTO preset_sections (preset_id, name, position) VALUES (?, ?, 0)",
+        "INSERT INTO preset_preset_sections (preset_id, name, position) VALUES (?, ?, 0)",
         (preset_id, "Main"),
     )
     section_id = cur.lastrowid


### PR DESCRIPTION
## Summary
- update preset queries to match renamed tables
- adjust main preset logic for new metric table
- update tests for renamed schema and enum values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a1328a5008332883dfd0c961da44e