### PR TITLE
Update tests for revised metric schema

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,26 +20,26 @@ def sample_db(tmp_path: Path) -> Path:
     conn.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES (?, ?, ?, ?, ?, ?, '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES (?, ?, ?, ?, ?, '', 0)
         """,
-        ("Reps", "int", "manual_text", "post_set", 1, "set"),
+        ("Reps", "int", "post_set", 1, "set"),
     )
     conn.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES (?, ?, ?, ?, ?, ?, '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES (?, ?, ?, ?, ?, '', 0)
         """,
-        ("Weight", "float", "manual_text", "pre_set", 0, "set"),
+        ("Weight", "float", "pre_set", 0, "set"),
     )
     conn.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES (?, ?, ?, ?, ?, ?, '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES (?, ?, ?, ?, ?, '', 0)
         """,
-        ("Machine", "str", "manual_enum", "pre_session", 0, "exercise"),
+        ("Machine", "enum", "pre_session", 0, "exercise"),
     )
 
     reps_id = conn.execute("SELECT id FROM library_metric_types WHERE name='Reps'").fetchone()[0]
@@ -119,32 +119,32 @@ def sample_db(tmp_path: Path) -> Path:
     conn.execute(
         """
         INSERT INTO preset_exercise_metrics
-            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
-        VALUES (?, 'Reps', 'int', 'manual_text', 'post_set', 1, 'set', ?)
+            (section_exercise_id, metric_name, type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Reps', 'int', 'post_set', 1, 'set', ?)
         """,
         (push_se_id, reps_id),
     )
     conn.execute(
         """
         INSERT INTO preset_exercise_metrics
-            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
-        VALUES (?, 'Reps', 'int', 'manual_text', 'pre_set', 1, 'set', ?)
+            (section_exercise_id, metric_name, type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Reps', 'int', 'pre_set', 1, 'set', ?)
         """,
         (bench_se_id, reps_id),
     )
     conn.execute(
         """
         INSERT INTO preset_exercise_metrics
-            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, library_metric_type_id)
-        VALUES (?, 'Weight', 'float', 'manual_text', 'pre_set', 0, 'set', ?)
+            (section_exercise_id, metric_name, type, input_timing, is_required, scope, library_metric_type_id)
+        VALUES (?, 'Weight', 'float', 'pre_set', 0, 'set', ?)
         """,
         (bench_se_id, weight_id),
     )
     conn.execute(
         """
         INSERT INTO preset_exercise_metrics
-            (section_exercise_id, metric_name, input_type, source_type, input_timing, is_required, scope, enum_values_json, library_metric_type_id)
-        VALUES (?, 'Machine', 'str', 'manual_enum', 'pre_session', 0, 'exercise', ?, ?)
+            (section_exercise_id, metric_name, type, input_timing, is_required, scope, enum_values_json, library_metric_type_id)
+        VALUES (?, 'Machine', 'enum', 'pre_session', 0, 'exercise', ?, ?)
         """,
         (bench_se_id, '["A","B"]', machine_id),
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,12 +17,12 @@ def sample_db(tmp_path):
     cur = conn.cursor()
     # metric types
     cur.execute(
-        "INSERT INTO library_metric_types (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created) "
-        "VALUES ('Reps', 'int', 'manual_text', 'post_set', 1, 'set', '', 0)"
+        "INSERT INTO library_metric_types (name, type, input_timing, is_required, scope, description, is_user_created) "
+        "VALUES ('Reps', 'int', 'post_set', 1, 'set', '', 0)"
     )
     cur.execute(
-        "INSERT INTO library_metric_types (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created) "
-        "VALUES ('Weight', 'float', 'manual_text', 'post_set', 0, 'set', '', 0)"
+        "INSERT INTO library_metric_types (name, type, input_timing, is_required, scope, description, is_user_created) "
+        "VALUES ('Weight', 'float', 'post_set', 0, 'set', '', 0)"
     )
     # exercises
     cur.execute("INSERT INTO library_exercises (name, description, is_user_created) VALUES ('Push Up', 'Upper body', 0)")
@@ -97,8 +97,7 @@ def test_get_metrics_with_override(sample_db):
 def test_add_and_remove_metric(sample_db):
     metric_id = core.add_metric_type(
         name="Tempo",
-        input_type="int",
-        source_type="manual_text",
+        mtype="int",
         input_timing="post_set",
         scope="set",
         db_path=sample_db,
@@ -214,8 +213,7 @@ def test_override_with_user_flag(sample_db):
 def test_delete_metric_type(sample_db):
     metric_id = core.add_metric_type(
         name="Tempo",
-        input_type="int",
-        source_type="manual_text",
+        mtype="int",
         input_timing="post_set",
         scope="set",
         db_path=sample_db,

--- a/tests/test_database_helpers.py
+++ b/tests/test_database_helpers.py
@@ -9,8 +9,7 @@ def test_get_all_exercises(sample_db):
     ex.name = "Custom"
     ex.add_metric({
         "name": "Reps",
-        "input_type": "int",
-        "source_type": "manual_text",
+        "type": "int",
         "input_timing": "post_set",
         "is_required": True,
         "scope": "set",

--- a/tests/test_exercise_model.py
+++ b/tests/test_exercise_model.py
@@ -7,8 +7,7 @@ def test_exercise_load_modify_save(sample_db):
     assert any(m["name"] == "Reps" for m in ex.metrics)
     ex.add_metric({
         "name": "Weight",
-        "input_type": "float",
-        "source_type": "manual_text",
+        "type": "float",
         "input_timing": "pre_set",
         "is_required": False,
         "scope": "set",

--- a/tests/test_preset_editor.py
+++ b/tests/test_preset_editor.py
@@ -208,8 +208,8 @@ def test_save_preserves_metric_overrides(db_copy):
     cur.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES ('Reps', 'int', 'manual_text', 'post_set', 0, 'set', '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES ('Reps', 'int', 'post_set', 0, 'set', '', 0)
         """
     )
     mt_id = cur.lastrowid
@@ -226,8 +226,7 @@ def test_save_preserves_metric_overrides(db_copy):
     cur.execute(
         """
         UPDATE library_exercise_metrics
-           SET input_type = 'int',
-               source_type = 'manual_text',
+           SET type = 'int',
                input_timing = 'pre_session',
                is_required = 1,
                scope = 'set'
@@ -262,8 +261,8 @@ def test_save_preset_metadata(db_copy):
     cur.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES ('Difficulty', 'int', 'manual_text', 'preset', 0, 'preset', '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES ('Difficulty', 'int', 'preset', 0, 'preset', '', 0)
         """
     )
     conn.commit()
@@ -280,7 +279,7 @@ def test_save_preset_metadata(db_copy):
     cur = conn.cursor()
     cur.execute(
         """
-        SELECT input_type, source_type, input_timing, scope, is_required, value
+        SELECT type, input_timing, scope, is_required, value
         FROM preset_preset_metrics WHERE deleted = 0
         """
     )
@@ -288,7 +287,7 @@ def test_save_preset_metadata(db_copy):
     conn.close()
     editor.close()
 
-    assert row == ("int", "manual_text", "preset", "preset", 0, "3")
+    assert row == ("int", "preset", "preset", 0, "3")
 
 
 def test_session_metric_timing_alias(db_copy):
@@ -297,8 +296,8 @@ def test_session_metric_timing_alias(db_copy):
     cur.execute(
         """
         INSERT INTO library_metric_types
-            (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created)
-        VALUES ('Marker', 'int', 'manual_text', 'pre_session', 0, 'session', '', 0)
+            (name, type, input_timing, is_required, scope, description, is_user_created)
+        VALUES ('Marker', 'int', 'pre_session', 0, 'session', '', 0)
         """
     )
     conn.commit()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -82,7 +82,7 @@ def test_enum_values_accepts_spaces():
         exercise_obj = type("obj", (), {"metrics": []})()
 
     popup = AddMetricPopup(DummyScreen(), mode="new")
-    popup.input_widgets["input_type"].text = "str"
+    popup.input_widgets["type"].text = "str"
     filtered = popup.enum_values_field.input_filter("A B,C", False)
     assert filtered == "A B,C"
 
@@ -93,7 +93,7 @@ def test_enum_values_strip_spaces_after_comma():
         exercise_obj = type("obj", (), {"metrics": []})()
 
     popup = AddMetricPopup(DummyScreen(), mode="new")
-    popup.input_widgets["input_type"].text = "str"
+    popup.input_widgets["type"].text = "str"
     filtered = popup.enum_values_field.input_filter("A, B ,  C", False)
     assert filtered == "A,B,C"
 
@@ -111,7 +111,7 @@ def test_add_metric_popup_has_single_enum_field():
         if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
     ]
     assert len(enum_fields) == 0
