### PR TITLE
Add optional metric toggle in workout screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -445,6 +445,10 @@ ScreenManager:
     on_pre_enter: root.populate_metrics()
     prev_metric_list: prev_metric_list
     next_metric_list: next_metric_list
+    prev_optional_list: prev_optional_list
+    next_optional_list: next_optional_list
+    prev_toggle_button: prev_toggle_button
+    next_toggle_button: next_toggle_button
     metrics_scroll: metrics_scroll
     BoxLayout:
         orientation: "vertical"
@@ -479,16 +483,52 @@ ScreenManager:
                 orientation: "vertical"
                 size_hint_y: None
                 height: self.minimum_height
-                MDList:
-                    id: prev_metric_list
+                MDBoxLayout:
+                    orientation: "vertical"
                     size_hint_y: None
                     height: self.minimum_height if root.current_tab == "previous" else 0
                     opacity: 1 if root.current_tab == "previous" else 0
-                MDList:
-                    id: next_metric_list
+                    MDList:
+                        id: prev_metric_list
+                        size_hint_y: None
+                        height: self.minimum_height
+                    MDBoxLayout:
+                        id: prev_optional_box
+                        orientation: "vertical"
+                        size_hint_y: None
+                        height: prev_toggle_button.height + prev_optional_list.height
+                        MDRaisedButton:
+                            id: prev_toggle_button
+                            text: "Show more metrics"
+                            on_release: root.toggle_optional("previous")
+                        MDList:
+                            id: prev_optional_list
+                            size_hint_y: None
+                            height: self.minimum_height if root.prev_optional_shown else 0
+                            opacity: 1 if root.prev_optional_shown else 0
+                MDBoxLayout:
+                    orientation: "vertical"
                     size_hint_y: None
                     height: self.minimum_height if root.current_tab == "next" else 0
                     opacity: 1 if root.current_tab == "next" else 0
+                    MDList:
+                        id: next_metric_list
+                        size_hint_y: None
+                        height: self.minimum_height
+                    MDBoxLayout:
+                        id: next_optional_box
+                        orientation: "vertical"
+                        size_hint_y: None
+                        height: next_toggle_button.height + next_optional_list.height
+                        MDRaisedButton:
+                            id: next_toggle_button
+                            text: "Show more metrics"
+                            on_release: root.toggle_optional("next")
+                        MDList:
+                            id: next_optional_list
+                            size_hint_y: None
+                            height: self.minimum_height if root.next_optional_shown else 0
+                            opacity: 1 if root.next_optional_shown else 0
         MDRaisedButton:
             text: "Save Metrics"
             on_release: root.save_metrics()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -58,6 +58,31 @@ def test_switch_tab_updates_current_tab():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_toggle_optional_shows_and_hides_metrics():
+    from kivy.lang import Builder
+    from pathlib import Path
+
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    screen = MetricInputScreen()
+    screen.populate_metrics(
+        [
+            {
+                "name": "RPE",
+                "type": "int",
+                "input_timing": "post_set",
+                "is_required": False,
+            }
+        ]
+    )
+    assert len(screen.prev_optional_list.children) == 0
+    screen.toggle_optional("previous")
+    assert len(screen.prev_optional_list.children) == 1
+    screen.toggle_optional("previous")
+    assert len(screen.prev_optional_list.children) == 0
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_rest_screen_toggle_ready_changes_state():
     screen = RestScreen()
     screen.is_ready = False


### PR DESCRIPTION
## Summary
- Separate required and optional metrics in the input screen with buttons to show or hide optional entries
- Expand layout to display optional metrics on demand while keeping required fields always visible
- Verify optional metric toggle with a dedicated UI test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68906801daa883329dd8e0ae6801ace0