### PR TITLE
Fix KivyMD tab initialization error

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -887,10 +887,10 @@ ScreenManager:
             id: tabs
             DetailsTab:
                 id: details_tab
-                text: "Details"
+                title: "Details"
             WorkoutTab:
                 id: workout_tab
-                text: "Workout"
+                title: "Workout"
         MDRaisedButton:
             text: "Back to Detail"
             on_release: app.root.current = "preset_detail"


### PR DESCRIPTION
## Summary
- ensure custom tabs specify titles so KivyMD can render them

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68907b4f76388332ad0768537ade2e74