### PR TITLE
Fix section name overwrite in preset editor

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -944,3 +944,26 @@ def test_exercise_summary_item_toggle_expands_and_collapses():
     assert item._expanded is True
     item._toggle()  # collapse
     assert item._expanded is False
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_refresh_sections_preserves_names(monkeypatch):
+    from kivy.lang import Builder
+    from pathlib import Path
+    from kivymd.uix.boxlayout import MDBoxLayout
+
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+    app = _DummyApp()
+    app.preset_editor = core.PresetEditor()
+    app.preset_editor.add_section("Warmup")
+    app.preset_editor.add_section("Skill work")
+    app.preset_editor.add_section("Workout")
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+    screen = EditPresetScreen()
+    screen.sections_box = MDBoxLayout(orientation="vertical")
+    screen.refresh_sections()
+    assert [s["name"] for s in app.preset_editor.sections] == [
+        "Warmup",
+        "Skill work",
+        "Workout",
+    ]

--- a/ui/screens/edit_preset_screen.py
+++ b/ui/screens/edit_preset_screen.py
@@ -266,7 +266,7 @@ class EditPresetScreen(MDScreen):
                 name = f"Section {len(app.preset_editor.sections) + 1}"
             index = app.preset_editor.add_section(name)
         color = self._colors[len(self.sections_box.children) % len(self._colors)]
-        section = SectionWidget(section_name=name, color=color, section_index=index)
+        section = SectionWidget(section_index=index, section_name=name, color=color)
         self.sections_box.add_widget(section)
         section.refresh_exercises()
         self.update_save_enabled()


### PR DESCRIPTION
## Summary
- Ensure section widgets initialize with the correct index to avoid renaming other sections
- Add regression test covering section name preservation when refreshing the edit preset screen

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890839e69988332a10896f24aec7798