### PR TITLE
Fix LoadingDialog reference in EditPreset screen

### DIFF
--- a/ui/screens/edit_preset_screen.py
+++ b/ui/screens/edit_preset_screen.py
@@ -194,6 +194,8 @@ class EditPresetScreen(MDScreen):
         if os.environ.get("KIVY_UNITTEST"):
             self._load_preset()
         else:
+            from main import LoadingDialog  # local import to avoid circular dependency
+
             self.loading_dialog = LoadingDialog()
             self.loading_dialog.open()
             Clock.schedule_once(lambda dt: self._load_preset(), 0)


### PR DESCRIPTION
## Summary
- avoid NameError in `EditPresetScreen.on_pre_enter`
- import `LoadingDialog` locally before instantiation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bf240d8508332920484e00c758cd3