### PR TITLE
Move RestScreen to dedicated screen module

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,7 @@ from core import (
     DEFAULT_DB_PATH,
 )
 from ui.screens.metric_input_screen import MetricInputScreen
+from ui.screens.rest_screen import RestScreen
 
 # Load workout presets from the database at startup
 load_workout_presets(DEFAULT_DB_PATH)
@@ -96,84 +97,6 @@ class LoadingDialog(MDDialog):
         super().__init__(type="custom", content_cls=box, **kwargs)
 
 
-class RestScreen(MDScreen):
-    timer_label = StringProperty("00:20")
-    target_time = NumericProperty(0)
-    next_exercise_name = StringProperty("")
-    is_ready = BooleanProperty(False)
-    timer_color = ListProperty([1, 0, 0, 1])
-
-    def on_enter(self, *args):
-        session = MDApp.get_running_app().workout_session
-        if session:
-            self.next_exercise_name = session.next_exercise_display()
-            self.target_time = session.rest_target_time
-        else:
-            self.target_time = time.time() + DEFAULT_REST_DURATION
-        self.is_ready = False
-        self.timer_color = (1, 0, 0, 1)
-        self.update_timer(0)
-        self._event = Clock.schedule_interval(self.update_timer, 0.1)
-        return super().on_enter(*args)
-
-    def on_leave(self, *args):
-        if hasattr(self, "_event") and self._event:
-            self._event.cancel()
-        return super().on_leave(*args)
-
-    def toggle_ready(self):
-        self.is_ready = not self.is_ready
-        self.timer_color = (0, 1, 0, 1) if self.is_ready else (1, 0, 0, 1)
-        if self.is_ready and self.target_time <= time.time():
-            if hasattr(self, "_event") and self._event:
-                self._event.cancel()
-                self._event = None
-            if self.manager:
-                self.manager.current = "workout_active"
-
-    def on_touch_down(self, touch):
-        if self.ids.timer_label.collide_point(*touch.pos):
-            self.toggle_ready()
-            return True
-        return super().on_touch_down(touch)
-
-    def update_timer(self, dt):
-        remaining = self.target_time - time.time()
-        if remaining <= 0:
-            self.timer_label = "00:00"
-            if hasattr(self, "_event") and self._event:
-                self._event.cancel()
-                self._event = None
-            if self.is_ready and self.manager:
-                self.manager.current = "workout_active"
-        else:
-            total_seconds = math.ceil(remaining)
-            minutes, seconds = divmod(total_seconds, 60)
-            self.timer_label = f"{minutes:02d}:{seconds:02d}"
-
-    def adjust_timer(self, seconds):
-        session = MDApp.get_running_app().workout_session
-        if session:
-            session.adjust_rest_timer(seconds)
-            self.target_time = session.rest_target_time
-        else:
-            now = time.time()
-            if self.target_time <= now:
-                self.target_time = now
-            self.target_time += seconds
-            if self.target_time <= now:
-                self.target_time = now
-        if self.target_time <= time.time():
-            if hasattr(self, "_event") and self._event:
-                self._event.cancel()
-                self._event = None
-            self.update_timer(0)
-            if self.is_ready and self.manager:
-                self.manager.current = "workout_active"
-        else:
-            if not hasattr(self, "_event") or not self._event:
-                self._event = Clock.schedule_interval(self.update_timer, 0.1)
-            self.update_timer(0)
 
 class MetricInputScreen(MDScreen):
     """Screen for entering workout metrics."""

--- a/ui/screens/__init__.py
+++ b/ui/screens/__init__.py
@@ -14,5 +14,6 @@ from .workout_active_screen import WorkoutActiveScreen
 __all__ = ["WorkoutActiveScreen"]
 
 from .preset_detail_screen import PresetDetailScreen
+from .rest_screen import RestScreen
 
 

--- a/ui/screens/rest_screen.py
+++ b/ui/screens/rest_screen.py
@@ -1,0 +1,89 @@
+from kivymd.app import MDApp
+from kivymd.uix.screen import MDScreen
+from kivy.clock import Clock
+from kivy.properties import NumericProperty, StringProperty, BooleanProperty, ListProperty
+import time
+import math
+from core import DEFAULT_REST_DURATION
+
+
+class RestScreen(MDScreen):
+    """Screen shown between exercises with a rest timer."""
+
+    timer_label = StringProperty("00:20")
+    target_time = NumericProperty(0)
+    next_exercise_name = StringProperty("")
+    is_ready = BooleanProperty(False)
+    timer_color = ListProperty([1, 0, 0, 1])
+
+    def on_enter(self, *args):
+        session = MDApp.get_running_app().workout_session
+        if session:
+            self.next_exercise_name = session.next_exercise_display()
+            self.target_time = session.rest_target_time
+        else:
+            self.target_time = time.time() + DEFAULT_REST_DURATION
+        self.is_ready = False
+        self.timer_color = (1, 0, 0, 1)
+        self.update_timer(0)
+        self._event = Clock.schedule_interval(self.update_timer, 0.1)
+        return super().on_enter(*args)
+
+    def on_leave(self, *args):
+        if hasattr(self, "_event") and self._event:
+            self._event.cancel()
+        return super().on_leave(*args)
+
+    def toggle_ready(self):
+        self.is_ready = not self.is_ready
+        self.timer_color = (0, 1, 0, 1) if self.is_ready else (1, 0, 0, 1)
+        if self.is_ready and self.target_time <= time.time():
+            if hasattr(self, "_event") and self._event:
+                self._event.cancel()
+                self._event = None
+            if self.manager:
+                self.manager.current = "workout_active"
+
+    def on_touch_down(self, touch):
+        if self.ids.timer_label.collide_point(*touch.pos):
+            self.toggle_ready()
+            return True
+        return super().on_touch_down(touch)
+
+    def update_timer(self, dt):
+        remaining = self.target_time - time.time()
+        if remaining <= 0:
+            self.timer_label = "00:00"
+            if hasattr(self, "_event") and self._event:
+                self._event.cancel()
+                self._event = None
+            if self.is_ready and self.manager:
+                self.manager.current = "workout_active"
+        else:
+            total_seconds = math.ceil(remaining)
+            minutes, seconds = divmod(total_seconds, 60)
+            self.timer_label = f"{minutes:02d}:{seconds:02d}"
+
+    def adjust_timer(self, seconds):
+        session = MDApp.get_running_app().workout_session
+        if session:
+            session.adjust_rest_timer(seconds)
+            self.target_time = session.rest_target_time
+        else:
+            now = time.time()
+            if self.target_time <= now:
+                self.target_time = now
+            self.target_time += seconds
+            if self.target_time <= now:
+                self.target_time = now
+        if self.target_time <= time.time():
+            if hasattr(self, "_event") and self._event:
+                self._event.cancel()
+                self._event = None
+            self.update_timer(0)
+            if self.is_ready and self.manager:
+                self.manager.current = "workout_active"
+        else:
+            if not hasattr(self, "_event") or not self._event:
+                self._event = Clock.schedule_interval(self.update_timer, 0.1)
+            self.update_timer(0)


### PR DESCRIPTION
## Summary
- create `rest_screen.py` under `ui/screens`
- import RestScreen from new module in `main.py`
- remove inlined RestScreen class from `main.py`
- register RestScreen inside `ui.screens` package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688be668d5e483329523d9e3057f8a27