### PR TITLE
Add metric name and description to preset metrics

### DIFF
--- a/core.py
+++ b/core.py
@@ -1287,13 +1287,12 @@ class PresetEditor:
 
         cursor.execute(
             """
-            SELECT mt.name, pm.value, pm.type,
-                   pm.input_timing, pm.is_required, pm.scope,
-                   pm.enum_values_json, mt.description
-              FROM preset_preset_metrics pm
-              JOIN library_metric_types mt ON mt.id = pm.library_metric_type_id
-             WHERE pm.preset_id = ? AND pm.deleted = 0 AND mt.deleted = 0
-             ORDER BY pm.position
+            SELECT metric_name, value, type,
+                   input_timing, is_required, scope,
+                   enum_values_json, metric_description
+              FROM preset_preset_metrics
+             WHERE preset_id = ? AND deleted = 0
+             ORDER BY position
             """,
             (preset_id,),
         )
@@ -1813,6 +1812,8 @@ class PresetEditor:
                        SET type = ?,
                            input_timing = ?,
                            scope = ?,
+                           metric_name = ?,
+                           metric_description = ?,
                            is_required = ?,
                            enum_values_json = ?,
                            position = ?,
@@ -1824,6 +1825,8 @@ class PresetEditor:
                         metric.get("type"),
                         _to_db_timing(metric.get("input_timing")),
                         metric.get("scope"),
+                        metric.get("name"),
+                        metric.get("description"),
                         int(metric.get("is_required", False)),
                         enum_json,
                         pos,
@@ -1838,6 +1841,8 @@ class PresetEditor:
                         (
                             preset_id,
                             library_metric_type_id,
+                            metric_name,
+                            metric_description,
                             type,
                             input_timing,
                             scope,
@@ -1846,11 +1851,13 @@ class PresetEditor:
                             position,
                             value
                         )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         preset_id,
                         mt_id,
+                        metric.get("name"),
+                        metric.get("description"),
                         metric.get("type"),
                         _to_db_timing(metric.get("input_timing")),
                         metric.get("scope"),

