### PR TITLE
Fix rest screen navigation layout

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -370,8 +370,9 @@ ScreenManager:
     orientation: "vertical"
     spacing: "4dp"
     padding: "8dp"
-    size_hint: None, None
-    size: self.minimum_size
+    size_hint_x: 1
+    size_hint_y: None
+    height: self.minimum_height
     canvas.before:
         Color:
             rgba: root.md_bg_color
@@ -382,9 +383,14 @@ ScreenManager:
     MDIcon:
         icon: root.icon
         halign: "center"
+        size_hint_y: None
+        height: self.texture_size[1]
     MDLabel:
         text: root.text
         halign: "center"
+        font_style: "Caption"
+        size_hint_y: None
+        height: self.texture_size[1]
 
 <RestScreen>:
     BoxLayout:
@@ -433,7 +439,6 @@ ScreenManager:
             spacing: "10dp"
             size_hint_y: None
             height: self.minimum_height
-            pos_hint: {"center_x": 0.5}
             IconTextButton:
                 id: record_btn
                 icon: "clipboard"


### PR DESCRIPTION
## Summary
- ensure rest screen navigation buttons evenly spaced
- shrink caption text and widen touch area for navigation buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890964cf0ec833291a9d35f9f2cb3a8