### PR TITLE
Fix LoadingDialog import in EditExerciseScreen

### DIFF
--- a/ui/screens/edit_exercise_screen.py
+++ b/ui/screens/edit_exercise_screen.py
@@ -136,6 +136,8 @@ class EditExerciseScreen(MDScreen):
         if os.environ.get("KIVY_UNITTEST"):
             self._load_exercise()
         else:
+            from main import LoadingDialog  # local import to avoid circular dependency
+
             self.loading_dialog = LoadingDialog()
             self.loading_dialog.open()
             Clock.schedule_once(lambda dt: self._load_exercise(), 0)


### PR DESCRIPTION
## Summary
- fix missing import for LoadingDialog when entering EditExerciseScreen

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ca05544a48332824f804eb6806fbb