### PR TITLE
Add undo button for rest screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -439,10 +439,15 @@ ScreenManager:
             size_hint_y: None
             height: "20dp"
         MDGridLayout:
-            cols: 5
+            cols: 6
             spacing: "10dp"
             size_hint_y: None
             height: self.minimum_height
+            IconTextButton:
+                icon: "undo"
+                text: "Undo"
+                disabled: root.undo_disabled
+                on_release: root.show_undo_confirmation()
             IconTextButton:
                 id: record_btn
                 icon: "clipboard"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -338,6 +338,20 @@ def test_open_metric_input_prefers_pre_set(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_active_screen_resumes_from_session(monkeypatch, sample_db):
+    screen = WorkoutActiveScreen()
+    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session.current_set_start_time = 100.0
+    session.resume_from_last_start = True
+    dummy_app = _DummyApp()
+    dummy_app.workout_session = session
+    monkeypatch.setattr(App, "get_running_app", lambda: dummy_app)
+    monkeypatch.setattr(time, "time", lambda: 106.0)
+    screen.start_timer()
+    assert int(screen.elapsed) == 6
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_update_elapsed_formats_time(monkeypatch):
     screen = WorkoutActiveScreen()
     screen.start_time = 100.0

--- a/ui/screens/workout_active_screen.py
+++ b/ui/screens/workout_active_screen.py
@@ -17,10 +17,16 @@ class WorkoutActiveScreen(MDScreen):
     def start_timer(self, *args):
         """Start or resume the stopwatch."""
         self.stop_timer()
-        self.elapsed = 0.0
-        self.formatted_time = "00:00"
-        self.start_time = time.time()
+        session = MDApp.get_running_app().workout_session
+        if session and getattr(session, "resume_from_last_start", False):
+            self.start_time = session.current_set_start_time
+            session.resume_from_last_start = False
+        else:
+            self.start_time = time.time()
+            if session:
+                session.current_set_start_time = self.start_time
         self._event = Clock.schedule_interval(self._update_elapsed, 0.1)
+        self._update_elapsed(0)
 
     def on_pre_enter(self, *args):
         session = MDApp.get_running_app().workout_session


### PR DESCRIPTION
## Summary
- allow workout session to undo last set and resume timer
- add Undo button with confirmation dialog on rest screen
- resume active timer from previous start when undoing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891ec784efc8332920c210f7a71311b