### PR TITLE
Fix preset editing from details screen

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -397,6 +397,40 @@ def test_preset_select_button_updates(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_presets_screen_preserves_selection_on_leave(monkeypatch):
+    """Leaving the Presets screen keeps the app's selected preset."""
+    from kivy.lang import Builder
+    from pathlib import Path
+
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    # Ensure the preset exists
+    monkeypatch.setattr(core, "WORKOUT_PRESETS", [{"name": "Sample", "exercises": []}])
+
+    # Provide an app instance with a selected_preset attribute
+    class DummyApp:
+        selected_preset = ""
+
+    dummy_app = DummyApp()
+    monkeypatch.setattr(App, "get_running_app", lambda: dummy_app)
+
+    screen = PresetsScreen()
+    dummy_item = type(
+        "Obj",
+        (),
+        {"md_bg_color": (0, 0, 0, 0), "theme_text_color": "Primary", "text_color": (0, 0, 0, 1)},
+    )()
+
+    # Select a preset and verify the app reflects it
+    screen.select_preset("Sample", dummy_item)
+    assert dummy_app.selected_preset == "Sample"
+
+    # Leaving the screen should not clear the app's selection
+    screen.on_leave()
+    assert dummy_app.selected_preset == "Sample"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_preset_detail_screen_populate(monkeypatch):
     from kivy.lang import Builder
     from pathlib import Path

--- a/ui/screens/presets_screen.py
+++ b/ui/screens/presets_screen.py
@@ -21,16 +21,24 @@ class PresetsScreen(MDScreen):
         self._default_btn_color = self.ids.select_btn.md_bg_color
         return super().on_kv_post(base_widget)
 
-    def clear_selection(self):
-        """Reset any selected preset and remove highlight."""
+    def clear_selection(self, reset_app: bool = True):
+        """Reset any selected preset and remove highlight.
+
+        ``reset_app`` controls whether the app-level ``selected_preset``
+        attribute is cleared. When leaving this screen for another screen,
+        we want to preserve the global selection so the detail or edit
+        screens can load the chosen preset. When entering this screen
+        anew, we clear the global selection so no stale state remains.
+        """
         if self.selected_item:
             self.selected_item.md_bg_color = (0, 0, 0, 0)
             self.selected_item.theme_text_color = "Primary"
         self.selected_item = None
         self.selected_preset = ""
-        app = MDApp.get_running_app()
-        if app:
-            app.selected_preset = ""
+        if reset_app:
+            app = MDApp.get_running_app()
+            if app:
+                app.selected_preset = ""
         if self._default_btn_color is not None:
             self.ids.select_btn.md_bg_color = self._default_btn_color
 
@@ -40,7 +48,9 @@ class PresetsScreen(MDScreen):
         return super().on_pre_enter(*args)
 
     def on_leave(self, *args):
-        self.clear_selection()
+        # Preserve app.selected_preset so other screens know which preset
+        # was chosen when navigating away from this screen.
+        self.clear_selection(reset_app=False)
         return super().on_leave(*args)
 
     def populate(self):


### PR DESCRIPTION
## Summary
- keep app-level selected preset when leaving the Presets screen
- test that leaving the Presets screen doesn't clear the chosen preset

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890692ecb2c833298cb96169800f9f9