### PR TITLE
Stabilize preset detail UI

### DIFF
--- a/ui/expandable_list_item.py
+++ b/ui/expandable_list_item.py
@@ -1,145 +1,58 @@
 from kivy.metrics import dp
 from kivy.clock import Clock
-from kivy.uix.behaviors import ButtonBehavior
 from kivymd.uix.list import OneLineListItem
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.label import MDLabel
 
 
 class ExpandableListItem(OneLineListItem):
-    """List item that expands to show all text when tapped."""
+    """List item that automatically grows to fit its text."""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._expanded = False
+        # Disable ripple/press behaviour so the item is static when tapped
+        self.ripple_behavior = False
         Clock.schedule_once(self._post_init)
 
     def _post_init(self, *_):
-        self.bind(on_release=self._toggle)
         label = self.ids._lbl_primary
-        label.shorten = True
-        label.max_lines = 3
+        label.shorten = False
+        label.max_lines = 0
         label.text_size = (self.width, None)
-        self._line_height = label.line_height
-        self._collapsed_height = self._line_height * 3 + dp(20)
         label.texture_update()
-        self.height = min(label.texture_size[1] + dp(20), self._collapsed_height)
+        self.height = label.texture_size[1] + dp(20)
         self.bind(width=self._update_width)
 
     def _update_width(self, *_):
         label = self.ids._lbl_primary
         label.text_size = (self.width, None)
         label.texture_update()
-        if self._expanded:
-            self.height = label.texture_size[1] + dp(20)
-        else:
-            self.height = min(label.texture_size[1] + dp(20), self._collapsed_height)
-
-    def _toggle(self, *_):
-        label = self.ids._lbl_primary
-        if self._expanded:
-            self._expanded = False
-            label.max_lines = 3
-            label.shorten = True
-            label.texture_update()
-            self.height = min(label.texture_size[1] + dp(20), self._collapsed_height)
-        else:
-            self._expanded = True
-            label.max_lines = 0
-            label.shorten = False
-            label.texture_update()
-            self.height = label.texture_size[1] + dp(20)
+        self.height = label.texture_size[1] + dp(20)
 
 
-class ExerciseSummaryItem(ButtonBehavior, MDBoxLayout):
-    """Collapsible list item used on the preset detail screen.
-
-    Displays the exercise name and number of sets. When collapsed the
-    exercise name is shortened with an ellipsis to ensure the set count is
-    always visible. Tapping the item expands it to show the full exercise
-    name and moves the set count onto a new line."""
+class ExerciseSummaryItem(MDBoxLayout):
+    """Static list item showing an exercise name and set count."""
 
     def __init__(self, name: str, sets: int, **kwargs):
-        super().__init__(orientation="vertical", padding=(dp(16), dp(8)), spacing=dp(4), size_hint_y=None, **kwargs)
-        self._expanded = False
+        super().__init__(orientation="vertical", padding=(dp(16), dp(8)), size_hint_y=None, **kwargs)
         self._name_text = name
         label = "set" if sets == 1 else "sets"
         self._sets_text = f"{sets} {label}"
-
-        # top row for collapsed state
-        self._top_row = MDBoxLayout(orientation="horizontal")
-        self.name_label = MDLabel(text=name, shorten=True, max_lines=1)
-        self.sets_label = MDLabel(text=f"- {self._sets_text}", size_hint_x=None)
-        self._top_row.add_widget(self.name_label)
-        self._top_row.add_widget(self.sets_label)
-        self.add_widget(self._top_row)
-
+        self.label = MDLabel(text=self.text, shorten=False, max_lines=0)
+        self.add_widget(self.label)
+        # Update size after the widget has a width
         Clock.schedule_once(self._post_init)
 
     def _post_init(self, *_):
-        self.sets_label.texture_update()
-        self.sets_label.width = self.sets_label.texture_size[0]
         self.bind(width=self._update_width)
         self._update_width()
 
     def _update_width(self, *_):
-        # Ensure the exercise name accounts for the width of the set label
-        # When expanded the set count is on a new line so the name can take
-        # the full width. When collapsed the name should only use the width
-        # that remains after the set count label.
-        if self._expanded:
-            avail = self.width
-        else:
-            avail = self.width - self.sets_label.width
-            if avail < 0:
-                avail = self.width
-        self.name_label.text_size = (avail, None)
-        self.name_label.texture_update()
-        self.sets_label.texture_update()
-        if self._expanded:
-            height = self.name_label.texture_size[1] + self.sets_label.texture_size[1] + dp(16) + self.spacing
-        else:
-            height = max(self.name_label.texture_size[1], self.sets_label.texture_size[1]) + dp(16)
-        self.height = height
-
-    def on_touch_up(self, touch):
-        if self.collide_point(*touch.pos):
-            self._toggle()
-            return True
-        return super().on_touch_up(touch)
-
-    def _toggle(self):
-        if self._expanded:
-            # Collapse
-            self._expanded = False
-            self.clear_widgets()
-            # Remove labels from any previous parent before re-adding them
-            if self.name_label.parent:
-                self.name_label.parent.remove_widget(self.name_label)
-            if self.sets_label.parent:
-                self.sets_label.parent.remove_widget(self.sets_label)
-            self.name_label.shorten = True
-            self.name_label.max_lines = 1
-            self.sets_label.text = f"- {self._sets_text}"
-            self._top_row = MDBoxLayout(orientation="horizontal")
-            self._top_row.add_widget(self.name_label)
-            self._top_row.add_widget(self.sets_label)
-            self.add_widget(self._top_row)
-        else:
-            # Expand
-            self._expanded = True
-            self.clear_widgets()
-            if self.name_label.parent:
-                self.name_label.parent.remove_widget(self.name_label)
-            if self.sets_label.parent:
-                self.sets_label.parent.remove_widget(self.sets_label)
-            self.name_label.shorten = False
-            self.name_label.max_lines = 0
-            self.name_label.text_size = (self.width, None)
-            self.sets_label.text = self._sets_text
-            self.add_widget(self.name_label)
-            self.add_widget(self.sets_label)
-        self._update_width()
+        avail = self.width - self.padding[0] * 2
+        self.label.text = self.text
+        self.label.text_size = (avail, None)
+        self.label.texture_update()
+        self.height = self.label.texture_size[1] + self.padding[1] * 2
 
     @property
     def text(self) -> str:  # pragma: no cover - simple property for tests


### PR DESCRIPTION
## Summary
- stop preset detail list items from toggling on tap
- auto-size exercise summaries so long names wrap with set count at the end

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689076cb85b48332b2bc32c9c8e911ec