### PR TITLE
Ensure workout sessions capture preset metadata

### DIFF
--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -45,7 +45,7 @@ def test_pre_set_metrics_flow(sample_db):
     session.set_pre_set_metrics({"Reps": 5})
     assert session.has_required_pre_set_metrics()
     session.record_metrics({"Weight": 100})
-    assert session.exercises[1]["results"][0] == {"Reps": 5, "Weight": 100}
+    assert session.exercises[1]["results"][0]["metrics"] == {"Reps": 5, "Weight": 100}
 
 
 def test_rest_time_uses_next_exercise(sample_db):


### PR DESCRIPTION
## Summary
- Load preset, exercise, and metric identifiers and descriptions when starting a session
- Track per-set start/end times and notes
- Persist identifiers and timestamps to session tables during save

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890c348b774833295f15a4ded0a2b0a