### PR TITLE
Fix metric input navigation back button

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -589,7 +589,7 @@ ScreenManager:
                 id: metrics_list
         MDRaisedButton:
             size_hint_y: 0.1
-            text: "Save Metrics"
+            text: "Back"
             on_release: root.save_metrics()
 
 <WorkoutEditScreen@MDScreen>:

--- a/tests/test_metric_input_tabs.py
+++ b/tests/test_metric_input_tabs.py
@@ -228,3 +228,54 @@ def test_save_future_metrics_preserves_session_state():
     assert dummy_session.current_set == 0
     assert len(dummy_session.exercises[1]["results"]) == 1
 
+
+def test_save_future_metrics_returns_to_rest():
+    screen = MetricInputScreen()
+
+    class DummySession:
+        def __init__(self):
+            self.exercises = [
+                {"name": "Bench", "sets": 1, "results": []},
+                {"name": "Squat", "sets": 1, "results": []},
+            ]
+            self.current_exercise = 0
+            self.current_set = 0
+            self.current_set_start_time = 0
+            self.pending_pre_set_metrics = {}
+            self.awaiting_post_set_metrics = False
+
+        def record_metrics(self, metrics):
+            ex = self.exercises[self.current_exercise]
+            ex.setdefault("results", []).append({"metrics": metrics})
+            self.current_set += 1
+            if self.current_set >= ex["sets"]:
+                self.current_set = 0
+                self.current_exercise += 1
+            self.pending_pre_set_metrics = {}
+            self.awaiting_post_set_metrics = False
+            return False
+
+    dummy_session = DummySession()
+    dummy_app = types.SimpleNamespace(workout_session=dummy_session)
+    metric_module.MDApp.get_running_app = classmethod(lambda cls: dummy_app)
+
+    class DummyList:
+        def __init__(self):
+            self.children = []
+
+        def clear_widgets(self):
+            pass
+
+        def add_widget(self, widget):
+            pass
+
+    screen.metrics_list = DummyList()
+    screen.session = dummy_session
+    screen.exercise_idx = 1
+    screen.set_idx = 0
+    screen.manager = types.SimpleNamespace(current="metric_input")
+
+    screen.save_metrics()
+
+    assert screen.manager.current == "rest"
+

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -382,7 +382,7 @@ class MetricInputScreen(MDScreen):
         ):
             session.set_pre_set_metrics(metrics)
             app.record_pre_set = False
-            if self.manager:
+            if getattr(self, "manager", None):
                 self.manager.current = "rest"
             return
 
@@ -406,9 +406,9 @@ class MetricInputScreen(MDScreen):
             self.exercise_idx = session.current_exercise
             self.set_idx = session.current_set
             self.update_display()
-            if finished and self.manager:
+            if finished and getattr(self, "manager", None):
                 self.manager.current = "workout_summary"
-            elif self.manager:
+            elif getattr(self, "manager", None):
                 self.manager.current = "rest"
         else:
             session.current_exercise = orig_ex
@@ -416,6 +416,8 @@ class MetricInputScreen(MDScreen):
             session.current_set_start_time = orig_start
             session.pending_pre_set_metrics = orig_pending
             session.awaiting_post_set_metrics = orig_awaiting
-            self.exercise_idx = target_ex
-            self.set_idx = target_set
+            self.exercise_idx = orig_ex
+            self.set_idx = orig_set
             self.update_display()
+            if getattr(self, "manager", None):
+                self.manager.current = "rest"


### PR DESCRIPTION
## Summary
- Ensure metric input screen returns to rest time when leaving any set
- Rename metric entry button to "Back"
- Test navigation for saving metrics on non-current sets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891efa4f51c8332bf01d0f6dd88ac0b