### PR TITLE
Fix MDTabsBase missing import and preset overview metrics lookup

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -1,4 +1,5 @@
 #:import NoTransition kivy.uix.screenmanager.NoTransition
+#:import MDTabsBase kivymd.uix.tab.MDTabsBase
 ScreenManager:
     WelcomeScreen:
         name: "welcome"

--- a/ui/screens/preset_overview_screen.py
+++ b/ui/screens/preset_overview_screen.py
@@ -64,7 +64,9 @@ class PresetOverviewScreen(MDScreen):
                 desc = desc_info.get("description", "") if desc_info else ""
                 sets = ex.get("sets", 0) or 0
                 rest = ex.get("rest", 0) or 0
-                metrics = core.get_metrics_for_exercise(ex["name"], preset_name)
+                metrics = core.get_metrics_for_exercise(
+                    ex["name"], preset_name=preset_name
+                )
                 metric_names = ", ".join(m["name"] for m in metrics)
                 lines = [ex["name"], f"sets {sets} | rest: {rest}s", desc]
                 if metric_names:


### PR DESCRIPTION
## Summary
- make MDTabsBase available to the KV builder
- correctly retrieve exercise metrics for preset overview

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890788ae0c88332a61266c4cb872465