### PR TITLE
Initialize rest timer before screen is shown

### DIFF
--- a/ui/screens/rest_screen.py
+++ b/ui/screens/rest_screen.py
@@ -19,7 +19,7 @@ class RestScreen(MDScreen):
     is_ready = BooleanProperty(False)
     timer_color = ListProperty([1, 0, 0, 1])
 
-    def on_enter(self, *args):
+    def on_pre_enter(self, *args):
         session = MDApp.get_running_app().workout_session
         if session:
             ex_name = session.next_exercise_name()
@@ -44,6 +44,9 @@ class RestScreen(MDScreen):
         self.update_timer(0)
         self._event = Clock.schedule_interval(self.update_timer, 0.1)
         self.update_record_button_color()
+        return super().on_pre_enter(*args)
+
+    def on_enter(self, *args):
         return super().on_enter(*args)
 
     def on_leave(self, *args):


### PR DESCRIPTION
## Summary
- Initialize RestScreen state in `on_pre_enter` so timer and labels are ready before the screen displays.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890bb96092c8332a47955a8a5d1dff1