### PR TITLE
Fix preset metric filtering

### DIFF
--- a/main.py
+++ b/main.py
@@ -1116,7 +1116,7 @@ class EditPresetScreen(MDScreen):
         metrics = [
             m
             for m in core.get_all_metric_types()
-            if m.get("input_timing") == "preset"
+            if m.get("input_timing") == "preset" and m.get("scope") == "preset"
         ]
         app = MDApp.get_running_app()
         values = app.preset_editor.metadata if app and app.preset_editor else {}


### PR DESCRIPTION
## Summary
- filter metrics in Edit Preset details tab by both `input_timing` and `scope`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a31766d608332853a8fb15c16023a