### PR TITLE
Fix preset name row removal

### DIFF
--- a/main.py
+++ b/main.py
@@ -1108,8 +1108,9 @@ class EditPresetScreen(MDScreen):
         if not self.details_box:
             return
         self.ids.preset_name.text = self.preset_name
+        preset_row = self.ids.get("preset_name_row")
         for child in list(self.details_box.children):
-            if getattr(child, "id", "") != "preset_name_row":
+            if child is not preset_row:
                 self.details_box.remove_widget(child)
 
         self.preset_metric_widgets = {}

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -551,6 +551,26 @@ def test_edit_preset_populate_details(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_preset_name_row_preserved(monkeypatch):
+    from kivy.lang import Builder
+    from pathlib import Path
+
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: [])
+
+    app = _DummyApp()
+    app.preset_editor = type("PE", (), {"metadata": {}, "is_modified": lambda self=None: False})()
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+
+    screen = EditPresetScreen()
+    screen.populate_details()
+
+    assert screen.ids.preset_name_row in screen.details_box.children
+    assert screen.ids.preset_name in screen.ids.preset_name_row.children
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_fallback_input_timing_options(monkeypatch):
     """Fallback schema uses allowed input_timing values."""
 


### PR DESCRIPTION
## Summary
- ensure `populate_details` keeps the preset name row instead of clearing it
- test that the row is preserved when populating details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a319e419083328ccbfc466d3a17bd