### PR TITLE
Add preset name row in details tab

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -662,14 +662,20 @@ ScreenManager:
                                 size_hint_y: None
                                 height: self.minimum_height
                                 spacing: dp(10)
-                                MDTextField:
-                                    id: preset_name
-                                    hint_text: "Preset Name"
-                                    multiline: False
-                                    on_text: root.update_preset_name(self.text)
-                                    size_hint_x: 1
+                                MDBoxLayout:
+                                    id: preset_name_row
+                                    orientation: "horizontal"
                                     size_hint_y: None
-                                    height: "48dp"  # Give it space to render properly
+                                    height: "40dp"
+                                    MDLabel:
+                                        text: "Preset Name"
+                                        size_hint_x: 0.4
+                                    MDTextField:
+                                        id: preset_name
+                                        hint_text: "Preset Name"
+                                        multiline: False
+                                        on_text: root.update_preset_name(self.text)
+                                        size_hint_x: 1
 
             MDBoxLayout:
                 size_hint_y: None

--- a/main.py
+++ b/main.py
@@ -1109,11 +1109,15 @@ class EditPresetScreen(MDScreen):
             return
         self.ids.preset_name.text = self.preset_name
         for child in list(self.details_box.children):
-            if getattr(child, "id", "") != "preset_name":
+            if getattr(child, "id", "") != "preset_name_row":
                 self.details_box.remove_widget(child)
 
         self.preset_metric_widgets = {}
-        metrics = [m for m in core.get_all_metric_types() if m.get("scope") == "preset"]
+        metrics = [
+            m
+            for m in core.get_all_metric_types()
+            if m.get("input_timing") == "preset"
+        ]
         app = MDApp.get_running_app()
         values = app.preset_editor.metadata if app and app.preset_editor else {}
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -519,8 +519,22 @@ def test_edit_preset_populate_details(monkeypatch):
     Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
 
     metrics = [
-        {"name": "Focus", "input_type": "str", "source_type": "manual_text", "scope": "preset", "enum_values_json": None},
-        {"name": "Level", "input_type": "int", "source_type": "manual_text", "scope": "preset", "enum_values_json": None},
+        {
+            "name": "Focus",
+            "input_type": "str",
+            "source_type": "manual_text",
+            "scope": "preset",
+            "enum_values_json": None,
+            "input_timing": "preset",
+        },
+        {
+            "name": "Level",
+            "input_type": "int",
+            "source_type": "manual_text",
+            "scope": "preset",
+            "enum_values_json": None,
+            "input_timing": "preset",
+        },
     ]
 
     monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: metrics)


### PR DESCRIPTION
## Summary
- show preset name as part of the details list on EditPresetScreen
- filter preset detail metrics by `input_timing == "preset"`
- update tests for new metric filter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a2f1c37a48332bb5a614fa4d00d00