### PR TITLE
Add multi-tap navigation for metric input screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -518,7 +518,7 @@ ScreenManager:
             size_hint_y: 0.1
             MDIconButton:
                 icon: "chevron-left"
-                on_release: root.navigate_left()
+                on_release: root.register_left_tap()
                 disabled: not root.can_nav_left
             MDLabel:
                 id: nav_label
@@ -528,7 +528,7 @@ ScreenManager:
                 text_color: 0.2, 0.6, 0.86, 1
             MDIconButton:
                 icon: "chevron-right"
-                on_release: root.navigate_right()
+                on_release: root.register_right_tap()
                 disabled: not root.can_nav_right
         ScrollView:
             size_hint_y: None

--- a/tests/test_metric_input_tabs.py
+++ b/tests/test_metric_input_tabs.py
@@ -12,6 +12,7 @@ kivy_modules = {
     "kivy.uix": types.ModuleType("kivy.uix"),
     "kivy.uix.scrollview": types.ModuleType("kivy.uix.scrollview"),
     "kivy.uix.spinner": types.ModuleType("kivy.uix.spinner"),
+    "kivy.clock": types.ModuleType("kivy.clock"),
 }
 
 kivy_modules["kivy.metrics"].dp = lambda x: x
@@ -24,6 +25,9 @@ kivy_modules["kivy.properties"].ObjectProperty = _Prop
 kivy_modules["kivy.properties"].StringProperty = _Prop
 kivy_modules["kivy.properties"].BooleanProperty = _Prop
 kivy_modules["kivy.properties"].ListProperty = _Prop
+kivy_modules["kivy.clock"].Clock = types.SimpleNamespace(
+    schedule_once=lambda *args, **kwargs: types.SimpleNamespace(cancel=lambda: None)
+)
 
 for name, module in kivy_modules.items():
     module.__spec__ = ModuleSpec(name, loader=None)
@@ -121,6 +125,8 @@ def test_navigation_across_sets_and_exercises():
             ]
             self.current_exercise = 0
             self.current_set = 0
+            self.section_starts = [0]
+            self.exercise_sections = [0, 0]
 
     screen.session = DummySession()
     screen.update_display()
@@ -137,6 +143,37 @@ def test_navigation_across_sets_and_exercises():
 
     screen.navigate_left()
     assert screen.label_text == "Bench \u2013 Set 2 of 2"
+
+
+def test_multi_tap_navigation():
+    screen = MetricInputScreen()
+
+    class DummySession:
+        def __init__(self):
+            self.exercises = [
+                {"name": "Bench", "sets": 2, "metric_defs": []},
+                {"name": "Squat", "sets": 2, "metric_defs": []},
+                {"name": "Run", "sets": 1, "metric_defs": []},
+            ]
+            self.current_exercise = 0
+            self.current_set = 0
+            self.section_starts = [0, 2]
+            self.exercise_sections = [0, 0, 1]
+
+    screen.session = DummySession()
+    screen.update_display()
+
+    screen.navigate_right_double()
+    assert (screen.exercise_idx, screen.set_idx) == (1, 0)
+
+    screen.navigate_right_triple()
+    assert (screen.exercise_idx, screen.set_idx) == (2, 0)
+
+    screen.navigate_left_double()
+    assert (screen.exercise_idx, screen.set_idx) == (1, 0)
+
+    screen.navigate_left_triple()
+    assert (screen.exercise_idx, screen.set_idx) == (0, 0)
 
 
 def test_save_future_metrics_preserves_session_state():

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -6,6 +6,7 @@ from kivy.properties import (
     BooleanProperty,
     ListProperty,
 )
+from kivy.clock import Clock
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.textfield import MDTextField
@@ -38,6 +39,10 @@ class MetricInputScreen(MDScreen):
         self.session = None
         self.exercise_idx = 0
         self.set_idx = 0
+        self._left_taps = 0
+        self._right_taps = 0
+        self._left_event = None
+        self._right_event = None
         # Explicit defaults for stubbed property behavior in tests
         self.metrics_list = None
         self.label_text = ""
@@ -86,6 +91,40 @@ class MetricInputScreen(MDScreen):
         last_set = self.set_idx == ex["sets"] - 1
         self.can_nav_right = not (last_ex and last_set)
 
+    def register_left_tap(self):
+        self._left_taps += 1
+        if self._left_event:
+            self._left_event.cancel()
+        self._left_event = Clock.schedule_once(self._process_left_tap, 0.3)
+
+    def _process_left_tap(self, _dt):
+        count = self._left_taps
+        self._left_taps = 0
+        self._left_event = None
+        if count >= 3:
+            self.navigate_left_triple()
+        elif count == 2:
+            self.navigate_left_double()
+        else:
+            self.navigate_left()
+
+    def register_right_tap(self):
+        self._right_taps += 1
+        if self._right_event:
+            self._right_event.cancel()
+        self._right_event = Clock.schedule_once(self._process_right_tap, 0.3)
+
+    def _process_right_tap(self, _dt):
+        count = self._right_taps
+        self._right_taps = 0
+        self._right_event = None
+        if count >= 3:
+            self.navigate_right_triple()
+        elif count == 2:
+            self.navigate_right_double()
+        else:
+            self.navigate_right()
+
     def navigate_left(self):
         if not self.can_nav_left:
             return
@@ -94,6 +133,30 @@ class MetricInputScreen(MDScreen):
         else:
             self.exercise_idx -= 1
             self.set_idx = self.session.exercises[self.exercise_idx]["sets"] - 1
+        self.update_display()
+
+    def navigate_left_double(self):
+        if self.set_idx > 0:
+            self.set_idx = 0
+        elif self.exercise_idx > 0:
+            self.exercise_idx -= 1
+            self.set_idx = 0
+        self.update_display()
+
+    def navigate_left_triple(self):
+        if not self.session:
+            return
+        sections = getattr(self.session, "section_starts", [])
+        if not sections:
+            return
+        current_section = self.session.exercise_sections[self.exercise_idx]
+        first_idx = sections[current_section]
+        if self.exercise_idx != first_idx or self.set_idx != 0:
+            self.exercise_idx = first_idx
+            self.set_idx = 0
+        elif current_section > 0:
+            self.exercise_idx = sections[current_section - 1]
+            self.set_idx = 0
         self.update_display()
 
     def navigate_right(self):
@@ -106,6 +169,25 @@ class MetricInputScreen(MDScreen):
             self.exercise_idx += 1
             self.set_idx = 0
         self.update_display()
+
+    def navigate_right_double(self):
+        if self.exercise_idx < len(self.session.exercises) - 1:
+            self.exercise_idx += 1
+            self.set_idx = 0
+            self.update_display()
+
+    def navigate_right_triple(self):
+        if not self.session:
+            return
+        sections = getattr(self.session, "section_starts", [])
+        if not sections:
+            return
+        current_section = self.session.exercise_sections[self.exercise_idx]
+        next_section = current_section + 1
+        if next_section < len(sections):
+            self.exercise_idx = sections[next_section]
+            self.set_idx = 0
+            self.update_display()
 
     # ------------------------------------------------------------------
     # Filter buttons


### PR DESCRIPTION
## Summary
- Track workout sections in `WorkoutSession` to support advanced navigation
- Support single, double, and triple tap navigation for sets, exercises, and sections on the Metrics screen
- Update UI and tests for new navigation behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e990176083329cee532626035189