### PR TITLE
feat: redesign preset overview with tabs

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -857,8 +857,21 @@ ScreenManager:
             id: exercise_list
 
 
+<DetailsTab@MDBoxLayout+MDTabsBase>:
+    orientation: "vertical"
+    ScrollView:
+        MDList:
+            id: details_list
+
+<WorkoutTab@MDBoxLayout+MDTabsBase>:
+    orientation: "vertical"
+    ScrollView:
+        MDList:
+            id: workout_list
+
 <PresetOverviewScreen>:
-    overview_list: overview_list
+    details_list: details_tab.ids.details_list
+    workout_list: workout_tab.ids.workout_list
     preset_label: preset_label
     BoxLayout:
         orientation: "vertical"
@@ -870,9 +883,14 @@ ScreenManager:
             halign: "center"
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1
-        ScrollView:
-            MDList:
-                id: overview_list
+        MDTabs:
+            id: tabs
+            DetailsTab:
+                id: details_tab
+                text: "Details"
+            WorkoutTab:
+                id: workout_tab
+                text: "Workout"
         MDRaisedButton:
             text: "Back to Detail"
             on_release: app.root.current = "preset_detail"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -525,7 +525,9 @@ def test_preset_overview_screen_populate(monkeypatch):
             self.children.append(widget)
 
     screen = PresetOverviewScreen()
-    screen.overview_list = DummyList()
+    screen.details_list = DummyList()
+    screen.workout_list = DummyList()
+    screen.preset_label = type("L", (), {"text": ""})()
 
     class DummyApp:
         selected_preset = "Test"
@@ -536,8 +538,12 @@ def test_preset_overview_screen_populate(monkeypatch):
                 (),
                 {
                     "sections": [
-                        {"name": "Sec", "exercises": [{"name": "Push", "sets": 1}]}
-                    ]
+                        {
+                            "name": "Sec",
+                            "exercises": [{"name": "Push", "sets": 1, "rest": 0}],
+                        }
+                    ],
+                    "preset_metrics": [{"name": "PM", "scope": "preset", "value": "V"}],
                 },
             )()
 
@@ -553,10 +559,18 @@ def test_preset_overview_screen_populate(monkeypatch):
             "is_user_created": False,
         },
     )
+    monkeypatch.setattr(
+        core,
+        "get_metrics_for_exercise",
+        lambda name, *a, **k: [{"name": "M1"}, {"name": "M2"}],
+    )
     screen.populate()
 
-    entries = [getattr(c, "text", "") for c in screen.overview_list.children]
-    assert "Push\nsets 1 | rest: 0s\nDesc" in entries
+    workout_entries = [getattr(c, "text", "") for c in screen.workout_list.children]
+    assert "Push\nsets 1 | rest: 0s\nDesc\nM1, M2" in workout_entries
+
+    detail_entries = [getattr(c, "text", "") for c in screen.details_list.children]
+    assert "PM: V" in detail_entries
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")

--- a/ui/screens/preset_overview_screen.py
+++ b/ui/screens/preset_overview_screen.py
@@ -1,15 +1,15 @@
 from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
-from kivymd.uix.label import MDLabel
 from kivy.properties import ObjectProperty
 import core
-from ui.expandable_list_item import ExpandableListItem
+from ui.expandable_list_item import ExpandableListItem, ExerciseSummaryItem
 
 
 class PresetOverviewScreen(MDScreen):
     """Display an overview of the selected preset."""
 
-    overview_list = ObjectProperty(None)
+    details_list = ObjectProperty(None)
+    workout_list = ObjectProperty(None)
     preset_label = ObjectProperty(None)
 
     def on_pre_enter(self, *args):
@@ -17,9 +17,12 @@ class PresetOverviewScreen(MDScreen):
         return super().on_pre_enter(*args)
 
     def populate(self):
-        if not self.overview_list or not self.preset_label:
+        if not self.details_list or not self.workout_list or not self.preset_label:
             return
-        self.overview_list.clear_widgets()
+
+        self.details_list.clear_widgets()
+        self.workout_list.clear_widgets()
+
         app = MDApp.get_running_app()
         app.init_preset_editor()
         preset_name = app.selected_preset
@@ -28,21 +31,46 @@ class PresetOverviewScreen(MDScreen):
             if preset_name
             else "Preset Overview - summary of the chosen preset"
         )
+
         editor = app.preset_editor
         if not editor:
             return
+
+        # Populate details tab with preset metrics and section summaries
+        for metric in editor.preset_metrics:
+            if metric.get("scope") == "preset":
+                value = metric.get("value")
+                text = (
+                    f"{metric['name']}: {value}"
+                    if value is not None
+                    else metric["name"]
+                )
+                self.details_list.add_widget(ExpandableListItem(text=text))
+
         for section in editor.sections:
-            self.overview_list.add_widget(
-                MDLabel(text=f"Section: {section['name']}")
+            self.details_list.add_widget(
+                ExpandableListItem(text=f"Section: {section['name']}")
             )
+            for ex in section.get("exercises", []):
+                sets = ex.get("sets", 0) or 0
+                self.details_list.add_widget(
+                    ExerciseSummaryItem(name=ex["name"], sets=sets)
+                )
+
+        # Populate workout tab with full exercise details
+        for section in editor.sections:
             for ex in section.get("exercises", []):
                 desc_info = core.get_exercise_details(ex["name"])
                 desc = desc_info.get("description", "") if desc_info else ""
                 sets = ex.get("sets", 0) or 0
                 rest = ex.get("rest", 0) or 0
+                metrics = core.get_metrics_for_exercise(ex["name"], preset_name)
+                metric_names = ", ".join(m["name"] for m in metrics)
                 lines = [ex["name"], f"sets {sets} | rest: {rest}s", desc]
+                if metric_names:
+                    lines.append(metric_names)
                 text = "\n".join(lines)
-                self.overview_list.add_widget(ExpandableListItem(text=text))
+                self.workout_list.add_widget(ExpandableListItem(text=text))
 
     def start_workout(self):
         app = MDApp.get_running_app()


### PR DESCRIPTION
## Summary
- redesign preset overview screen to use Details and Workout tabs
- display preset metrics plus exercise summaries in Details tab
- show exercises with sets, rest, descriptions, and metrics in Workout tab

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689076b902cc8332b00954dba3502c7a