### PR TITLE
Fix metric filter buttons overflow with horizontal scroll

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -530,44 +530,60 @@ ScreenManager:
                 icon: "chevron-right"
                 on_release: root.navigate_right()
                 disabled: not root.can_nav_right
-        BoxLayout:
-            orientation: "horizontal"
+        ScrollView:
             size_hint_y: None
             height: "40dp"
-            spacing: "5dp"
-            padding: "0dp", "10dp"
-            MDFlatButton:
-                id: required_btn
-                text: "Required"
-                size_hint_x: 0.25
-                font_size: "14sp"
-                md_bg_color: root.required_color
-                text_color: 1, 1, 1, 1
-                on_release: root.toggle_filter('required')
-            MDFlatButton:
-                id: additional_btn
-                text: "Additional"
-                size_hint_x: 0.25
-                font_size: "14sp"
-                md_bg_color: root.additional_color
-                text_color: 1, 1, 1, 1
-                on_release: root.toggle_filter('additional')
-            MDFlatButton:
-                id: pre_btn
-                text: "Pre Set"
-                size_hint_x: 0.25
-                font_size: "14sp"
-                md_bg_color: root.pre_color
-                text_color: 1, 1, 1, 1
-                on_release: root.toggle_filter('pre')
-            MDFlatButton:
-                id: post_btn
-                text: "Post Set"
-                size_hint_x: 0.25
-                font_size: "14sp"
-                md_bg_color: root.post_color
-                text_color: 1, 1, 1, 1
-                on_release: root.toggle_filter('post')
+            do_scroll_x: True
+            do_scroll_y: False
+            bar_width: 0
+            BoxLayout:
+                orientation: "horizontal"
+                size_hint_x: None
+                width: self.minimum_width
+                size_hint_y: None
+                height: "40dp"
+                spacing: "5dp"
+                padding: "0dp", "10dp"
+                MDFlatButton:
+                    id: required_btn
+                    text: "Required"
+                    size_hint: None, None
+                    width: self.texture_size[0] + dp(20)
+                    height: "40dp"
+                    font_size: "14sp"
+                    md_bg_color: root.required_color
+                    text_color: 1, 1, 1, 1
+                    on_release: root.toggle_filter('required')
+                MDFlatButton:
+                    id: additional_btn
+                    text: "Additional"
+                    size_hint: None, None
+                    width: self.texture_size[0] + dp(20)
+                    height: "40dp"
+                    font_size: "14sp"
+                    md_bg_color: root.additional_color
+                    text_color: 1, 1, 1, 1
+                    on_release: root.toggle_filter('additional')
+                MDFlatButton:
+                    id: pre_btn
+                    text: "Pre Set"
+                    size_hint: None, None
+                    width: self.texture_size[0] + dp(20)
+                    height: "40dp"
+                    font_size: "14sp"
+                    md_bg_color: root.pre_color
+                    text_color: 1, 1, 1, 1
+                    on_release: root.toggle_filter('pre')
+                MDFlatButton:
+                    id: post_btn
+                    text: "Post Set"
+                    size_hint: None, None
+                    width: self.texture_size[0] + dp(20)
+                    height: "40dp"
+                    font_size: "14sp"
+                    md_bg_color: root.post_color
+                    text_color: 1, 1, 1, 1
+                    on_release: root.toggle_filter('post')
         ScrollView:
             MDList:
                 id: metrics_list


### PR DESCRIPTION
## Summary
- Wrap workout metric filter buttons in a horizontal `ScrollView`
- Allow scrolling through Required/Additional/Pre/Post filters when screen width is limited

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890d07309b083329164909e5c81bf09