### PR TITLE
Fix KivyMD tabs base to avoid MDTabsBase factory error

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -1,5 +1,4 @@
 #:import NoTransition kivy.uix.screenmanager.NoTransition
-#:import MDTabsBase kivymd.uix.tab.MDTabsBase
 ScreenManager:
     WelcomeScreen:
         name: "welcome"
@@ -858,13 +857,13 @@ ScreenManager:
             id: exercise_list
 
 
-<DetailsTab@MDBoxLayout+MDTabsBase>:
+<DetailsTab@Tab>:
     orientation: "vertical"
     ScrollView:
         MDList:
             id: details_list
 
-<WorkoutTab@MDBoxLayout+MDTabsBase>:
+<WorkoutTab@Tab>:
     orientation: "vertical"
     ScrollView:
         MDList:

--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ if os.name == "nt" or sys.platform.startswith("win"):
     Window.size = (280, 280 * (20 / 9))
 
 
-class Tab(MDFloatLayout, MDTabsBase):
+class Tab(MDBoxLayout, MDTabsBase):
     """A basic tab for use with :class:`~kivymd.uix.tab.MDTabs`."""
 
 


### PR DESCRIPTION
## Summary
- define Tab class using MDBoxLayout+MDTabsBase for proper KivyMD tab registration
- refactor kv tabs to use the Tab base instead of mixing MDTabsBase directly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68907a442b908332bf0f7cb8834be40a