### PR TITLE
Implement preset metric support

### DIFF
--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -111,7 +111,7 @@ def test_to_dict_after_modifications(db_copy):
                 ],
             }
         ],
-        "metadata": {},
+        "preset_metrics": [],
     }
     assert editor.to_dict() == expected
     editor.close()
@@ -249,7 +249,7 @@ def test_save_preset_metadata(db_copy):
     editor.preset_name = "Meta Preset"
     editor.add_section("Warmup")
     editor.add_exercise(0, "Push ups")
-    editor.metadata["Difficulty"] = 3
+    editor.add_metric("Difficulty", value=3)
     editor.save()
 
     conn = sqlite3.connect(db_copy)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -540,7 +540,18 @@ def test_edit_preset_populate_details(monkeypatch):
     monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: metrics)
 
     app = _DummyApp()
-    app.preset_editor = type("PE", (), {"metadata": {"Focus": "Legs", "Level": 2}, "is_modified": lambda self=None: False})()
+    app.preset_editor = type(
+        "PE",
+        (),
+        {
+            "preset_metrics": [
+                {"name": "Focus", "value": "Legs"},
+                {"name": "Level", "value": 2},
+            ],
+            "metadata": {"Focus": "Legs", "Level": 2},
+            "is_modified": lambda self=None: False,
+        },
+    )()
     monkeypatch.setattr(App, "get_running_app", lambda: app)
 
     screen = EditPresetScreen()


### PR DESCRIPTION
## Summary
- manage preset-level metrics via `preset_metrics` in `PresetEditor`
- load any required metric types by default
- persist preset metrics to the database
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a3ac1d76c8332a174e54787b2b46d