### PR TITLE
Update preset metric handling

### DIFF
--- a/DB_DESIGN.md
+++ b/DB_DESIGN.md
@@ -60,7 +60,7 @@ Presets represent **workout templates** made up of sections, exercises, and per-
 | `preset_preset_sections`  | Named sections within a preset (e.g., “Warm-Up”, “Main Set”)     |
 | `preset_section_exercises`| Exercises within a section, with full local copies of name, etc. |
 | `preset_exercise_metrics` | Metrics for each exercise — snapshotted and editable             |
-| `preset_preset_metrics`   | Metrics that apply to the entire preset/session (e.g., RPE, Duration) |
+| `preset_preset_metrics`   | Metrics that apply to the entire preset/session (e.g., RPE, Duration); stores `metric_name` and `metric_description` snapshots |
 
 ---
 
@@ -84,7 +84,7 @@ This allows for fine-grained control of workout logic, data input timing, and UI
 - Soft deletes are implemented uniformly via a `deleted BOOLEAN DEFAULT 0` field.
 - `enum_values_json` supports customizable metric inputs like drop-downs or sliders.
 - Metrics store a `value` field, supporting pre-filled defaults in both presets and exercises.
-- Snapshotted fields like `metric_name`, `type`, etc., ensure the preset behaves the same even if the original metric definition changes or is deleted.
+- Snapshotted fields like `metric_name`, `metric_description`, `type`, etc., ensure the preset behaves the same even if the original metric definition changes or is deleted.
 
 ---
 

--- a/ui/screens/edit_preset_screen.py
+++ b/ui/screens/edit_preset_screen.py
@@ -318,7 +318,7 @@ class EditPresetScreen(MDScreen):
             ]
 
         for m in metrics:
-            name = m.get("name")
+            name = m.get("metric_name") or m.get("name")
             mtype = m.get("type")
             enum_vals = m.get("values") or []
             value = m.get("value")
@@ -406,9 +406,12 @@ class EditPresetScreen(MDScreen):
 
         rv.data = [
             {
-                "name": m["name"],
-                "text": m["name"],
-                "is_user_created": all_defs.get(m["name"], {}).get(
+                "name": m.get("metric_name") or m.get("name"),
+                "text": m.get("metric_name") or m.get("name"),
+                "is_user_created": all_defs.get(
+                    m.get("metric_name") or m.get("name"),
+                    {},
+                ).get(
                     "is_user_created", False
                 ),
             }
@@ -726,11 +729,16 @@ class AddPresetMetricPopup(MDDialog):
         app = MDApp.get_running_app()
         existing = set()
         if app and app.preset_editor:
-            existing = {m.get("name") for m in app.preset_editor.preset_metrics}
+            existing = {
+                m.get("metric_name") or m.get("name")
+                for m in app.preset_editor.preset_metrics
+            }
         metrics = [
             m
             for m in core.get_all_metric_types()
-            if m.get("scope") == "preset" and m.get("name") not in existing
+            if m.get("scope") == "preset" and (
+                m.get("name") not in existing and m.get("metric_name") not in existing
+            )
         ]
 
         list_view = MDList()
@@ -773,11 +781,16 @@ class AddSessionMetricPopup(MDDialog):
         app = MDApp.get_running_app()
         existing = set()
         if app and app.preset_editor:
-            existing = {m.get("name") for m in app.preset_editor.preset_metrics}
+            existing = {
+                m.get("metric_name") or m.get("name")
+                for m in app.preset_editor.preset_metrics
+            }
         metrics = [
             m
             for m in core.get_all_metric_types()
-            if m.get("scope") == "session" and m.get("name") not in existing
+            if m.get("scope") == "session" and (
+                m.get("name") not in existing and m.get("metric_name") not in existing
+            )
         ]
 
         list_view = MDList()


### PR DESCRIPTION
## Summary
- document that preset metrics store metric name and description
- adjust EditPresetScreen to read metric name/description snapshots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ca3abb51c8332baaf555df35c182a