### PR TITLE
Move RestScreen to dedicated module

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,7 @@ import math
 from kivy.core.window import Window
 import string
 import sqlite3
+from ui.screens.rest_screen import RestScreen
 
 if os.name == "nt" or sys.platform.startswith("win"):
     Window.size = (280, 280 * (20 / 9))
@@ -123,86 +124,6 @@ class WorkoutActiveScreen(MDScreen):
         self.elapsed = time.time() - self.start_time
         minutes, seconds = divmod(int(self.elapsed), 60)
         self.formatted_time = f"{minutes:02d}:{seconds:02d}"
-
-
-class RestScreen(MDScreen):
-    timer_label = StringProperty("00:20")
-    target_time = NumericProperty(0)
-    next_exercise_name = StringProperty("")
-    is_ready = BooleanProperty(False)
-    timer_color = ListProperty([1, 0, 0, 1])
-
-    def on_enter(self, *args):
-        session = MDApp.get_running_app().workout_session
-        if session:
-            self.next_exercise_name = session.next_exercise_display()
-            self.target_time = session.rest_target_time
-        else:
-            self.target_time = time.time() + DEFAULT_REST_DURATION
-        self.is_ready = False
-        self.timer_color = (1, 0, 0, 1)
-        self.update_timer(0)
-        self._event = Clock.schedule_interval(self.update_timer, 0.1)
-        return super().on_enter(*args)
-
-    def on_leave(self, *args):
-        if hasattr(self, "_event") and self._event:
-            self._event.cancel()
-        return super().on_leave(*args)
-
-    def toggle_ready(self):
-        self.is_ready = not self.is_ready
-        self.timer_color = (0, 1, 0, 1) if self.is_ready else (1, 0, 0, 1)
-        if self.is_ready and self.target_time <= time.time():
-            if hasattr(self, "_event") and self._event:
-                self._event.cancel()
-                self._event = None
-            if self.manager:
-                self.manager.current = "workout_active"
-
-    def on_touch_down(self, touch):
-        if self.ids.timer_label.collide_point(*touch.pos):
-            self.toggle_ready()
-            return True
-        return super().on_touch_down(touch)
-
-    def update_timer(self, dt):
-        remaining = self.target_time - time.time()
-        if remaining <= 0:
-            self.timer_label = "00:00"
-            if hasattr(self, "_event") and self._event:
-                self._event.cancel()
-                self._event = None
-            if self.is_ready and self.manager:
-                self.manager.current = "workout_active"
-        else:
-            total_seconds = math.ceil(remaining)
-            minutes, seconds = divmod(total_seconds, 60)
-            self.timer_label = f"{minutes:02d}:{seconds:02d}"
-
-    def adjust_timer(self, seconds):
-        session = MDApp.get_running_app().workout_session
-        if session:
-            session.adjust_rest_timer(seconds)
-            self.target_time = session.rest_target_time
-        else:
-            now = time.time()
-            if self.target_time <= now:
-                self.target_time = now
-            self.target_time += seconds
-            if self.target_time <= now:
-                self.target_time = now
-        if self.target_time <= time.time():
-            if hasattr(self, "_event") and self._event:
-                self._event.cancel()
-                self._event = None
-            self.update_timer(0)
-            if self.is_ready and self.manager:
-                self.manager.current = "workout_active"
-        else:
-            if not hasattr(self, "_event") or not self._event:
-                self._event = Clock.schedule_interval(self.update_timer, 0.1)
-            self.update_timer(0)
 
 
 class MetricInputScreen(MDScreen):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -19,7 +19,6 @@ if kivy_available:
     import core
 
     from main import (
-        RestScreen,
         MetricInputScreen,
         WorkoutActiveScreen,
         AddMetricPopup,
@@ -30,6 +29,7 @@ if kivy_available:
         PresetsScreen,
         EditPresetScreen,
     )
+    from ui.screens.rest_screen import RestScreen
     import time
 
     class _DummyApp:

--- a/ui/screens/rest_screen.py
+++ b/ui/screens/rest_screen.py
@@ -1,0 +1,90 @@
+from kivymd.app import MDApp
+from kivymd.uix.screen import MDScreen
+from kivy.properties import StringProperty, NumericProperty, BooleanProperty, ListProperty
+from kivy.clock import Clock
+import time
+import math
+
+from core import DEFAULT_REST_DURATION
+
+
+class RestScreen(MDScreen):
+    """Screen displayed between exercises showing a rest timer."""
+
+    timer_label = StringProperty("00:20")
+    target_time = NumericProperty(0)
+    next_exercise_name = StringProperty("")
+    is_ready = BooleanProperty(False)
+    timer_color = ListProperty([1, 0, 0, 1])
+
+    def on_enter(self, *args):
+        session = MDApp.get_running_app().workout_session
+        if session:
+            self.next_exercise_name = session.next_exercise_display()
+            self.target_time = session.rest_target_time
+        else:
+            self.target_time = time.time() + DEFAULT_REST_DURATION
+        self.is_ready = False
+        self.timer_color = (1, 0, 0, 1)
+        self.update_timer(0)
+        self._event = Clock.schedule_interval(self.update_timer, 0.1)
+        return super().on_enter(*args)
+
+    def on_leave(self, *args):
+        if hasattr(self, "_event") and self._event:
+            self._event.cancel()
+        return super().on_leave(*args)
+
+    def toggle_ready(self):
+        self.is_ready = not self.is_ready
+        self.timer_color = (0, 1, 0, 1) if self.is_ready else (1, 0, 0, 1)
+        if self.is_ready and self.target_time <= time.time():
+            if hasattr(self, "_event") and self._event:
+                self._event.cancel()
+                self._event = None
+            if self.manager:
+                self.manager.current = "workout_active"
+
+    def on_touch_down(self, touch):
+        if self.ids.timer_label.collide_point(*touch.pos):
+            self.toggle_ready()
+            return True
+        return super().on_touch_down(touch)
+
+    def update_timer(self, dt):
+        remaining = self.target_time - time.time()
+        if remaining <= 0:
+            self.timer_label = "00:00"
+            if hasattr(self, "_event") and self._event:
+                self._event.cancel()
+                self._event = None
+            if self.is_ready and self.manager:
+                self.manager.current = "workout_active"
+        else:
+            total_seconds = math.ceil(remaining)
+            minutes, seconds = divmod(total_seconds, 60)
+            self.timer_label = f"{minutes:02d}:{seconds:02d}"
+
+    def adjust_timer(self, seconds):
+        session = MDApp.get_running_app().workout_session
+        if session:
+            session.adjust_rest_timer(seconds)
+            self.target_time = session.rest_target_time
+        else:
+            now = time.time()
+            if self.target_time <= now:
+                self.target_time = now
+            self.target_time += seconds
+            if self.target_time <= now:
+                self.target_time = now
+        if self.target_time <= time.time():
+            if hasattr(self, "_event") and self._event:
+                self._event.cancel()
+                self._event = None
+            self.update_timer(0)
+            if self.is_ready and self.manager:
+                self.manager.current = "workout_active"
+        else:
+            if not hasattr(self, "_event") or not self._event:
+                self._event = Clock.schedule_interval(self.update_timer, 0.1)
+            self.update_timer(0)


### PR DESCRIPTION
## Summary
- move `RestScreen` implementation out of `main.py`
- create `ui/screens/rest_screen.py`
- import new module in `main.py`
- update tests to reference the new location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bdc33e28c8332baf02cc2c6a73ed6