### PR TITLE
Fix AddMetricPopup type default

### DIFF
--- a/main.py
+++ b/main.py
@@ -1794,7 +1794,7 @@ class AddMetricPopup(MDDialog):
                 metric[key] = bool(widget.active)
             else:
                 metric[key] = widget.text
-        metric_type = metric.pop("type", mtype)
+        metric_type = metric.pop("type", metric_type)
         metric["type"] = metric_type
         if values:
             metric["values"] = values


### PR DESCRIPTION
## Summary
- resolve undefined variable in `AddMetricPopup.save_metric()`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b68cb64808332924636e682be7765