### PR TITLE
Add preset exercise check when deleting metric types

### DIFF
--- a/core.py
+++ b/core.py
@@ -1176,9 +1176,16 @@ def delete_metric_type(
         raise ValueError("Metric type is in use and cannot be deleted")
 
     cursor.execute(
-
         "SELECT 1 FROM preset_preset_metrics WHERE library_metric_type_id = ? AND deleted = 0 LIMIT 1",
+        (mt_id,),
+    )
+    if cursor.fetchone():
+        conn.close()
+        raise ValueError("Metric type is in use and cannot be deleted")
 
+    cursor.execute(
+        "SELECT 1 FROM preset_exercise_metrics "
+        "WHERE library_metric_type_id = ? AND deleted = 0 LIMIT 1",
         (mt_id,),
     )
     if cursor.fetchone():


### PR DESCRIPTION
## Summary
- prevent deleting metric types used by preset_exercise_metrics
- test that deleting an in-use metric type raises an error

## Testing
- `pytest tests/test_core.py::test_delete_metric_type_in_use_by_preset_exercise -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b68cc3ea88332944b5fca15c29b0f