### PR TITLE
Update fallback metric timing names

### DIFF
--- a/main.py
+++ b/main.py
@@ -1541,8 +1541,8 @@ class AddMetricPopup(MDDialog):
                     "name": "input_timing",
                     "options": [
                         "preset",
-                        "pre_workout",
-                        "post_workout",
+                        "pre_session",
+                        "post_session",
                         "pre_set",
                         "post_set",
                     ],
@@ -1810,8 +1810,8 @@ class EditMetricPopup(MDDialog):
                     "name": "input_timing",
                     "options": [
                         "preset",
-                        "pre_workout",
-                        "post_workout",
+                        "pre_session",
+                        "post_session",
                         "pre_set",
                         "post_set",
                     ],
@@ -2240,8 +2240,8 @@ class EditMetricTypePopup(MDDialog):
                     "name": "input_timing",
                     "options": [
                         "preset",
-                        "pre_workout",
-                        "post_workout",
+                        "pre_session",
+                        "post_session",
                         "pre_set",
                         "post_set",
                     ],

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -534,3 +534,22 @@ def test_edit_preset_populate_details(monkeypatch):
 
     assert set(screen.preset_metric_widgets.keys()) == {"Focus", "Level"}
     assert screen.preset_metric_widgets["Focus"].text == "Legs"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_fallback_input_timing_options(monkeypatch):
+    """Fallback schema uses allowed input_timing values."""
+
+    class DummyScreen:
+        exercise_obj = type("obj", (), {"metrics": []})()
+
+    monkeypatch.setattr(core, "get_metric_type_schema", lambda *a, **k: [])
+    popup = AddMetricPopup(DummyScreen(), mode="new")
+    opts = list(popup.input_widgets["input_timing"].values)
+    assert opts == [
+        "preset",
+        "pre_session",
+        "post_session",
+        "pre_set",
+        "post_set",
+    ]


### PR DESCRIPTION
## Summary
- update fallback `input_timing` values to use `pre_session` and `post_session`
- ensure all fallback sections match new values
- test fallback `input_timing` list when schema is unavailable

## Testing
- `pytest -q` *(fails: test_save_existing_preset, test_remove_exercise_and_save)*

------
https://chatgpt.com/codex/tasks/task_e_688a2c466a308332ae7c3f8ea1fa3263