### PR TITLE
Add session metric button to EditPresetScreen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -696,24 +696,32 @@ ScreenManager:
 
                 Screen:
                     name: "metrics"
-                    BoxLayout:
-                        orientation: "vertical"
-                        MDLabel:
-                            text: "Required Session Metrics"
-                            halign: "center"
-                            theme_text_color: "Custom"
-                            text_color: 0.2, 0.6, 0.86, 1
-                            size_hint_y: None
-                            height: "40dp"
-                        MDRecycleView:
-                            id: session_metric_list
-                            viewclass: "MetricRow"
-                            RecycleBoxLayout:
-                                default_size: None, dp(56)
-                                default_size_hint: 1, None
+                    FloatLayout:
+                        BoxLayout:
+                            orientation: "vertical"
+                            MDLabel:
+                                text: "Required Session Metrics"
+                                halign: "center"
+                                theme_text_color: "Custom"
+                                text_color: 0.2, 0.6, 0.86, 1
                                 size_hint_y: None
-                                height: self.minimum_height
-                                orientation: "vertical"
+                                height: "40dp"
+                            MDRecycleView:
+                                id: session_metric_list
+                                viewclass: "MetricRow"
+                                RecycleBoxLayout:
+                                    default_size: None, dp(56)
+                                    default_size_hint: 1, None
+                                    size_hint_y: None
+                                    height: self.minimum_height
+                                    orientation: "vertical"
+                        MDFloatingActionButton:
+                            id: add_session_metric_btn
+                            icon: "plus"
+                            md_bg_color: app.theme_cls.primary_color
+                            pos_hint: {"center_x": 0.5, "y": 0.02}
+                            tooltip_text: "Add Metric"
+                            on_release: root.open_add_session_metric_popup()
 
             MDBoxLayout:
                 size_hint_y: None

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -254,6 +254,37 @@ def test_add_preset_metric_popup_filters_scope(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_add_session_metric_popup_filters_scope(monkeypatch):
+    app = _DummyApp()
+    app.preset_editor = type(
+        "PE",
+        (),
+        {
+            "preset_metrics": [{"name": "Duration"}],
+            "add_metric": lambda self, *a, **k: None,
+            "is_modified": lambda self=None: False,
+        },
+    )()
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+
+    metrics = [
+        {"name": "Duration", "scope": "session"},
+        {"name": "Mood", "scope": "session"},
+        {"name": "Focus", "scope": "preset"},
+    ]
+
+    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: metrics)
+    screen = EditPresetScreen()
+    popup = AddSessionMetricPopup(screen)
+    list_view = popup.content_cls.children[0]
+    names = {child.text for child in list_view.children}
+
+    assert "Focus" not in names
+    assert "Duration" not in names
+    assert "Mood" in names
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_edit_exercise_default_tab():
     screen = EditExerciseScreen()
     screen.previous_screen = "exercise_library"
@@ -648,6 +679,34 @@ def test_details_has_add_button(monkeypatch):
     screen.populate_details()
 
     assert "add_metric_btn" in screen.ids
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_metrics_has_add_button(monkeypatch):
+    from kivy.lang import Builder
+    from pathlib import Path
+
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: [])
+
+    app = _DummyApp()
+    app.preset_editor = type(
+        "PE",
+        (),
+        {
+            "preset_metrics": [],
+            "is_modified": lambda self=None: False,
+            "update_metric": lambda self, *a, **k: None,
+            "add_metric": lambda self, *a, **k: None,
+        },
+    )()
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+
+    screen = EditPresetScreen()
+    screen.populate_metrics()
+
+    assert "add_session_metric_btn" in screen.ids
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")


### PR DESCRIPTION
## Summary
- show preset metrics for session scope
- add floating action button to add session metrics
- list session-only metrics not yet in preset
- add tests for popup filtering and button presence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b1ed349d08332ab89b5acfe2bd226