### PR TITLE
Handle database errors when saving presets

### DIFF
--- a/ui/screens/edit_preset_screen.py
+++ b/ui/screens/edit_preset_screen.py
@@ -24,6 +24,7 @@ from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.button import MDRaisedButton
 from kivymd.uix.dialog import MDDialog
 import os
+import sqlite3
 
 import core
 from core import DEFAULT_DB_PATH
@@ -434,7 +435,7 @@ class EditPresetScreen(MDScreen):
         try:
             # Validate before confirmation to show immediate error
             app.preset_editor.save()
-        except ValueError as exc:
+        except (ValueError, sqlite3.IntegrityError, Exception) as exc:
             dialog = MDDialog(
                 title="Error",
                 text=str(exc),


### PR DESCRIPTION
## Summary
- Broaden pre-save validation to catch database integrity and other exceptions and show an error dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890b58fe0dc8332948d225d34654249