--- a/data/workout_data.sql
+++ b/data/workout_data.sql
@@ -160,11 +160,11 @@ INSERT INTO "preset_exercise_metrics" VALUES (510,130,2,'Weight',NULL,'float','p
 INSERT INTO "preset_exercise_metrics" VALUES (511,130,3,'Tempo',NULL,'str','preset','exercise',0,NULL,3,0,NULL);
 INSERT INTO "preset_exercise_metrics" VALUES (512,130,4,'RPE',NULL,'slider','post_set','set',0,NULL,4,0,NULL);
 INSERT INTO "preset_exercise_metrics" VALUES (513,130,6,'Performing Side',NULL,'enum','pre_set','set',1,'["Right", "Left"]',5,0,NULL);
-INSERT INTO "preset_preset_metrics" VALUES (22,1,15,'int','preset','preset',1,NULL,0,0,'1');
-INSERT INTO "preset_preset_metrics" VALUES (23,1,20,'str','preset','preset',0,NULL,1,0,'Calisthenics');
-INSERT INTO "preset_preset_metrics" VALUES (24,1,16,'int','pre_workout','session',1,NULL,2,0,NULL);
-INSERT INTO "preset_preset_metrics" VALUES (25,1,17,'int','pre_workout','session',1,NULL,3,0,NULL);
-INSERT INTO "preset_preset_metrics" VALUES (26,1,18,'int','pre_workout','session',1,NULL,4,0,NULL);
+INSERT INTO "preset_preset_metrics" VALUES (22,1,15,'Day Number','The Day number the preset is in your workout plan','int','preset','preset',1,NULL,0,0,'1');
+INSERT INTO "preset_preset_metrics" VALUES (23,1,20,'Preset Focus','','str','preset','preset',0,NULL,1,0,'Calisthenics');
+INSERT INTO "preset_preset_metrics" VALUES (24,1,16,'Macrocycle','The longest phase in your training plan, typically spanning several months and focused on your overall goal.','int','pre_workout','session',1,NULL,2,0,NULL);
+INSERT INTO "preset_preset_metrics" VALUES (25,1,17,'Mesocycle','A cycle within the macrocycle designed to develop targeted physical qualities.','int','pre_workout','session',1,NULL,3,0,NULL);
+INSERT INTO "preset_preset_metrics" VALUES (26,1,18,'Microcycle','The smallest structural unit within a mesocycle, typically one week long, used to organize training sessions.','int','pre_workout','session',1,NULL,4,0,NULL);
 INSERT INTO "preset_preset_sections" VALUES (1,1,'Workout',0,0);
 INSERT INTO "preset_preset_sections" VALUES (2,1,'Skill work',1,0);
 INSERT INTO "preset_preset_sections" VALUES (3,1,'Workout',2,0);

--- a/data/workout_schema.sql
+++ b/data/workout_schema.sql
@@ -58,6 +58,8 @@ CREATE TABLE IF NOT EXISTS "preset_preset_metrics" (
 	"id"	INTEGER,
 	"preset_id"	INTEGER NOT NULL,
 	"library_metric_type_id"	INTEGER,
+        "metric_name"   TEXT NOT NULL,
+        "metric_description"    TEXT,
 	"type"	TEXT NOT NULL CHECK("type" IN ('int', 'float', 'str', 'bool', 'enum', 'slider')),
 	"input_timing"	TEXT NOT NULL CHECK("input_timing" IN ('library', 'preset', 'pre_workout', 'post_workout')),
 	"scope"	TEXT NOT NULL CHECK("scope" IN ('preset', 'session')),

--- a/migrations/002_add_metric_name_and_description.py
+++ b/migrations/002_add_metric_name_and_description.py
@@ -1,0 +1,87 @@
+import sqlite3
+import shutil
+import time
+from pathlib import Path
+import sys
+
+
+ALLOWED_TYPES = ("int", "float", "str", "bool", "enum", "slider")
+
+
+def main():
+    base = Path(__file__).resolve().parent.parent
+    db_dir = base / 'data'
+    old_db = db_dir / 'workout.db'
+    backup_dir = base / 'backups'
+    backup_dir.mkdir(exist_ok=True)
+    backup_file = backup_dir / f"workout_{int(time.time())}.db.bak"
+    shutil.copyfile(old_db, backup_file)
+    new_db = db_dir / 'workout_new.db'
+    shutil.copyfile(old_db, new_db)
+    print(f"✅ Backup created at {backup_file}")
+
+    conn = sqlite3.connect(new_db)
+    try:
+        conn.execute('PRAGMA foreign_keys = OFF;')
+
+        conn.execute(
+            """
+            CREATE TABLE preset_preset_metrics_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                preset_id INTEGER NOT NULL,
+                library_metric_type_id INTEGER,
+                metric_name TEXT NOT NULL,
+                metric_description TEXT,
+                type TEXT NOT NULL CHECK(type IN ('int','float','str','bool','enum','slider')),
+                input_timing TEXT NOT NULL CHECK(input_timing IN ('library','preset','pre_workout','post_workout')),
+                scope TEXT NOT NULL CHECK(scope IN ('preset','session')),
+                is_required BOOLEAN NOT NULL DEFAULT 0,
+                enum_values_json TEXT,
+                position INTEGER DEFAULT 0,
+                deleted BOOLEAN NOT NULL DEFAULT 0,
+                value TEXT,
+                FOREIGN KEY(library_metric_type_id) REFERENCES library_metric_types(id) ON DELETE SET NULL,
+                FOREIGN KEY(preset_id) REFERENCES preset_presets(id) ON DELETE CASCADE
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO preset_preset_metrics_new (
+                id, preset_id, library_metric_type_id,
+                metric_name, metric_description,
+                type, input_timing, scope, is_required,
+                enum_values_json, position, deleted, value
+            )
+            SELECT pm.id, pm.preset_id, pm.library_metric_type_id,
+                   COALESCE(mt.name, ''), mt.description,
+                   pm.type, pm.input_timing, pm.scope, pm.is_required,
+                   pm.enum_values_json, pm.position, pm.deleted, pm.value
+              FROM preset_preset_metrics pm
+              LEFT JOIN library_metric_types mt ON pm.library_metric_type_id = mt.id;
+            """
+        )
+        conn.execute("DROP TABLE preset_preset_metrics")
+        conn.execute("ALTER TABLE preset_preset_metrics_new RENAME TO preset_preset_metrics")
+        conn.execute(
+            "CREATE UNIQUE INDEX idx_unique_preset_metric_active ON preset_preset_metrics (preset_id, library_metric_type_id) WHERE deleted = 0"
+        )
+
+        conn.execute('PRAGMA foreign_keys = ON;')
+        fk_errors = conn.execute('PRAGMA foreign_key_check;').fetchall()
+        if fk_errors:
+            raise RuntimeError(f"Foreign key violations detected: {fk_errors}")
+        conn.commit()
+    except Exception as exc:
+        conn.rollback()
+        print(f"Migration failed: {exc}")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+    shutil.move(str(new_db), str(old_db))
+    print("✅ Migration completed successfully.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- expand `preset_preset_metrics` schema to store metric name and description
- update sample data to include the new columns
- migrate existing databases with `002_add_metric_name_and_description.py`
- adjust core logic to load and save the additional fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9fff434083329676955891ef2d14