### PR TITLE
Add pre-session metric popup

### DIFF
--- a/tests/test_preset_metrics.py
+++ b/tests/test_preset_metrics.py
@@ -1,0 +1,24 @@
+import sqlite3
+import core
+
+def test_get_metrics_for_preset_pre_session(sample_db):
+    conn = sqlite3.connect(sample_db)
+    cur = conn.cursor()
+    preset_id = cur.execute(
+        "SELECT id FROM preset_presets WHERE name='Push Day'"
+    ).fetchone()[0]
+    cur.execute(
+        """
+        INSERT INTO preset_preset_metrics
+            (preset_id, metric_name, type, input_timing, scope, is_required, position)
+        VALUES (?, 'Duration', 'int', 'pre_workout', 'session', 1, 0)
+        """,
+        (preset_id,),
+    )
+    conn.commit()
+    conn.close()
+
+    metrics = core.get_metrics_for_preset('Push Day', db_path=sample_db)
+    duration = next(m for m in metrics if m["name"] == "Duration")
+    assert duration["input_timing"] == "pre_session"
+    assert duration["type"] == "int"

--- a/ui/popups.py
+++ b/ui/popups.py
@@ -13,6 +13,7 @@ from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.button import MDRaisedButton
 from kivymd.uix.list import MDList, OneLineListItem
 from kivymd.uix.label import MDLabel
+from kivymd.uix.slider import MDSlider
 
 import string
 import re
@@ -833,3 +834,111 @@ class EditMetricPopup(MDDialog):
             dialog.open()
         else:
             apply_updates()
+
+
+class PreSessionMetricPopup(MDDialog):
+    """Popup for entering pre-session metrics."""
+
+    def __init__(self, metrics: list[dict], on_save, **kwargs):
+        self.metrics = metrics
+        self.on_save = on_save
+        content, buttons = self._build_widgets()
+        super().__init__(
+            title="Session Metrics", type="custom", content_cls=content, buttons=buttons, **kwargs
+        )
+
+    def _build_widgets(self):
+        layout = MDBoxLayout(orientation="vertical", spacing="8dp", size_hint_y=None)
+        layout.bind(minimum_height=layout.setter("height"))
+        self.metric_list = MDList()
+        for m in self.metrics:
+            self.metric_list.add_widget(self._create_row(m))
+        scroll = ScrollView()
+        scroll.add_widget(self.metric_list)
+        layout.add_widget(scroll)
+        save_btn = MDRaisedButton(text="Save", on_release=lambda *_: self._on_save())
+        cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *_: self.dismiss())
+        return layout, [save_btn, cancel_btn]
+
+    def _create_row(self, metric):
+        name = metric.get("name")
+        mtype = metric.get("type", "str")
+        values = metric.get("values", [])
+        row = MDBoxLayout(orientation="horizontal", size_hint_y=None, height=dp(48))
+        row.metric_name = name
+        row.type = mtype
+        row.required = metric.get("is_required", False)
+        row.add_widget(MDLabel(text=name, size_hint_x=0.4))
+        if mtype == "slider":
+            widget = MDSlider(min=0, max=1, value=0)
+        elif mtype == "enum":
+            widget = Spinner(text=values[0] if values else "", values=values)
+        else:
+            input_filter = None
+            if mtype == "int":
+                input_filter = "int"
+            elif mtype == "float":
+                input_filter = "float"
+            widget = MDTextField(multiline=False, input_filter=input_filter)
+        row.input_widget = widget
+        row.add_widget(widget)
+        return row
+
+    def _collect(self):
+        data = {}
+        valid = True
+        for row in reversed(self.metric_list.children):
+            name = getattr(row, "metric_name", "")
+            widget = getattr(row, "input_widget", None)
+            mtype = getattr(row, "type", "str")
+            required = getattr(row, "required", False)
+            value = None
+            if isinstance(widget, MDTextField):
+                text = widget.text.strip()
+                if required and text == "":
+                    widget.error = True
+                    valid = False
+                    continue
+                if mtype == "int":
+                    try:
+                        value = int(text)
+                    except Exception:
+                        widget.error = True
+                        valid = False
+                        continue
+                elif mtype == "float":
+                    try:
+                        value = float(text)
+                    except Exception:
+                        widget.error = True
+                        valid = False
+                        continue
+                elif mtype == "bool":
+                    low = text.lower()
+                    if low in ("true", "1", "yes"):
+                        value = True
+                    elif low in ("false", "0", "no"):
+                        value = False
+                    else:
+                        widget.error = True
+                        valid = False
+                        continue
+                else:
+                    value = text
+            elif isinstance(widget, MDSlider):
+                value = float(widget.value)
+            elif isinstance(widget, Spinner):
+                value = widget.text
+                if required and value == "":
+                    valid = False
+                    continue
+            data[name] = value
+        return valid, data
+
+    def _on_save(self):
+        valid, data = self._collect()
+        if not valid:
+            return
+        if self.on_save:
+            self.on_save(data)
+        self.dismiss()

--- a/ui/screens/preset_overview_screen.py
+++ b/ui/screens/preset_overview_screen.py
@@ -4,6 +4,7 @@ from kivymd.uix.label import MDLabel
 from kivy.properties import ObjectProperty
 import core
 from ui.expandable_list_item import ExpandableListItem
+from ui.popups import PreSessionMetricPopup
 
 
 class PresetOverviewScreen(MDScreen):
@@ -48,5 +49,24 @@ class PresetOverviewScreen(MDScreen):
         app = MDApp.get_running_app()
         preset_name = app.selected_preset
         app.start_workout(preset_name)
+        if app.workout_session:
+            metrics = core.get_metrics_for_preset(preset_name)
+            pre_metrics = [
+                m for m in metrics if m.get("input_timing") == "pre_session"
+            ]
+            if pre_metrics:
+                popup = PreSessionMetricPopup(
+                    pre_metrics,
+                    lambda data: self._save_session_metrics(data),
+                )
+                popup.open()
+                return
+        if self.manager:
+            self.manager.current = "rest"
+
+    def _save_session_metrics(self, data):
+        app = MDApp.get_running_app()
+        if app.workout_session:
+            app.workout_session.set_session_metrics(data)
         if self.manager:
             self.manager.current = "rest"


### PR DESCRIPTION
## Summary
- add API to fetch preset-level metrics
- store session metrics on workout sessions
- prompt for pre-session metrics before starting workouts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68907833af088332b771f7b630e84e03