### PR TITLE
Fix db path in edit exercise screen

### DIFF
--- a/ui/screens/edit_exercise_screen.py
+++ b/ui/screens/edit_exercise_screen.py
@@ -403,9 +403,7 @@ class EditExerciseScreen(MDScreen):
 
                     removed = [name for name in orig if name not in current]
                     if removed:
-                        db_path = (
-                            Path(__file__).resolve().parent / "data" / "workout.db"
-                        )
+                        db_path = DEFAULT_DB_PATH
                         conn = sqlite3.connect(str(db_path))
                         cur = conn.cursor()
                         cur.execute(


### PR DESCRIPTION
## Summary
- use `DEFAULT_DB_PATH` for the edit exercise screen's preset cleanup logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bf3ff356483329ba1c8d0003c69b3