### PR TITLE
Fix metadata error in preset editor

### DIFF
--- a/main.py
+++ b/main.py
@@ -1130,7 +1130,12 @@ class EditPresetScreen(MDScreen):
             if m.get("input_timing") == "preset" and m.get("scope") == "preset"
         ]
         app = MDApp.get_running_app()
-        values = app.preset_editor.metadata if app and app.preset_editor else {}
+        values = {}
+        if app and app.preset_editor:
+            values = {
+                m.get("name"): m.get("value")
+                for m in app.preset_editor.preset_metrics
+            }
 
         for m in metrics:
             name = m.get("name")
@@ -1185,7 +1190,11 @@ class EditPresetScreen(MDScreen):
                     except Exception:
                         val = 0.0
                 if app and app.preset_editor is not None:
-                    app.preset_editor.metadata[metric] = val
+                    existing = [m for m in app.preset_editor.preset_metrics if m.get("name") == metric]
+                    if existing:
+                        app.preset_editor.update_metric(metric, value=val)
+                    else:
+                        app.preset_editor.add_metric(metric, value=val)
                 self.update_save_enabled()
 
             if isinstance(widget, MDTextField):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -548,8 +548,9 @@ def test_edit_preset_populate_details(monkeypatch):
                 {"name": "Focus", "value": "Legs"},
                 {"name": "Level", "value": 2},
             ],
-            "metadata": {"Focus": "Legs", "Level": 2},
             "is_modified": lambda self=None: False,
+            "update_metric": lambda self, *a, **k: None,
+            "add_metric": lambda self, *a, **k: None,
         },
     )()
     monkeypatch.setattr(App, "get_running_app", lambda: app)
@@ -571,7 +572,16 @@ def test_preset_name_row_preserved(monkeypatch):
     monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: [])
 
     app = _DummyApp()
-    app.preset_editor = type("PE", (), {"metadata": {}, "is_modified": lambda self=None: False})()
+    app.preset_editor = type(
+        "PE",
+        (),
+        {
+            "preset_metrics": [],
+            "is_modified": lambda self=None: False,
+            "update_metric": lambda self, *a, **k: None,
+            "add_metric": lambda self, *a, **k: None,
+        },
+    )()
     monkeypatch.setattr(App, "get_running_app", lambda: app)
 
     screen = EditPresetScreen()


### PR DESCRIPTION
## Summary
- use `preset_metrics` in `EditPresetScreen.populate_details`
- update metric handling when UI values change
- adjust tests for updated preset editor interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a3ef114dc8332bbfe3ce2b7f4f4af