### PR TITLE
Fix rest screen button styling and metric warning

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -367,6 +367,7 @@ ScreenManager:
     on_press: print("IconTextButton pressed:", root.icon)
     icon: ""
     text: ""
+    text_color: 1, 1, 1, 1
     md_bg_color: 0, 0, 0, 0
     orientation: "vertical"
     spacing: "4dp"
@@ -374,13 +375,6 @@ ScreenManager:
     size_hint_x: 1
     size_hint_y: None
     height: "72dp"
-    canvas.before:
-        Color:
-            rgba: 1, 0, 0, 0.2  # 🔴 Red semi-transparent background
-        RoundedRectangle:
-            pos: self.pos
-            size: self.size
-            radius: [8]
 
     MDIcon:
         icon: root.icon
@@ -388,15 +382,19 @@ ScreenManager:
         size_hint_y: None
         size_hint_x: None
         size: self.texture_size
-        pos_hint: {"center_x": 0.5}  # This is the key to center the icon
+        pos_hint: {"center_x": 0.5}
+        theme_text_color: "Custom"
+        text_color: root.text_color
 
     MDLabel:
         text: root.text
         font_size: "7sp"
         halign: "center"
-        text_size: None, None  # ← Key part: disables wrapping!
+        text_size: None, None
         size_hint_y: None
         height: self.texture_size[1]
+        theme_text_color: "Custom"
+        text_color: root.text_color
 
 <RestScreen>:
     BoxLayout:


### PR DESCRIPTION
## Summary
- Remove red background from rest screen navigation buttons
- Allow metrics button text and icon color to update when metrics are missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890bb6b6e3883328be3cebb9cc16280