### PR TITLE
Add required session metrics list in preset editor

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -693,8 +693,21 @@ ScreenManager:
                     BoxLayout:
                         orientation: "vertical"
                         MDLabel:
-                            text: "Metrics"
+                            text: "Required Session Metrics"
                             halign: "center"
+                            theme_text_color: "Custom"
+                            text_color: 0.2, 0.6, 0.86, 1
+                            size_hint_y: None
+                            height: "40dp"
+                        MDRecycleView:
+                            id: session_metric_list
+                            viewclass: "MetricRow"
+                            RecycleBoxLayout:
+                                default_size: None, dp(56)
+                                default_size_hint: 1, None
+                                size_hint_y: None
+                                height: self.minimum_height
+                                orientation: "vertical"
 
             MDBoxLayout:
                 size_hint_y: None

--- a/main.py
+++ b/main.py
@@ -971,6 +971,7 @@ class EditPresetScreen(MDScreen):
     details_box = ObjectProperty(None)
     current_tab = StringProperty("sections")
     metrics_box = ObjectProperty(None)
+    session_metric_list = ObjectProperty(None)
     save_enabled = BooleanProperty(False)
     loading_dialog = ObjectProperty(None, allownone=True)
 
@@ -1217,8 +1218,24 @@ class EditPresetScreen(MDScreen):
             self.ids.details_scroll.scroll_y = 1
 
     def populate_metrics(self):
-        """Placeholder for future metrics tab population."""
-        pass
+        """Populate the Metrics tab with required session metrics."""
+        rv = self.ids.get("session_metric_list")
+        if not rv:
+            return
+
+        metrics = [
+            m
+            for m in core.get_all_metric_types()
+            if m.get("scope") == "session" and m.get("is_required")
+        ]
+        rv.data = [
+            {
+                "name": m["name"],
+                "text": m["name"],
+                "is_user_created": m.get("is_user_created", False),
+            }
+            for m in metrics
+        ]
 
     def save_preset(self):
         app = MDApp.get_running_app()


### PR DESCRIPTION
## Summary
- show required session metrics in the Edit Preset screen
- add a `session_metric_list` property for the preset editor screen
- populate the Metrics tab from the metric library

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b19b6673c833282f8d0bd049c5933