### PR TITLE
Adjust rest timer increment based on remaining time

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -412,7 +412,7 @@ ScreenManager:
             height: self.minimum_height
             MDIconButton:
                 icon: "minus"
-                on_release: root.adjust_timer(-10)
+                on_release: root.adjust_timer_by_direction(-1)
             MDLabel:
                 id: timer_label
                 text: root.timer_label
@@ -422,7 +422,7 @@ ScreenManager:
                 text_color: root.timer_color
             MDIconButton:
                 icon: "plus"
-                on_release: root.adjust_timer(10)
+                on_release: root.adjust_timer_by_direction(1)
         MDLabel:
             text: "Next: " + root.next_exercise_name if root.next_exercise_name else ""
             halign: "center"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -352,6 +352,29 @@ def test_rest_screen_toggle_ready_changes_state():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+@pytest.mark.parametrize(
+    "remaining,expected",
+    [
+        (30, 10),
+        (120, 30),
+        (400, 60),
+    ],
+)
+def test_adjust_timer_by_direction_scales_with_remaining(monkeypatch, remaining, expected):
+    screen = RestScreen()
+    base_time = 100.0
+    screen.target_time = base_time + remaining
+    monkeypatch.setattr(time, "time", lambda: base_time)
+    dummy_app = _DummyApp()
+    dummy_app.workout_session = None
+    monkeypatch.setattr(App, "get_running_app", lambda: dummy_app)
+    screen.adjust_timer_by_direction(1)
+    assert screen.target_time == pytest.approx(base_time + remaining + expected)
+    screen.adjust_timer_by_direction(-1)
+    assert screen.target_time == pytest.approx(base_time + remaining)
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_open_metric_input_sets_flags(monkeypatch):
     screen = RestScreen()
 

--- a/ui/screens/rest_screen.py
+++ b/ui/screens/rest_screen.py
@@ -138,6 +138,19 @@ class RestScreen(MDScreen):
             minutes, seconds = divmod(total_seconds, 60)
             self.timer_label = f"{minutes:02d}:{seconds:02d}"
 
+    def _adjust_step(self) -> int:
+        """Return adjustment step based on remaining rest time."""
+        remaining = max(0, self.target_time - time.time())
+        if remaining < 60:
+            return 10
+        if remaining < 300:
+            return 30
+        return 60
+
+    def adjust_timer_by_direction(self, direction: int) -> None:
+        """Adjust timer forward/backward based on remaining time."""
+        self.adjust_timer(direction * self._adjust_step())
+
     def adjust_timer(self, seconds):
         session = MDApp.get_running_app().workout_session
         if session:


### PR DESCRIPTION
## Summary
- Step size for rest timer adjustments now depends on remaining time (0–60=10s, 60–300=30s, 300+=60s)
- Plus/minus buttons in rest screen use dynamic step
- Added test verifying adjustment scaling

## Testing
- `pytest` (54 passed, 47 skipped)


------
https://chatgpt.com/codex/tasks/task_e_6891ef34a4648332ab19f41092e648e5