### PR TITLE
Fix MDFlatButton width attr error

### DIFF
--- a/codex_mistakes.md
+++ b/codex_mistakes.md
@@ -20,3 +20,11 @@ Add new entries below as issues are encountered. Over time this becomes a refere
 - **Problem** – App crashed with `ValueError: No valid Icon was found. No valid Title was found.`
 - **Fix** – Added titles for `DetailsTab` and `WorkoutTab` in `main.kv`
 - **Lesson** – Always specify a title or icon for each KivyMD tab to satisfy initialization requirements
+
+### MDFlatButton width calculation crash
+
+- **Context** – MetricInputScreen filter buttons in `main.kv`
+- **Mistake** – Used `self.texture_size` to set button width even though `MDFlatButton` lacks this attribute
+- **Problem** – App raised `AttributeError: 'MDFlatButton' object has no attribute 'texture_size'`
+- **Fix** – Removed dependency on `texture_size` and assigned fixed widths using `dp(110)`
+- **Lesson** – MDFlatButton doesn't expose `texture_size`; prefer fixed dimensions or other sizing methods

--- a/main.kv
+++ b/main.kv
@@ -548,7 +548,7 @@ ScreenManager:
                     id: required_btn
                     text: "Required"
                     size_hint: None, None
-                    width: self.texture_size[0] + dp(20)
+                    width: dp(110)
                     height: "40dp"
                     font_size: "14sp"
                     md_bg_color: root.required_color
@@ -558,7 +558,7 @@ ScreenManager:
                     id: additional_btn
                     text: "Additional"
                     size_hint: None, None
-                    width: self.texture_size[0] + dp(20)
+                    width: dp(110)
                     height: "40dp"
                     font_size: "14sp"
                     md_bg_color: root.additional_color
@@ -568,7 +568,7 @@ ScreenManager:
                     id: pre_btn
                     text: "Pre Set"
                     size_hint: None, None
-                    width: self.texture_size[0] + dp(20)
+                    width: dp(110)
                     height: "40dp"
                     font_size: "14sp"
                     md_bg_color: root.pre_color
@@ -578,7 +578,7 @@ ScreenManager:
                     id: post_btn
                     text: "Post Set"
                     size_hint: None, None
-                    width: self.texture_size[0] + dp(20)
+                    width: dp(110)
                     height: "40dp"
                     font_size: "14sp"
                     md_bg_color: root.post_color


### PR DESCRIPTION
## Summary
- prevent MetricInputScreen filter buttons from using nonexistent `texture_size`
- log MDFlatButton width issue in codex_mistakes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890d2ee358c8332be278db159771a4b