### PR TITLE
Refactor rest screen buttons to icon grid

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -1,4 +1,5 @@
 #:import NoTransition kivy.uix.screenmanager.NoTransition
+#:import ButtonBehavior kivy.uix.behaviors.button.ButtonBehavior
 ScreenManager:
     WelcomeScreen:
         name: "welcome"
@@ -362,6 +363,29 @@ ScreenManager:
             text: "Back to Home"
             on_release: app.root.current = "home"
 
+<IconTextButton@MDBoxLayout+ButtonBehavior>:
+    icon: ""
+    text: ""
+    md_bg_color: 0, 0, 0, 0
+    orientation: "vertical"
+    spacing: "4dp"
+    padding: "8dp"
+    size_hint: None, None
+    size: self.minimum_size
+    canvas.before:
+        Color:
+            rgba: root.md_bg_color
+        RoundedRectangle:
+            pos: self.pos
+            size: self.size
+            radius: [8]
+    MDIcon:
+        icon: root.icon
+        halign: "center"
+    MDLabel:
+        text: root.text
+        halign: "center"
+
 <RestScreen>:
     BoxLayout:
         orientation: "vertical"
@@ -404,25 +428,36 @@ ScreenManager:
         Widget:
             size_hint_y: None
             height: "20dp"
-        MDRaisedButton:
-            id: record_btn
-            text: "Record Metrics"
-            on_release:
-                app.record_new_set = False
-                app.record_pre_set = True
-                app.root.current = "metric_input"
-        MDRaisedButton:
-            text: "Edit Workout"
-            on_release: app.root.current = "workout_edit"
-        MDRaisedButton:
-            text: "Workout Settings"
-            on_release: app.root.current = "workout_settings"
-        MDRaisedButton:
-            text: "Previous Workouts"
-            on_release: app.root.current = "previous_workouts"
-        MDRaisedButton:
-            text: "Finish Workout"
-            on_release: app.root.current = "workout_summary"
+        MDGridLayout:
+            cols: 5
+            spacing: "10dp"
+            size_hint_y: None
+            height: self.minimum_height
+            pos_hint: {"center_x": 0.5}
+            IconTextButton:
+                id: record_btn
+                icon: "clipboard"
+                text: "metrics"
+                on_release:
+                    app.record_new_set = False
+                    app.record_pre_set = True
+                    app.root.current = "metric_input"
+            IconTextButton:
+                icon: "pencil"
+                text: "edit"
+                on_release: app.root.current = "workout_edit"
+            IconTextButton:
+                icon: "cog"
+                text: "settings"
+                on_release: app.root.current = "workout_settings"
+            IconTextButton:
+                icon: "book"
+                text: "history"
+                on_release: app.root.current = "previous_workouts"
+            IconTextButton:
+                icon: "flag-checkered"
+                text: "finish"
+                on_release: app.root.current = "workout_summary"
 
 <WorkoutActiveScreen>:
     on_leave: root.stop_timer()


### PR DESCRIPTION
## Summary
- Add reusable `IconTextButton` widget combining an icon and label
- Replace vertical rest screen buttons with a horizontal grid of icon buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890909647908332be50ee9ac6824be2