### PR TITLE
Populate metrics screen with previous set data and notes

### DIFF
--- a/core.py
+++ b/core.py
@@ -901,6 +901,17 @@ class WorkoutSession:
             return f"{ex['name']} set {set_idx + 1} of {ex['sets']}"
         return ""
 
+    def last_recorded_set_metrics(self) -> dict:
+        """Return metrics from the most recently completed set.
+
+        If no sets have been completed yet, an empty dict is returned.
+        """
+
+        for ex in reversed(self.exercises[: self.current_exercise + 1]):
+            if ex["results"]:
+                return ex["results"][-1]
+        return {}
+
     # --------------------------------------------------------------
     # Pre-set metric helpers
     # --------------------------------------------------------------

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -80,6 +80,73 @@ def test_optional_metrics_populated():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_populate_uses_last_set_metrics(monkeypatch):
+    from kivy.lang import Builder
+    from pathlib import Path
+    import ui.screens.metric_input_screen as mis
+
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    screen = MetricInputScreen()
+
+    class DummyList:
+        def __init__(self):
+            self.children = []
+
+        def clear_widgets(self):
+            self.children.clear()
+
+        def add_widget(self, widget):
+            self.children.append(widget)
+
+    screen.prev_metric_list = DummyList()
+    screen.next_metric_list = DummyList()
+    screen.prev_optional_list = DummyList()
+    screen.next_optional_list = DummyList()
+
+    class DummySession:
+        preset_name = "Test"
+        pending_pre_set_metrics = {}
+
+        def next_exercise_name(self):
+            return "Bench"
+
+        def upcoming_exercise_name(self):
+            return "Bench"
+
+        def last_recorded_set_metrics(self):
+            return {"Weight": 100, "Notes": "prev"}
+
+    dummy_app = _DummyApp()
+    dummy_app.workout_session = DummySession()
+    monkeypatch.setattr(App, "get_running_app", lambda: dummy_app)
+
+    def fake_get_metrics(name, preset_name=None):
+        return [
+            {"name": "Weight", "type": "int", "input_timing": "post_set", "is_required": True}
+        ]
+
+    monkeypatch.setattr(mis, "get_metrics_for_exercise", fake_get_metrics)
+
+    screen.populate_metrics()
+
+    weight_row = next(
+        r for r in screen.prev_metric_list.children if getattr(r, "metric_name", "") == "Weight"
+    )
+    assert getattr(weight_row.input_widget, "text", "") == "100"
+
+    notes_prev = next(
+        r for r in screen.prev_optional_list.children if getattr(r, "metric_name", "") == "Notes"
+    )
+    assert getattr(notes_prev.input_widget, "text", "") == "prev"
+
+    notes_next = next(
+        r for r in screen.next_optional_list.children if getattr(r, "metric_name", "") == "Notes"
+    )
+    assert getattr(notes_next.input_widget, "text", "") == ""
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_rest_screen_toggle_ready_changes_state():
     screen = RestScreen()
     screen.is_ready = False

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -103,23 +103,32 @@ class MetricInputScreen(MDScreen):
         app = MDApp.get_running_app()
         prev_metrics = []
         next_metrics = []
+        prev_values = {}
+        next_values = {}
+        upcoming_ex = ""
         if app.workout_session:
-            curr_ex = app.workout_session.next_exercise_name()
+            session = app.workout_session
+            curr_ex = session.next_exercise_name()
             self.exercise_name = curr_ex
             all_metrics = get_metrics_for_exercise(
-                curr_ex, preset_name=app.workout_session.preset_name
+                curr_ex, preset_name=session.preset_name
             )
             prev_metrics = [m for m in all_metrics if m.get("input_timing") == "post_set"]
+            prev_values = session.last_recorded_set_metrics()
 
-            upcoming_ex = app.workout_session.upcoming_exercise_name()
+            upcoming_ex = session.upcoming_exercise_name()
             next_all = (
                 get_metrics_for_exercise(
-                    upcoming_ex, preset_name=app.workout_session.preset_name
+                    upcoming_ex, preset_name=session.preset_name
                 )
                 if upcoming_ex
                 else []
             )
             next_metrics = [m for m in next_all if m.get("input_timing") == "pre_set"]
+            next_values = session.pending_pre_set_metrics.copy()
+
+            if getattr(app, "record_pre_set", False) and not prev_values:
+                prev_metrics = []
         elif metrics is not None:
             prev_metrics = metrics
             next_metrics = metrics
@@ -140,17 +149,34 @@ class MetricInputScreen(MDScreen):
         next_optional = [m for m in next_metrics if not m.get("is_required")]
 
         for m in prev_required:
-            self.prev_metric_list.add_widget(self._create_row(m))
+            self.prev_metric_list.add_widget(
+                self._create_row(m, prev_values.get(m.get("name")))
+            )
         for m in next_required:
-            self.next_metric_list.add_widget(self._create_row(m))
+            self.next_metric_list.add_widget(
+                self._create_row(m, next_values.get(m.get("name")))
+            )
         for m in prev_optional:
-            self.prev_optional_list.add_widget(self._create_row(m))
+            self.prev_optional_list.add_widget(
+                self._create_row(m, prev_values.get(m.get("name")))
+            )
         for m in next_optional:
-            self.next_optional_list.add_widget(self._create_row(m))
+            self.next_optional_list.add_widget(
+                self._create_row(m, next_values.get(m.get("name")))
+            )
+
+        if prev_values:
+            self.prev_optional_list.add_widget(
+                self._create_row({"name": "Notes", "type": "str"}, prev_values.get("Notes"))
+            )
+        if upcoming_ex:
+            self.next_optional_list.add_widget(
+                self._create_row({"name": "Notes", "type": "str"}, next_values.get("Notes"))
+            )
 
         self.update_header()
 
-    def _create_row(self, metric):
+    def _create_row(self, metric, value=None):
         if isinstance(metric, str):
             name = metric
             mtype = "str"
@@ -166,20 +192,28 @@ class MetricInputScreen(MDScreen):
         row.add_widget(MDLabel(text=name, size_hint_x=0.4))
 
         if mtype == "slider":
-            widget = MDSlider(min=0, max=1, value=0)
+            widget = MDSlider(min=0, max=1, value=value or 0)
             widget.bind(
                 on_touch_down=self.on_slider_touch_down,
                 on_touch_up=self.on_slider_touch_up,
             )
         elif mtype == "enum":
-            widget = Spinner(text=values[0] if values else "", values=values)
+            widget = Spinner(
+                text=str(value) if value not in (None, "") else (values[0] if values else ""),
+                values=values,
+            )
         else:  # manual_text
             input_filter = None
             if mtype == "int":
                 input_filter = "int"
             elif mtype == "float":
                 input_filter = "float"
-            widget = MDTextField(multiline=False, input_filter=input_filter)
+            multiline = name == "Notes"
+            widget = MDTextField(
+                multiline=multiline,
+                input_filter=input_filter,
+                text=str(value) if value not in (None, "") else "",
+            )
 
         row.input_widget = widget
         row.add_widget(widget)


### PR DESCRIPTION
## Summary
- Track last recorded set metrics in `WorkoutSession`.
- Pre-fill previous set metrics and add notes fields to metric input screen.
- Cover last-set metric prefill and notes behavior with a unit test.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68908d02d8e08332b03d5cd1cb6f76d7