-    popup.input_widgets["source_type"].text = "manual_enum"
+    popup.input_widgets["type"].text = "enum"
     children = popup.content_cls.children[0].children
     enum_fields = [
         c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
@@ -125,8 +125,7 @@ def test_edit_metric_popup_has_single_enum_field():
         metrics = [
             {
                 "name": "Machine",
-                "input_type": "int",
-                "source_type": "manual_enum",
+                "type": "enum",
                 "values": ["A", "B"],
             }
         ]
@@ -147,13 +146,13 @@ def test_edit_metric_popup_has_single_enum_field():
         if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
     ]
     assert len(enum_fields) == 1
-    popup.input_widgets["source_type"].text = "manual_text"
+    popup.input_widgets["type"].text = "int"
     children = popup.content_cls.children[0].children
     enum_fields = [
         c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
     ]
     assert len(enum_fields) == 0
-    popup.input_widgets["source_type"].text = "manual_enum"
+    popup.input_widgets["type"].text = "enum"
     children = popup.content_cls.children[0].children
     enum_fields = [
         c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
@@ -167,8 +166,7 @@ def test_edit_metric_popup_no_duplicate_field():
         metrics = [
             {
                 "name": "Machine",
-                "input_type": "int",
-                "source_type": "manual_enum",
+                "type": "enum",
                 "values": ["A", "B"],
             }
         ]
@@ -473,8 +471,7 @@ def test_edit_metric_type_popup_enum_field_visibility():
         all_metrics = [
             {
                 "name": "Speed",
-                "input_type": "int",
-                "source_type": "manual_text",
+                "type": "int",
                 "is_user_created": True,
             }
         ]
@@ -485,7 +482,7 @@ def test_edit_metric_type_popup_enum_field_visibility():
         c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
     ]
     assert len(enum_fields) == 0
