### PR TITLE
Persist completed workout sessions

### DIFF
--- a/tests/test_session_save.py
+++ b/tests/test_session_save.py
@@ -1,0 +1,33 @@
+import sqlite3
+import pytest
+import core
+
+
+def _complete_session(db_path):
+    session = core.WorkoutSession("Push Day", db_path=db_path, rest_duration=1)
+    session.record_metrics({"Reps": 10})
+    session.mark_set_completed()
+    session.record_metrics({"Reps": 8})
+    session.mark_set_completed()
+    session.record_metrics({"Reps": 5, "Weight": 100, "Machine": "A"})
+    session.mark_set_completed()
+    session.record_metrics({"Reps": 5, "Weight": 100, "Machine": "A"})
+    return session
+
+
+def test_save_completed_session(sample_db):
+    session = _complete_session(sample_db)
+    core.save_completed_session(session, db_path=sample_db)
+    conn = sqlite3.connect(sample_db)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM session_sessions")
+    assert cur.fetchone()[0] == 1
+    cur.execute("SELECT COUNT(*) FROM session_exercise_sets")
+    assert cur.fetchone()[0] == 4
+    conn.close()
+
+
+def test_save_session_validation(sample_db):
+    session = core.WorkoutSession("Push Day", db_path=sample_db)
+    with pytest.raises(ValueError):
+        core.save_completed_session(session, db_path=sample_db)

--- a/ui/screens/workout_summary_screen.py
+++ b/ui/screens/workout_summary_screen.py
@@ -2,6 +2,9 @@ from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.list import OneLineListItem
 from kivy.properties import ObjectProperty
+from kivymd.uix.dialog import MDDialog
+from kivymd.uix.button import MDRaisedButton
+import core
 
 
 class WorkoutSummaryScreen(MDScreen):
@@ -11,6 +14,17 @@ class WorkoutSummaryScreen(MDScreen):
 
     def on_pre_enter(self, *args):
         self.populate()
+        app = MDApp.get_running_app()
+        session = app.workout_session if app else None
+        if session and not getattr(session, "saved", False):
+            errors = core.validate_workout_session(session)
+            if errors:
+                self._show_error("\n".join(errors))
+            else:
+                try:
+                    core.save_completed_session(session, db_path=session.db_path)
+                except Exception as exc:
+                    self._show_error(str(exc))
         return super().on_pre_enter(*args)
 
     def populate(self):
@@ -29,4 +43,15 @@ class WorkoutSummaryScreen(MDScreen):
                 self.summary_list.add_widget(
                     OneLineListItem(text=f"Set {idx}: {metrics_text}")
                 )
+
+    def _show_error(self, message: str):
+        def close_dialog(*_):
+            dialog.dismiss()
+
+        dialog = MDDialog(
+            title="Save Error",
+            text=message,
+            buttons=[MDRaisedButton(text="OK", on_release=close_dialog)],
+        )
+        dialog.open()
 


### PR DESCRIPTION
## Summary
- validate workout sessions before saving them
- persist completed sessions, sets, and metrics to session tables
- notify the user of any issues when saving a workout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890936abae083329c892c3e077d2587