### PR TITLE
Move PresetDetailScreen to separate module

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ except Exception:  # pragma: no cover - fallback for tests without kivymd
     from kivy.uix.spinner import Spinner as MDSpinner
 from kivymd.uix.button import MDRaisedButton
 from kivy.uix.screenmanager import NoTransition
+from ui.screens.preset_detail_screen import PresetDetailScreen
 from pathlib import Path
 import os
 import sys
@@ -469,10 +470,6 @@ class PresetsScreen(MDScreen):
             detail = self.manager.get_screen("preset_detail")
             detail.preset_name = self.selected_preset
             self.manager.current = "preset_detail"
-
-
-class PresetDetailScreen(MDScreen):
-    preset_name = StringProperty("")
 
 
 class ExerciseLibraryScreen(MDScreen):

--- a/ui/screens/__init__.py
+++ b/ui/screens/__init__.py
@@ -1,0 +1,1 @@
+from .preset_detail_screen import PresetDetailScreen

--- a/ui/screens/preset_detail_screen.py
+++ b/ui/screens/preset_detail_screen.py
@@ -1,0 +1,9 @@
+from kivymd.uix.screen import MDScreen
+from kivy.properties import StringProperty
+
+
+class PresetDetailScreen(MDScreen):
+    """Screen showing details for a workout preset."""
+
+    preset_name = StringProperty("")
+


### PR DESCRIPTION
## Summary
- create `ui/screens/preset_detail_screen.py`
- import the new screen in `main.py`
- delete old inline class definition
- expose screen via `ui.screens`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bdc7005f083328c77c2d09d803e49