### PR TITLE
Improve preset widgets layout

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -556,21 +556,10 @@ def test_preset_overview_screen_populate(monkeypatch):
             "is_user_created": False,
         },
     )
-    monkeypatch.setattr(
-        core,
-        "get_metrics_for_exercise",
-        lambda *a, **k: [{"name": "Reps"}, {"name": "Weight"}],
-    )
-
     screen.populate()
 
-    entries = [
-        (getattr(c, "text", ""), getattr(c, "secondary_text", ""))
-        for c in screen.overview_list.children
-        if hasattr(c, "text")
-    ]
-
-    assert ("Push - 1 set", "Desc | Metrics: Reps, Weight") in entries
+    entries = [getattr(c, "text", "") for c in screen.overview_list.children]
+    assert "Push\nsets 1 | rest: 0s\nDesc" in entries
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")

--- a/ui/expandable_list_item.py
+++ b/ui/expandable_list_item.py
@@ -1,6 +1,9 @@
 from kivy.metrics import dp
 from kivy.clock import Clock
+from kivy.uix.behaviors import ButtonBehavior
 from kivymd.uix.list import OneLineListItem
+from kivymd.uix.boxlayout import MDBoxLayout
+from kivymd.uix.label import MDLabel
 
 
 class ExpandableListItem(OneLineListItem):
@@ -46,3 +49,85 @@ class ExpandableListItem(OneLineListItem):
             label.shorten = False
             label.texture_update()
             self.height = label.texture_size[1] + dp(20)
+
+
+class ExerciseSummaryItem(ButtonBehavior, MDBoxLayout):
+    """Collapsible list item used on the preset detail screen.
+
+    Displays the exercise name and number of sets. When collapsed the
+    exercise name is shortened with an ellipsis to ensure the set count is
+    always visible. Tapping the item expands it to show the full exercise
+    name and moves the set count onto a new line."""
+
+    def __init__(self, name: str, sets: int, **kwargs):
+        super().__init__(orientation="vertical", padding=(dp(16), dp(8)), spacing=dp(4), size_hint_y=None, **kwargs)
+        self._expanded = False
+        self._name_text = name
+        label = "set" if sets == 1 else "sets"
+        self._sets_text = f"{sets} {label}"
+
+        # top row for collapsed state
+        self._top_row = MDBoxLayout(orientation="horizontal")
+        self.name_label = MDLabel(text=name, shorten=True, max_lines=1)
+        self.sets_label = MDLabel(text=f"- {self._sets_text}", size_hint_x=None)
+        self._top_row.add_widget(self.name_label)
+        self._top_row.add_widget(self.sets_label)
+        self.add_widget(self._top_row)
+
+        Clock.schedule_once(self._post_init)
+
+    def _post_init(self, *_):
+        self.sets_label.texture_update()
+        self.sets_label.width = self.sets_label.texture_size[0]
+        self.bind(width=self._update_width)
+        self._update_width()
+
+    def _update_width(self, *_):
+        # Ensure the exercise name accounts for the width of the set label
+        avail = self.width - self.sets_label.width
+        if avail < 0:
+            avail = self.width
+        self.name_label.text_size = (avail, None)
+        self.name_label.texture_update()
+        self.sets_label.texture_update()
+        if self._expanded:
+            height = self.name_label.texture_size[1] + self.sets_label.texture_size[1] + dp(16) + self.spacing
+        else:
+            height = max(self.name_label.texture_size[1], self.sets_label.texture_size[1]) + dp(16)
+        self.height = height
+
+    def on_touch_up(self, touch):
+        if self.collide_point(*touch.pos):
+            self._toggle()
+            return True
+        return super().on_touch_up(touch)
+
+    def _toggle(self):
+        if self._expanded:
+            # Collapse
+            self._expanded = False
+            self.clear_widgets()
+            self.name_label.shorten = True
+            self.name_label.max_lines = 1
+            self.sets_label.text = f"- {self._sets_text}"
+            self._top_row = MDBoxLayout(orientation="horizontal")
+            self._top_row.add_widget(self.name_label)
+            self._top_row.add_widget(self.sets_label)
+            self.add_widget(self._top_row)
+        else:
+            # Expand
+            self._expanded = True
+            self.clear_widgets()
+            self.name_label.shorten = False
+            self.name_label.max_lines = 0
+            self.name_label.text_size = (self.width, None)
+            self.sets_label.text = self._sets_text
+            self.add_widget(self.name_label)
+            self.add_widget(self.sets_label)
+        self._update_width()
+
+    @property
+    def text(self) -> str:  # pragma: no cover - simple property for tests
+        """Return a collapsed representation of the item."""
+        return f"{self._name_text} - {self._sets_text}"
+

--- a/ui/screens/preset_detail_screen.py
+++ b/ui/screens/preset_detail_screen.py
@@ -2,7 +2,7 @@ from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
 from kivy.properties import StringProperty, ObjectProperty
 import core
-from ui.expandable_list_item import ExpandableListItem
+from ui.expandable_list_item import ExpandableListItem, ExerciseSummaryItem
 
 
 class PresetDetailScreen(MDScreen):
@@ -38,8 +38,7 @@ class PresetDetailScreen(MDScreen):
             )
             for ex in section.get("exercises", []):
                 sets = ex.get("sets", 0) or 0
-                label = "set" if sets == 1 else "sets"
                 self.summary_list.add_widget(
-                    ExpandableListItem(text=f"{ex['name']} - {sets} {label}")
+                    ExerciseSummaryItem(name=ex["name"], sets=sets)
                 )
 

--- a/ui/screens/preset_overview_screen.py
+++ b/ui/screens/preset_overview_screen.py
@@ -38,18 +38,9 @@ class PresetOverviewScreen(MDScreen):
             for ex in section.get("exercises", []):
                 desc_info = core.get_exercise_details(ex["name"])
                 desc = desc_info.get("description", "") if desc_info else ""
-                metrics = core.get_metrics_for_exercise(
-                    ex["name"], preset_name=preset_name
-                )
-                metrics_text = ", ".join(m["name"] for m in metrics)
                 sets = ex.get("sets", 0) or 0
                 rest = ex.get("rest", 0) or 0
-                lines = [ex["name"]]
-                lines.append(desc if desc else "")
-                info_parts = [f"sets {sets}", f"rest: {rest}s"]
-                if metrics_text:
-                    info_parts.append(f"metrics: {metrics_text}")
-                lines.append(" | ".join(info_parts))
+                lines = [ex["name"], f"sets {sets} | rest: {rest}s", desc]
                 text = "\n".join(lines)
                 self.overview_list.add_widget(ExpandableListItem(text=text))
 


### PR DESCRIPTION
## Summary
- ensure preset details show exercise name with sets count using a new expandable item that truncates long names
- simplify preset overview entries to show exercise, sets/rest, and description on separate lines with expansion support
- adjust tests for new widget formats

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68906f8322b4833293e2a045373622b3