### PR TITLE
Expose screen modules via ui package

### DIFF
--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,6 @@
+"""UI package exposing available screens."""
+
+from .screens import PresetOverviewScreen
+
+__all__ = ["PresetOverviewScreen"]
+

--- a/ui/screens/__init__.py
+++ b/ui/screens/__init__.py
@@ -1,0 +1,6 @@
+"""UI screen package."""
+
+from .preset_overview_screen import PresetOverviewScreen
+
+__all__ = ["PresetOverviewScreen"]
+


### PR DESCRIPTION
## Summary
- re-export PresetOverviewScreen in ui.screens
- expose available screen modules directly via ui package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688be0ecda748332839585c37046e12a