### PR TITLE
Fix start_workout preset init

### DIFF
--- a/core.py
+++ b/core.py
@@ -750,11 +750,11 @@ def set_exercise_metric_override(
 class WorkoutSession:
     """In-memory representation of a workout session.
 
-    The session loads the selected preset from the database when it is
-    created.  While the workout is running it manages state in memory and
-    never writes to the database.  It may read additional information from
-    the database if needed but will not modify any tables until the workout
-    is finished, at which point the completed session is saved.
+    The entire preset is fetched from the database when the session is
+    created.  Once initialized all workout progress is kept purely in
+    memory and the database is not accessed again.  Future versions may
+    consult the database when adding unplanned exercises, but that
+    functionality is not yet implemented.
     """
 
     def __init__(

--- a/main.py
+++ b/main.py
@@ -409,9 +409,16 @@ class WorkoutApp(MDApp):
             self.preset_editor = None
         self.selected_preset = ""
 
-    def start_workout(self, exercises):
-        if exercises:
-            self.workout_session = WorkoutSession(exercises)
+    def start_workout(self, preset_name: str):
+        """Initialize a :class:`WorkoutSession` for ``preset_name``.
+
+        The entire preset is loaded from the database when the session is
+        created so no further database access is required while the workout
+        is in progress.
+        """
+
+        if preset_name:
+            self.workout_session = WorkoutSession(preset_name, db_path=DEFAULT_DB_PATH)
         else:
             self.workout_session = None
 


### PR DESCRIPTION
## Summary
- load entire workout preset in-memory when starting a session
- clarify `WorkoutSession` behaviour in docstring
- initialize a new `WorkoutSession` when selecting a preset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ca90dd71c8332a67caac92e12e68b