### PR TITLE
Prompt before finishing workout sessions

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -463,7 +463,7 @@ ScreenManager:
             IconTextButton:
                 icon: "flag-checkered"
                 text: "finish"
-                on_release: app.root.current = "workout_summary"
+                on_release: root.confirm_finish()
 
 <WorkoutActiveScreen>:
     on_leave: root.stop_timer()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -338,6 +338,36 @@ def test_open_metric_input_prefers_pre_set(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_confirm_finish_opens_dialog(monkeypatch):
+    import sys
+
+    opened = {"value": False}
+
+    class DummyDialog:
+        def __init__(self, *a, **k):
+            pass
+
+        def open(self_inner):
+            opened["value"] = True
+
+        def dismiss(self_inner):
+            pass
+
+    # Replace dialog and button classes with dummies to avoid GUI work
+    monkeypatch.setattr(
+        sys.modules["ui.screens.rest_screen"], "MDDialog", DummyDialog
+    )
+    monkeypatch.setattr(
+        sys.modules["ui.screens.rest_screen"], "MDRaisedButton", lambda *a, **k: None
+    )
+
+    screen = RestScreen()
+    screen.confirm_finish()
+
+    assert opened["value"]
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_update_elapsed_formats_time(monkeypatch):
     screen = WorkoutActiveScreen()
     screen.start_time = 100.0

--- a/ui/screens/rest_screen.py
+++ b/ui/screens/rest_screen.py
@@ -2,6 +2,8 @@ from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
 from kivy.clock import Clock
 from kivy.properties import NumericProperty, StringProperty, BooleanProperty, ListProperty
+from kivymd.uix.dialog import MDDialog
+from kivymd.uix.button import MDRaisedButton
 import time
 import math
 from core import DEFAULT_REST_DURATION, get_exercise_details
@@ -95,6 +97,26 @@ class RestScreen(MDScreen):
             app.record_new_set = True
         if app.root:
             app.root.current = "metric_input"
+
+    def confirm_finish(self):
+        dialog = None
+
+        def do_finish(*_args):
+            app = MDApp.get_running_app()
+            if app and app.root:
+                app.root.current = "workout_summary"
+            if dialog:
+                dialog.dismiss()
+
+        dialog = MDDialog(
+            title="Finish Workout?",
+            text="Are you sure you want to finish this workout?",
+            buttons=[
+                MDRaisedButton(text="Cancel", on_release=lambda *_: dialog.dismiss()),
+                MDRaisedButton(text="Finish", on_release=do_finish),
+            ],
+        )
+        dialog.open()
 
     def on_touch_down(self, touch):
         if self.ids.timer_label.collide_point(*touch.pos):


### PR DESCRIPTION
## Summary
- ask for confirmation before navigating to workout summary
- cover finish confirmation with a unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e9cb2ee083329f0d1bbb27c5bcf0