### PR TITLE
Fix metric editing crash

### DIFF
--- a/core.py
+++ b/core.py
@@ -1062,9 +1062,9 @@ def save_exercise(exercise: Exercise) -> None:
             if m.get("input_timing") != def_timing:
 
                 timing = m.get("input_timing")
-            if bool(m.get("is_required")) != bool(d_req):
+            if bool(m.get("is_required")) != bool(def_req):
                 req = int(m.get("is_required", False))
-            if m.get("scope") != d_scope:
+            if m.get("scope") != def_scope:
                 scope_val = m.get("scope")
 
         cursor.execute(

--- a/main.py
+++ b/main.py
@@ -2553,7 +2553,7 @@ class EditMetricTypePopup(MDDialog):
         if self.metric and self.is_user_created:
             core.update_metric_type(
                 self.metric_name,
-                type=data.get("type"),
+                mtype=data.get("type"),
                 input_timing=data.get("input_timing"),
                 scope=data.get("scope"),
                 description=data.get("description"),


### PR DESCRIPTION
## Summary
- fix incorrect kwarg in metric update call
- use proper variables for defaults when saving exercises

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b588a527083329844bcb2c8e68348