### PR TITLE
Add metrics tab placeholder in EditPresetScreen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -611,6 +611,10 @@ ScreenManager:
                     text: "Details"
                     md_bg_color: app.theme_cls.primary_color if root.current_tab == "details" else (.5, .5, .5, 1)
                     on_release: root.switch_tab("details")
+                MDRaisedButton:
+                    text: "Metrics"
+                    md_bg_color: app.theme_cls.primary_color if root.current_tab == "metrics" else (.5, .5, .5, 1)
+                    on_release: root.switch_tab("metrics")
 
             ScreenManager:
                 id: edit_tabs
@@ -683,6 +687,14 @@ ScreenManager:
                                     size_hint_y: None
                                     height: self.minimum_height
                                     spacing: dp(10)
+
+                Screen:
+                    name: "metrics"
+                    BoxLayout:
+                        orientation: "vertical"
+                        MDLabel:
+                            text: "Metrics"
+                            halign: "center"
 
             MDBoxLayout:
                 size_hint_y: None

--- a/main.py
+++ b/main.py
@@ -1091,11 +1091,13 @@ class EditPresetScreen(MDScreen):
         return section
 
     def switch_tab(self, tab: str):
-        """Switch between the sections and details tabs."""
-        if tab in ("sections", "details"):
+        """Switch between the sections, details, and metrics tabs."""
+        if tab in ("sections", "details", "metrics"):
             self.current_tab = tab
             if tab == "details":
                 self.populate_details()
+            elif tab == "metrics":
+                self.populate_metrics()
 
     def update_preset_name(self, name: str):
         """Update the preset name in the editor."""
@@ -1213,6 +1215,10 @@ class EditPresetScreen(MDScreen):
         # Ensure the preset name remains visible when entering the tab
         if "details_scroll" in self.ids:
             self.ids.details_scroll.scroll_y = 1
+
+    def populate_metrics(self):
+        """Placeholder for future metrics tab population."""
+        pass
 
     def save_preset(self):
         app = MDApp.get_running_app()


### PR DESCRIPTION
## Summary
- add "Metrics" tab button and metrics screen placeholder in `EditPresetScreen`
- allow switching to the new "metrics" tab in `main.py`
- include stub `populate_metrics` method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a46c7873c83329ea039a43c2fdede