### PR TITLE
feat: allow adjusted finish time

### DIFF
--- a/core.py
+++ b/core.py
@@ -859,9 +859,14 @@ class WorkoutSession:
         # track whether this session has been saved to the database
         self.saved: bool = False
 
-    def mark_set_completed(self) -> None:
-        """Record completion time and update rest timer for the next set."""
-        self.last_set_time = time.time()
+    def mark_set_completed(self, adjust_seconds: int = 0) -> None:
+        """Record completion time and update rest timer for the next set.
+
+        ``adjust_seconds`` allows backdating the completion timestamp by the
+        specified number of seconds.  Negative values indicate the set finished
+        earlier than the current clock time.
+        """
+        self.last_set_time = time.time() + adjust_seconds
         if self.current_exercise < len(self.exercises):
             upcoming = self.exercises[self.current_exercise]
             self.rest_duration = upcoming.get("rest", self.rest_duration)

--- a/main.kv
+++ b/main.kv
@@ -484,12 +484,27 @@ ScreenManager:
             halign: "center"
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1
-        MDRaisedButton:
-            text: "End Set"
-            on_release:
-                app.record_new_set = True
-                app.mark_set_complete();
-                app.root.current = "metric_input"
+        MDBoxLayout:
+            orientation: "horizontal"
+            spacing: "10dp"
+            MDRaisedButton:
+                text: "Finish"
+                on_release:
+                    app.record_new_set = True
+                    app.mark_set_complete()
+                    app.root.current = "metric_input"
+            MDRaisedButton:
+                text: "-5"
+                on_release:
+                    app.record_new_set = True
+                    app.mark_set_complete(-5)
+                    app.root.current = "metric_input"
+            MDRaisedButton:
+                text: "-10"
+                on_release:
+                    app.record_new_set = True
+                    app.mark_set_complete(-10)
+                    app.root.current = "metric_input"
 
 <MetricInputScreen>:
     on_pre_enter: root.populate_metrics()

--- a/main.py
+++ b/main.py
@@ -435,9 +435,9 @@ class WorkoutApp(MDApp):
         # ensure metric input doesn't accidentally advance sets
         self.record_new_set = False
 
-    def mark_set_complete(self):
+    def mark_set_complete(self, adjust_seconds=0):
         if self.workout_session:
-            self.workout_session.mark_set_completed()
+            self.workout_session.mark_set_completed(adjust_seconds=adjust_seconds)
 
 
 if __name__ == "__main__":

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -1,5 +1,6 @@
 import core
 import sqlite3
+import pytest
 
 
 def test_workout_session_flow(sample_db):
@@ -77,3 +78,13 @@ def test_required_post_set_metrics(sample_db):
     assert not session.has_required_post_set_metrics()
     session.record_metrics({"Reps": 10})
     assert session.has_required_post_set_metrics()
+
+
+def test_mark_set_completed_time_adjustment(sample_db, monkeypatch):
+    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=30)
+    session.exercises[0]["rest"] = 30
+    session.record_metrics({"Reps": 10})
+    monkeypatch.setattr(core.time, "time", lambda: 165.0)
+    session.mark_set_completed(adjust_seconds=-5)
+    assert session.last_set_time == pytest.approx(160.0)
+    assert session.rest_target_time == pytest.approx(190.0)


### PR DESCRIPTION
## Summary
- allow backdating set completion and rest start time
- add Finish, -5, and -10 buttons on the active workout screen
- test backdated set completion logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890c4e40f2c8332a5fcdbba2f80920a