### PR TITLE
Unify metric type field

### DIFF
--- a/core.py
+++ b/core.py
@@ -152,9 +152,8 @@ def get_metrics_for_exercise(
 ) -> list:
     """Return metric definitions for ``exercise_name``.
 
-    Each item in the returned list is a dictionary with ``name``, ``input_type``,
-    ``source_type`` and ``values`` keys. ``values`` will contain any allowed
-    values for ``manual_enum`` metrics.
+    Each item in the returned list is a dictionary with ``name`` and ``type``
+    keys. ``values`` will contain any allowed values for ``enum`` metrics.
     """
 
     conn = sqlite3.connect(str(db_path))
@@ -180,8 +179,7 @@ def get_metrics_for_exercise(
         """
         SELECT mt.id,
                mt.name,
-               COALESCE(em.input_type, mt.input_type),
-               COALESCE(em.source_type, mt.source_type),
+               COALESCE(em.type, mt.type),
                COALESCE(em.input_timing, mt.input_timing),
                COALESCE(em.is_required, mt.is_required),
                COALESCE(em.scope, mt.scope),
@@ -199,8 +197,7 @@ def get_metrics_for_exercise(
     for (
         metric_id,
         name,
-        input_type,
-        source_type,
+        metric_type,
         input_timing,
         is_required,
         scope,
@@ -208,7 +205,7 @@ def get_metrics_for_exercise(
         description,
     ) in cursor.fetchall():
         values = []
-        if source_type == "manual_enum" and enum_json:
+        if metric_type == "enum" and enum_json:
             try:
                 values = json.loads(enum_json)
             except Exception:
@@ -216,8 +213,7 @@ def get_metrics_for_exercise(
         metrics.append(
             {
                 "name": name,
-                "input_type": input_type,
-                "source_type": source_type,
+                "type": metric_type,
                 "input_timing": input_timing,
                 "is_required": bool(is_required),
                 "scope": scope,
@@ -272,7 +268,7 @@ def get_all_metric_types(
     if include_user_created:
         cursor.execute(
             """
-            SELECT name, input_type, source_type, input_timing,
+            SELECT name, type, input_timing,
                    is_required, scope, description, is_user_created,
                    enum_values_json
             FROM library_metric_types
@@ -283,8 +279,7 @@ def get_all_metric_types(
         metric_types = [
             {
                 "name": name,
-                "input_type": input_type,
-                "source_type": source_type,
+                "type": m_type,
                 "input_timing": input_timing,
                 "is_required": bool(is_required),
                 "scope": scope,
@@ -294,8 +289,7 @@ def get_all_metric_types(
             }
             for (
                 name,
-                input_type,
-                source_type,
+                m_type,
                 input_timing,
                 is_required,
                 scope,
@@ -307,7 +301,7 @@ def get_all_metric_types(
     else:
         cursor.execute(
             """
-            SELECT name, input_type, source_type, input_timing,
+            SELECT name, type, input_timing,
                    is_required, scope, description, enum_values_json
             FROM library_metric_types
             WHERE deleted = 0
@@ -317,8 +311,7 @@ def get_all_metric_types(
         metric_types = [
             {
                 "name": name,
-                "input_type": input_type,
-                "source_type": source_type,
+                "type": m_type,
                 "input_timing": input_timing,
                 "is_required": bool(is_required),
                 "scope": scope,
@@ -327,8 +320,7 @@ def get_all_metric_types(
             }
             for (
                 name,
-                input_type,
-                source_type,
+                m_type,
                 input_timing,
                 is_required,
                 scope,
@@ -410,8 +402,7 @@ def is_metric_type_user_created(
 
 def add_metric_type(
     name: str,
-    input_type: str,
-    source_type: str,
+    metric_type: str,
     input_timing: str,
     scope: str,
     description: str = "",
@@ -426,15 +417,14 @@ def add_metric_type(
     cursor.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing,
+            (name, type, input_timing,
              is_required, scope, description, is_user_created,
              enum_values_json)
-        VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
+        VALUES (?, ?, ?, ?, ?, ?, 1, ?)
         """,
         (
             name,
-            input_type,
-            source_type,
+            metric_type,
             input_timing,
             int(is_required),
             scope,
@@ -530,8 +520,7 @@ def remove_metric_from_exercise(
 def update_metric_type(
     metric_type_name: str,
     *,
-    input_type: str | None = None,
-    source_type: str | None = None,
+    metric_type: str | None = None,
     input_timing: str | None = None,
     scope: str | None = None,
     description: str | None = None,
@@ -561,12 +550,9 @@ def update_metric_type(
     metric_id = row[0]
     updates = []
     params: list = []
-    if input_type is not None:
-        updates.append("input_type = ?")
-        params.append(input_type)
-    if source_type is not None:
-        updates.append("source_type = ?")
-        params.append(source_type)
+    if metric_type is not None:
+        updates.append("type = ?")
+        params.append(metric_type)
     if input_timing is not None:
         updates.append("input_timing = ?")
         params.append(input_timing)
@@ -629,14 +615,14 @@ def set_section_exercise_metric_override(
     section_id = sections[section_index][0]
 
     cursor.execute(
-        "SELECT id, input_type, source_type FROM library_metric_types WHERE name = ? AND deleted = 0",
+        "SELECT id, type FROM library_metric_types WHERE name = ? AND deleted = 0",
         (metric_type_name,),
     )
     row = cursor.fetchone()
     if not row:
         conn.close()
         raise ValueError(f"Metric '{metric_type_name}' not found")
-    metric_type_id, def_input_type, def_source_type = row
+    metric_type_id, def_type = row
 
     cursor.execute(
         """SELECT id FROM preset_section_exercises WHERE section_id = ? AND exercise_name = ? AND deleted = 0 ORDER BY position LIMIT 1""",
@@ -668,14 +654,13 @@ def set_section_exercise_metric_override(
         cursor.execute(
             """
             INSERT INTO preset_exercise_metrics
-                (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, enum_values_json, library_metric_type_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (section_exercise_id, metric_name, type, input_timing, is_required, scope, enum_values_json, library_metric_type_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 se_id,
                 metric_type_name,
-                def_input_type,
-                def_source_type,
+                def_type,
                 input_timing,
                 int(is_required),
                 scope,
@@ -692,8 +677,7 @@ def set_exercise_metric_override(
     metric_type_name: str,
     *,
     is_user_created: bool | None = None,
-    input_type: str | None = None,
-    source_type: str | None = None,
+    metric_type: str | None = None,
     input_timing: str | None = None,
     is_required: bool | None = None,
     scope: str | None = None,
@@ -748,12 +732,9 @@ def set_exercise_metric_override(
 
     updates = []
     params: list = []
-    if input_type is not None:
-        updates.append("input_type = ?")
-        params.append(input_type)
-    if source_type is not None:
-        updates.append("source_type = ?")
-        params.append(source_type)
+    if metric_type is not None:
+        updates.append("type = ?")
+        params.append(metric_type)
     if input_timing is not None:
         updates.append("input_timing = ?")
         params.append(input_timing)
@@ -771,8 +752,7 @@ def set_exercise_metric_override(
         cursor.execute(
             """
             UPDATE library_exercise_metrics
-               SET input_type = NULL,
-                   source_type = NULL,
+               SET type = NULL,
                    input_timing = NULL,
                    is_required = NULL,
                    scope = NULL,
@@ -1061,25 +1041,23 @@ def save_exercise(exercise: Exercise) -> None:
 
     for position, m in enumerate(exercise.metrics):
         cursor.execute(
-            "SELECT id, source_type FROM library_metric_types WHERE name = ?",
+            "SELECT id, type FROM library_metric_types WHERE name = ?",
             (m["name"],),
         )
         mt_row = cursor.fetchone()
         if not mt_row:
             continue
-        metric_id, source_type = mt_row
+        metric_id, def_type = mt_row
         cursor.execute(
-            "SELECT input_type, source_type, input_timing, is_required, scope FROM library_metric_types WHERE id = ?",
+            "SELECT type, input_timing, is_required, scope FROM library_metric_types WHERE id = ?",
             (metric_id,),
         )
         default_row = cursor.fetchone()
-        in_type = source = timing = req = scope_val = None
+        m_type = timing = req = scope_val = None
         if default_row:
-            def_in_type, def_source, def_timing, def_req, def_scope = default_row
-            if m.get("input_type") != def_in_type:
-                in_type = m.get("input_type")
-            if m.get("source_type") != def_source:
-                source = m.get("source_type")
+            def_type_db, def_timing, def_req, def_scope = default_row
+            if m.get("type") != def_type_db:
+                m_type = m.get("type")
             if m.get("input_timing") != def_timing:
                 timing = m.get("input_timing")
             if bool(m.get("is_required")) != bool(def_req):
@@ -1089,22 +1067,18 @@ def save_exercise(exercise: Exercise) -> None:
 
         cursor.execute(
             """INSERT INTO library_exercise_metrics
-                (exercise_id, metric_type_id, position, input_type, source_type, input_timing, is_required, scope, enum_values_json)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (exercise_id, metric_type_id, position, type, input_timing, is_required, scope, enum_values_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 ex_id,
                 metric_id,
                 position,
-                in_type,
-                source,
+                m_type,
                 timing,
                 req,
                 scope_val,
                 (
-                    json.dumps(m.get("values"))
-                    if m.get("values")
-                    and (m.get("source_type") or source_type) == "manual_enum"
-                    else None
+                    json.dumps(m.get("values")) if m.get("values") and m.get("type") == "enum" else None
                 ),
             ),
         )
@@ -1246,7 +1220,7 @@ class PresetEditor:
         cursor = self.conn.cursor()
         cursor.execute(
             """
-            SELECT name, description, input_type, source_type,
+            SELECT name, description, type,
                    input_timing, is_required, scope, enum_values_json
               FROM library_metric_types
              WHERE deleted = 0 AND is_required = 1
@@ -1257,15 +1231,14 @@ class PresetEditor:
         for (
             name,
             desc,
-            in_type,
-            source,
+            m_type,
             timing,
             req,
             scope,
             enum_json,
         ) in cursor.fetchall():
             values = []
-            if source == "manual_enum" and enum_json:
+            if m_type == "enum" and enum_json:
                 try:
                     values = json.loads(enum_json)
                 except Exception:
@@ -1273,8 +1246,7 @@ class PresetEditor:
             self.preset_metrics.append(
                 {
                     "name": name,
-                    "input_type": in_type,
-                    "source_type": source,
+                    "type": m_type,
                     "input_timing": timing,
                     "is_required": bool(req),
                     "scope": scope,
@@ -1331,7 +1303,7 @@ class PresetEditor:
 
         cursor.execute(
             """
-            SELECT mt.name, pm.value, pm.input_type, pm.source_type,
+            SELECT mt.name, pm.value, pm.type,
                    pm.input_timing, pm.is_required, pm.scope,
                    pm.enum_values_json, mt.description
               FROM preset_preset_metrics pm
@@ -1344,26 +1316,25 @@ class PresetEditor:
         for (
             name,
             value,
-            in_type,
-            source,
+            m_type,
             timing,
             req,
             scope,
             enum_json,
             desc,
         ) in cursor.fetchall():
-            if in_type == "int":
+            if m_type == "int":
                 try:
                     value = int(value)
                 except Exception:
                     value = 0
-            elif in_type == "float":
+            elif m_type == "float":
                 try:
                     value = float(value)
                 except Exception:
                     value = 0.0
             values = []
-            if source == "manual_enum" and enum_json:
+            if m_type == "enum" and enum_json:
                 try:
                     values = json.loads(enum_json)
                 except Exception:
@@ -1371,8 +1342,7 @@ class PresetEditor:
             self.preset_metrics.append(
                 {
                     "name": name,
-                    "input_type": in_type,
-                    "source_type": source,
+                    "type": m_type,
                     "input_timing": _from_db_timing(timing),
                     "is_required": bool(req),
                     "scope": scope,
@@ -1498,7 +1468,7 @@ class PresetEditor:
         cursor = self.conn.cursor()
         cursor.execute(
             """
-            SELECT description, input_type, source_type, input_timing,
+            SELECT description, type, input_timing,
                    scope, is_required, enum_values_json
               FROM library_metric_types
              WHERE name = ? AND deleted = 0
@@ -1510,15 +1480,14 @@ class PresetEditor:
             raise ValueError(f"Metric '{metric_name}' not found")
         (
             desc,
-            in_type,
-            source,
+            m_type,
             timing,
             scope,
             req,
             enum_json,
         ) = row
         values = []
-        if source == "manual_enum" and enum_json:
+        if m_type == "enum" and enum_json:
             try:
                 values = json.loads(enum_json)
             except Exception:
@@ -1526,8 +1495,7 @@ class PresetEditor:
         self.preset_metrics.append(
             {
                 "name": metric_name,
-                "input_type": in_type,
-                "source_type": source,
+                "type": m_type,
                 "input_timing": timing,
                 "is_required": bool(req),
                 "scope": scope,
@@ -1702,8 +1670,7 @@ class PresetEditor:
                             cursor.execute(
                             """
                             SELECT mt.name,
-                                   COALESCE(em.input_type, mt.input_type),
-                                   COALESCE(em.source_type, mt.source_type),
+                                   COALESCE(em.type, mt.type),
                                    COALESCE(em.input_timing, mt.input_timing),
                                    COALESCE(em.is_required, mt.is_required),
                                    COALESCE(em.scope, mt.scope),
@@ -1719,8 +1686,7 @@ class PresetEditor:
                         )
                         for (
                             mt_name,
-                            m_input,
-                            m_source,
+                            m_type,
                             m_timing,
                             m_req,
                             m_scope,
@@ -1729,12 +1695,11 @@ class PresetEditor:
                             mt_id,
                         ) in cursor.fetchall():
                             cursor.execute(
-                                """INSERT INTO preset_exercise_metrics (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, enum_values_json, position, library_metric_type_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                                """INSERT INTO preset_exercise_metrics (section_exercise_id, metric_name, type, input_timing, is_required, scope, enum_values_json, position, library_metric_type_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                                 (
                                     ex_id,
                                     mt_name,
-                                    m_input,
-                                    m_source,
+                                    m_type,
                                     m_timing,
                                     m_req,
                                     m_scope,
@@ -1762,8 +1727,7 @@ class PresetEditor:
                     cursor.execute(
                         """
                         SELECT mt.name,
-                               COALESCE(em.input_type, mt.input_type),
-                               COALESCE(em.source_type, mt.source_type),
+                               COALESCE(em.type, mt.type),
                                COALESCE(em.input_timing, mt.input_timing),
                                COALESCE(em.is_required, mt.is_required),
                                COALESCE(em.scope, mt.scope),
@@ -1779,8 +1743,7 @@ class PresetEditor:
                     )
                     for (
                         mt_name,
-                        m_input,
-                        m_source,
+                        m_type,
                         m_timing,
                         m_req,
                         m_scope,
@@ -1789,12 +1752,11 @@ class PresetEditor:
                         mt_id,
                     ) in cursor.fetchall():
                         cursor.execute(
-                            """INSERT INTO preset_exercise_metrics (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, enum_values_json, position, library_metric_type_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                            """INSERT INTO preset_exercise_metrics (section_exercise_id, metric_name, type, input_timing, is_required, scope, enum_values_json, position, library_metric_type_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                             (
                                 ex_id,
                                 mt_name,
-                                m_input,
-                                m_source,
+                                m_type,
                                 m_timing,
                                 m_req,
                                 m_scope,
@@ -1852,7 +1814,7 @@ class PresetEditor:
             mt_id = row[0]
             enum_json = (
                 json.dumps(metric.get("values"))
-                if metric.get("source_type") == "manual_enum" and metric.get("values")
+                if metric.get("type") == "enum" and metric.get("values")
                 else None
             )
 
@@ -1860,8 +1822,7 @@ class PresetEditor:
                 cursor.execute(
                     """
                     UPDATE preset_preset_metrics
-                       SET input_type = ?,
-                           source_type = ?,
+                       SET type = ?,
                            input_timing = ?,
                            scope = ?,
                            is_required = ?,
@@ -1872,8 +1833,7 @@ class PresetEditor:
                      WHERE id = ?
                     """,
                     (
-                        metric.get("input_type"),
-                        metric.get("source_type"),
+                        metric.get("type"),
                         _to_db_timing(metric.get("input_timing")),
                         metric.get("scope"),
                         int(metric.get("is_required", False)),
@@ -1890,8 +1850,7 @@ class PresetEditor:
                         (
                             preset_id,
                             library_metric_type_id,
-                            input_type,
-                            source_type,
+                            type,
                             input_timing,
                             scope,
                             is_required,
@@ -1899,13 +1858,12 @@ class PresetEditor:
                             position,
                             value
                         )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         preset_id,
                         mt_id,
-                        metric.get("input_type"),
-                        metric.get("source_type"),
+                        metric.get("type"),
                         _to_db_timing(metric.get("input_timing")),
                         metric.get("scope"),
                         int(metric.get("is_required", False)),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,26 +20,26 @@ def sample_db(tmp_path: Path) -> Path:
     conn.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES (?, ?, ?, ?, ?, ?, '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES (?, ?, ?, ?, ?, '', 0)
         """,
-        ("Reps", "int", "manual_text", "post_set", 1, "set"),
+        ("Reps", "int", "post_set", 1, "set"),
     )
     conn.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES (?, ?, ?, ?, ?, ?, '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES (?, ?, ?, ?, ?, '', 0)
         """,
-        ("Weight", "float", "manual_text", "pre_set", 0, "set"),
+        ("Weight", "float", "pre_set", 0, "set"),
     )
     conn.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES (?, ?, ?, ?, ?, ?, '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES (?, ?, ?, ?, ?, '', 0)
         """,
-        ("Machine", "str", "manual_enum", "pre_session", 0, "exercise"),
+        ("Machine", "enum", "pre_session", 0, "exercise"),
     )
 
     reps_id = conn.execute("SELECT id FROM library_metric_types WHERE name='Reps'").fetchone()[0]
@@ -119,32 +119,32 @@ def sample_db(tmp_path: Path) -> Path:
     conn.execute(
         """
         INSERT INTO preset_exercise_metrics
-            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
-        VALUES (?, 'Reps', 'int', 'manual_text', 'post_set', 1, 'set', ?)
+            (section_exercise_id, metric_name, type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Reps', 'int', 'post_set', 1, 'set', ?)
         """,
         (push_se_id, reps_id),
     )
     conn.execute(
         """
         INSERT INTO preset_exercise_metrics
-            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
-        VALUES (?, 'Reps', 'int', 'manual_text', 'pre_set', 1, 'set', ?)
+            (section_exercise_id, metric_name, type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Reps', 'int', 'pre_set', 1, 'set', ?)
         """,
         (bench_se_id, reps_id),
     )
     conn.execute(
         """
         INSERT INTO preset_exercise_metrics
-            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
-        VALUES (?, 'Weight', 'float', 'manual_text', 'pre_set', 0, 'set', ?)
+            (section_exercise_id, metric_name, type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Weight', 'float', 'pre_set', 0, 'set', ?)
         """,
         (bench_se_id, weight_id),
     )
     conn.execute(
         """
         INSERT INTO preset_exercise_metrics
-            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, enum_values_json, library_metric_type_id)
-        VALUES (?, 'Machine', 'str', 'manual_enum', 'pre_session', 0, 'exercise', ?, ?)
+            (section_exercise_id, metric_name, type, input_timing, is_required, scope, enum_values_json, library_metric_type_id)
+        VALUES (?, 'Machine', 'enum', 'pre_session', 0, 'exercise', ?, ?)
         """,
         (bench_se_id, '["A","B"]', machine_id),
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,12 +17,12 @@ def sample_db(tmp_path):
     cur = conn.cursor()
     # metric types
     cur.execute(
-        "INSERT INTO library_metric_types (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created) "
-        "VALUES ('Reps', 'int', 'manual_text', 'post_set', 1, 'set', '', 0)"
+        "INSERT INTO library_metric_types (name, type, input_timing, is_required, scope, description, is_user_created) "
+        "VALUES ('Reps', 'int', 'post_set', 1, 'set', '', 0)"
     )
     cur.execute(
-        "INSERT INTO library_metric_types (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created) "
-        "VALUES ('Weight', 'float', 'manual_text', 'post_set', 0, 'set', '', 0)"
+        "INSERT INTO library_metric_types (name, type, input_timing, is_required, scope, description, is_user_created) "
+        "VALUES ('Weight', 'float', 'post_set', 0, 'set', '', 0)"
     )
     # exercises
     cur.execute("INSERT INTO library_exercises (name, description, is_user_created) VALUES ('Push Up', 'Upper body', 0)")
@@ -97,8 +97,7 @@ def test_get_metrics_with_override(sample_db):
 def test_add_and_remove_metric(sample_db):
     metric_id = core.add_metric_type(
         name="Tempo",
-        input_type="int",
-        source_type="manual_text",
+        metric_type="int",
         input_timing="post_set",
         scope="set",
         db_path=sample_db,
@@ -214,8 +213,7 @@ def test_override_with_user_flag(sample_db):
 def test_delete_metric_type(sample_db):
     metric_id = core.add_metric_type(
         name="Tempo",
-        input_type="int",
-        source_type="manual_text",
+        metric_type="int",
         input_timing="post_set",
         scope="set",
         db_path=sample_db,

--- a/tests/test_database_helpers.py
+++ b/tests/test_database_helpers.py
@@ -9,8 +9,7 @@ def test_get_all_exercises(sample_db):
     ex.name = "Custom"
     ex.add_metric({
         "name": "Reps",
-        "input_type": "int",
-        "source_type": "manual_text",
+        "type": "int",
         "input_timing": "post_set",
         "is_required": True,
         "scope": "set",

--- a/tests/test_exercise_model.py
+++ b/tests/test_exercise_model.py
@@ -7,8 +7,7 @@ def test_exercise_load_modify_save(sample_db):
     assert any(m["name"] == "Reps" for m in ex.metrics)
     ex.add_metric({
         "name": "Weight",
-        "input_type": "float",
-        "source_type": "manual_text",
+        "type": "float",
         "input_timing": "pre_set",
         "is_required": False,
         "scope": "set",

--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -208,8 +208,8 @@ def test_save_preserves_metric_overrides(db_copy):
     cur.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES ('Reps', 'int', 'manual_text', 'post_set', 0, 'set', '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES ('Reps', 'int', 'post_set', 0, 'set', '', 0)
         """
     )
     mt_id = cur.lastrowid
@@ -226,8 +226,7 @@ def test_save_preserves_metric_overrides(db_copy):
     cur.execute(
         """
         UPDATE library_exercise_metrics
-           SET input_type = 'int',
-               source_type = 'manual_text',
+           SET type = 'int',
                input_timing = 'pre_session',
                is_required = 1,
                scope = 'set'
@@ -262,8 +261,8 @@ def test_save_preset_metadata(db_copy):
     cur.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES ('Difficulty', 'int', 'manual_text', 'preset', 0, 'preset', '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES ('Difficulty', 'int', 'preset', 0, 'preset', '', 0)
         """
     )
     conn.commit()
@@ -280,7 +279,7 @@ def test_save_preset_metadata(db_copy):
     cur = conn.cursor()
     cur.execute(
         """
-        SELECT input_type, source_type, input_timing, scope, is_required, value
+        SELECT type, input_timing, scope, is_required, value
         FROM preset_preset_metrics WHERE deleted = 0
         """
     )
@@ -288,7 +287,7 @@ def test_save_preset_metadata(db_copy):
     conn.close()
     editor.close()
 
-    assert row == ("int", "manual_text", "preset", "preset", 0, "3")
+    assert row == ("int", "preset", "preset", 0, "3")
 
 
 def test_session_metric_timing_alias(db_copy):
@@ -297,8 +296,8 @@ def test_session_metric_timing_alias(db_copy):
     cur.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES ('Marker', 'int', 'manual_text', 'pre_session', 0, 'session', '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES ('Marker', 'int', 'pre_session', 0, 'session', '', 0)
         """
     )
     conn.commit()

--- a/tests/test_workout_db.py
+++ b/tests/test_workout_db.py
@@ -31,10 +31,10 @@ def populate_sample_data(db_path: Path) -> None:
     )
     # Metric types
     cur.executemany(
-        "INSERT INTO library_metric_types (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created) VALUES (?, ?, ?, ?, ?, ?, ?, 1)",
+        "INSERT INTO library_metric_types (name, type, input_timing, is_required, scope, description, is_user_created) VALUES (?, ?, ?, ?, ?, ?, 1)",
         [
-            ("Reps", "int", "manual_text", "post_set", 1, "set", "Number of reps"),
-            ("Weight", "float", "manual_text", "post_set", 0, "set", "Weight used"),
+            ("Reps", "int", "post_set", 1, "set", "Number of reps"),
+            ("Weight", "float", "post_set", 0, "set", "Weight used"),
         ],
     )
     # Preset with one section and two exercises
@@ -89,9 +89,9 @@ def sample_db(tmp_db: Path) -> Path:
 def test_get_metric_type_schema(tmp_db: Path):
     fields = core.get_metric_type_schema(db_path=tmp_db)
     names = {f["name"] for f in fields}
-    assert names == {"name", "input_type", "source_type", "input_timing", "is_required", "scope", "description", "enum_values_json"}
-    input_type_opts = next(f["options"] for f in fields if f["name"] == "input_type")
-    assert set(input_type_opts) == {"int", "float", "str", "bool"}
+    assert names == {"name", "type", "input_timing", "is_required", "scope", "description", "enum_values_json"}
+    type_opts = next(f["options"] for f in fields if f["name"] == "type")
+    assert set(type_opts) == {"int", "float", "str", "bool", "enum", "slider"}
 
 
 def test_get_all_exercises_and_details(sample_db: Path):


### PR DESCRIPTION
## Summary
- merge `input_type` and `source_type` columns into single `type`
- update helper functions and overrides to use `metric_type`
- adjust tests and fixtures for new schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b49e168748332b9d306eec9496960