### PR TITLE
Handle enum metrics requiring explicit selection

### DIFF
--- a/core.py
+++ b/core.py
@@ -939,7 +939,11 @@ class WorkoutSession:
         """Return ``True`` if all required pre-set metrics have been entered."""
 
         required = self.required_pre_set_metric_names()
-        return all(name in self.pending_pre_set_metrics for name in required)
+        return all(
+            name in self.pending_pre_set_metrics
+            and self.pending_pre_set_metrics.get(name) not in (None, "")
+            for name in required
+        )
 
     # --------------------------------------------------------------
     # Post-set metric helpers

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -48,6 +48,21 @@ def test_pre_set_metrics_flow(sample_db):
     assert session.exercises[1]["results"][0] == {"Reps": 5, "Weight": 100}
 
 
+def test_pre_set_metrics_require_selection(sample_db):
+    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+
+    session.record_metrics({"Reps": 10})
+    session.mark_set_completed()
+    session.record_metrics({"Reps": 8})
+    session.mark_set_completed()
+
+    assert session.next_exercise_name() == "Bench Press"
+    session.set_pre_set_metrics({"Reps": ""})
+    assert not session.has_required_pre_set_metrics()
+    session.set_pre_set_metrics({"Reps": 5})
+    assert session.has_required_pre_set_metrics()
+
+
 def test_rest_time_uses_next_exercise(sample_db):
     conn = sqlite3.connect(sample_db)
     conn.execute(

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -268,7 +268,7 @@ class MetricInputScreen(MDScreen):
             )
         elif mtype == "enum":
             widget = Spinner(
-                text=str(value) if value not in (None, "") else (values[0] if values else ""),
+                text=str(value) if value not in (None, "") else "",
                 values=values,
             )
         else:  # manual_text


### PR DESCRIPTION
## Summary
- require a non-empty value before treating required pre-set metrics as filled
- show enum metrics with an initially blank spinner
- test enum metric collection and selection requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890c1c72fbc833299d8708468954688