### PR TITLE
Improve filter button layout and color

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -534,27 +534,39 @@ ScreenManager:
             orientation: "horizontal"
             size_hint_y: None
             height: "40dp"
-            spacing: "10dp"
+            spacing: "5dp"
             padding: "0dp", "10dp"
             MDFlatButton:
+                id: required_btn
                 text: "Required"
-                theme_text_color: "Custom"
-                text_color: root.filter_color('required')
+                size_hint_x: 0.25
+                font_size: "14sp"
+                md_bg_color: root.required_color
+                text_color: 1, 1, 1, 1
                 on_release: root.toggle_filter('required')
             MDFlatButton:
+                id: additional_btn
                 text: "Additional"
-                theme_text_color: "Custom"
-                text_color: root.filter_color('additional')
+                size_hint_x: 0.25
+                font_size: "14sp"
+                md_bg_color: root.additional_color
+                text_color: 1, 1, 1, 1
                 on_release: root.toggle_filter('additional')
             MDFlatButton:
+                id: pre_btn
                 text: "Pre Set"
-                theme_text_color: "Custom"
-                text_color: root.filter_color('pre')
+                size_hint_x: 0.25
+                font_size: "14sp"
+                md_bg_color: root.pre_color
+                text_color: 1, 1, 1, 1
                 on_release: root.toggle_filter('pre')
             MDFlatButton:
+                id: post_btn
                 text: "Post Set"
-                theme_text_color: "Custom"
-                text_color: root.filter_color('post')
+                size_hint_x: 0.25
+                font_size: "14sp"
+                md_bg_color: root.post_color
+                text_color: 1, 1, 1, 1
                 on_release: root.toggle_filter('post')
         ScrollView:
             MDList:

--- a/tests/test_metric_input_tabs.py
+++ b/tests/test_metric_input_tabs.py
@@ -23,6 +23,7 @@ class _Prop:
 kivy_modules["kivy.properties"].ObjectProperty = _Prop
 kivy_modules["kivy.properties"].StringProperty = _Prop
 kivy_modules["kivy.properties"].BooleanProperty = _Prop
+kivy_modules["kivy.properties"].ListProperty = _Prop
 
 for name, module in kivy_modules.items():
     module.__spec__ = ModuleSpec(name, loader=None)

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -4,6 +4,7 @@ from kivy.properties import (
     ObjectProperty,
     StringProperty,
     BooleanProperty,
+    ListProperty,
 )
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.boxlayout import MDBoxLayout
@@ -26,6 +27,11 @@ class MetricInputScreen(MDScreen):
     show_pre = BooleanProperty(True)
     show_post = BooleanProperty(True)
 
+    required_color = ListProperty([0, 1, 0, 1])
+    additional_color = ListProperty([0, 0, 0, 1])
+    pre_color = ListProperty([0, 1, 0, 1])
+    post_color = ListProperty([0, 1, 0, 1])
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.session = None
@@ -40,6 +46,7 @@ class MetricInputScreen(MDScreen):
         self.show_additional = False
         self.show_pre = True
         self.show_post = True
+        self._update_filter_colors()
 
     # ------------------------------------------------------------------
     # Navigation
@@ -110,6 +117,7 @@ class MetricInputScreen(MDScreen):
         }.get(name)
         if attr:
             setattr(self, attr, not getattr(self, attr))
+            self._update_filter_colors()
             self.update_metrics()
 
     def filter_color(self, name: str):
@@ -120,6 +128,12 @@ class MetricInputScreen(MDScreen):
             "post": "show_post",
         }.get(name)
         return (0, 1, 0, 1) if attr and getattr(self, attr) else (0, 0, 0, 1)
+
+    def _update_filter_colors(self):
+        self.required_color = self.filter_color("required")
+        self.additional_color = self.filter_color("additional")
+        self.pre_color = self.filter_color("pre")
+        self.post_color = self.filter_color("post")
 
     # ------------------------------------------------------------------
     # Metrics


### PR DESCRIPTION
## Summary
- Color-code metric filters and update colors automatically when toggled
- Lay out filter buttons evenly with smaller text to keep them on-screen
- Add ListProperty stub to test harness

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890cd11a7c48332a484e563bab3e314