### PR TITLE
feat: make preset exercises expandable

### DIFF
--- a/ui/expandable_list_item.py
+++ b/ui/expandable_list_item.py
@@ -1,0 +1,48 @@
+from kivy.metrics import dp
+from kivy.clock import Clock
+from kivymd.uix.list import OneLineListItem
+
+
+class ExpandableListItem(OneLineListItem):
+    """List item that expands to show all text when tapped."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._expanded = False
+        Clock.schedule_once(self._post_init)
+
+    def _post_init(self, *_):
+        self.bind(on_release=self._toggle)
+        label = self.ids._lbl_primary
+        label.shorten = True
+        label.max_lines = 3
+        label.text_size = (self.width, None)
+        self._line_height = label.line_height
+        self._collapsed_height = self._line_height * 3 + dp(20)
+        label.texture_update()
+        self.height = min(label.texture_size[1] + dp(20), self._collapsed_height)
+        self.bind(width=self._update_width)
+
+    def _update_width(self, *_):
+        label = self.ids._lbl_primary
+        label.text_size = (self.width, None)
+        label.texture_update()
+        if self._expanded:
+            self.height = label.texture_size[1] + dp(20)
+        else:
+            self.height = min(label.texture_size[1] + dp(20), self._collapsed_height)
+
+    def _toggle(self, *_):
+        label = self.ids._lbl_primary
+        if self._expanded:
+            self._expanded = False
+            label.max_lines = 3
+            label.shorten = True
+            label.texture_update()
+            self.height = min(label.texture_size[1] + dp(20), self._collapsed_height)
+        else:
+            self._expanded = True
+            label.max_lines = 0
+            label.shorten = False
+            label.texture_update()
+            self.height = label.texture_size[1] + dp(20)

--- a/ui/screens/preset_detail_screen.py
+++ b/ui/screens/preset_detail_screen.py
@@ -1,8 +1,8 @@
 from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
-from kivymd.uix.list import OneLineListItem
 from kivy.properties import StringProperty, ObjectProperty
 import core
+from ui.expandable_list_item import ExpandableListItem
 
 
 class PresetDetailScreen(MDScreen):
@@ -30,16 +30,16 @@ class PresetDetailScreen(MDScreen):
             if metric.get("scope") == "preset":
                 value = metric.get("value")
                 text = f"{metric['name']}: {value}" if value is not None else metric["name"]
-                self.summary_list.add_widget(OneLineListItem(text=text))
+                self.summary_list.add_widget(ExpandableListItem(text=text))
 
         for section in editor.sections:
             self.summary_list.add_widget(
-                OneLineListItem(text=f"Section: {section['name']}")
+                ExpandableListItem(text=f"Section: {section['name']}")
             )
             for ex in section.get("exercises", []):
                 sets = ex.get("sets", 0) or 0
                 label = "set" if sets == 1 else "sets"
                 self.summary_list.add_widget(
-                    OneLineListItem(text=f"{ex['name']} - {sets} {label}")
+                    ExpandableListItem(text=f"{ex['name']} - {sets} {label}")
                 )
 

--- a/ui/screens/preset_overview_screen.py
+++ b/ui/screens/preset_overview_screen.py
@@ -1,9 +1,9 @@
 from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
-from kivymd.uix.list import TwoLineListItem
 from kivymd.uix.label import MDLabel
 from kivy.properties import ObjectProperty
 import core
+from ui.expandable_list_item import ExpandableListItem
 
 
 class PresetOverviewScreen(MDScreen):
@@ -44,18 +44,14 @@ class PresetOverviewScreen(MDScreen):
                 metrics_text = ", ".join(m["name"] for m in metrics)
                 sets = ex.get("sets", 0) or 0
                 rest = ex.get("rest", 0) or 0
-                secondary_parts = []
-                if desc:
-                    secondary_parts.append(desc)
-                secondary_parts.append(f"Sets: {sets}")
-                secondary_parts.append(f"Rest: {rest}s")
+                lines = [ex["name"]]
+                lines.append(desc if desc else "")
+                info_parts = [f"sets {sets}", f"rest: {rest}s"]
                 if metrics_text:
-                    secondary_parts.append(f"Metrics: {metrics_text}")
-                secondary = " | ".join(secondary_parts)
-                text = ex["name"]
-                self.overview_list.add_widget(
-                    TwoLineListItem(text=text, secondary_text=secondary)
-                )
+                    info_parts.append(f"metrics: {metrics_text}")
+                lines.append(" | ".join(info_parts))
+                text = "\n".join(lines)
+                self.overview_list.add_widget(ExpandableListItem(text=text))
 
     def start_workout(self):
         app = MDApp.get_running_app()


### PR DESCRIPTION
## Summary
- allow preset overview items to wrap and expand for full text
- use expandable list item for preset details to reveal long entries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68906c42cc748332bda76f5266157f10