-    popup.input_widgets["source_type"].text = "manual_enum"
+    popup.input_widgets["type"].text = "enum"
     children = popup.content_cls.children[0].children
     enum_fields = [
         c for c in children if getattr(c, "hint_text", "") == "Enum Values (comma separated)"
@@ -499,8 +496,7 @@ def test_edit_metric_type_popup_loads_enum_values():
         all_metrics = [
             {
                 "name": "Side",
-                "input_type": "str",
-                "source_type": "manual_enum",
+                "type": "enum",
                 "is_user_created": True,
                 "enum_values_json": "[\"Left\", \"Right\", \"None\"]",
             }
@@ -583,16 +579,14 @@ def test_edit_preset_populate_details(monkeypatch):
     metrics = [
         {
             "name": "Focus",
-            "input_type": "str",
-            "source_type": "manual_text",
+            "type": "str",
             "scope": "preset",
             "enum_values_json": None,
             "input_timing": "preset",
         },
         {
             "name": "Level",
-            "input_type": "int",
-            "source_type": "manual_text",
+            "type": "int",
             "scope": "preset",
             "enum_values_json": None,
             "input_timing": "preset",

--- a/tests/test_workout_db.py
+++ b/tests/test_workout_db.py
@@ -31,10 +31,10 @@ def populate_sample_data(db_path: Path) -> None:
     )
     # Metric types
     cur.executemany(
-        "INSERT INTO library_metric_types (name, input_type, source_type, input_timing, is_required, scope, description, is_user_created) VALUES (?, ?, ?, ?, ?, ?, ?, 1)",
+        "INSERT INTO library_metric_types (name, type, input_timing, is_required, scope, description, is_user_created) VALUES (?, ?, ?, ?, ?, ?, 1)",
         [
-            ("Reps", "int", "manual_text", "post_set", 1, "set", "Number of reps"),
-            ("Weight", "float", "manual_text", "post_set", 0, "set", "Weight used"),
+            ("Reps", "int", "post_set", 1, "set", "Number of reps"),
+            ("Weight", "float", "post_set", 0, "set", "Weight used"),
         ],
     )
     # Preset with one section and two exercises
@@ -89,9 +89,9 @@ def sample_db(tmp_db: Path) -> Path:
 def test_get_metric_type_schema(tmp_db: Path):
     fields = core.get_metric_type_schema(db_path=tmp_db)
     names = {f["name"] for f in fields}
-    assert names == {"name", "input_type", "source_type", "input_timing", "is_required", "scope", "description", "enum_values_json"}
-    input_type_opts = next(f["options"] for f in fields if f["name"] == "input_type")
-    assert set(input_type_opts) == {"int", "float", "str", "bool"}
+    assert names == {"name", "type", "input_timing", "is_required", "scope", "description", "enum_values_json"}
+    type_opts = next(f["options"] for f in fields if f["name"] == "type")
+    assert set(type_opts) == {"int", "float", "str", "bool", "enum", "slider"}
 
 
 def test_get_all_exercises_and_details(sample_db: Path):


### PR DESCRIPTION
## Summary
- update fixtures and tests to use `type` column for metric definitions
- adjust UI tests for new metric type handling

## Testing
- `pytest -q` *(fails: sqlite3.OperationalError: no such column: source_type)*

------
https://chatgpt.com/codex/tasks/task_e_688b4ff86c8c8332877501ee428df1e5