### PR TITLE
Show slider value in metric input screen

### DIFF
--- a/tests/test_metric_input_tabs.py
+++ b/tests/test_metric_input_tabs.py
@@ -67,6 +67,14 @@ class _TextField(_DummyWidget):
 class _Slider(_DummyWidget):
     def __init__(self, value=0, **kwargs):
         self.value = value
+        self._binding = None
+
+    def bind(self, **kwargs):
+        self._binding = kwargs.get("value")
+
+class _Label(_DummyWidget):
+    def __init__(self, text="", **kwargs):
+        self.text = text
 
 kivymd_modules["kivymd.uix.selectioncontrol"].MDCheckbox = type(
     "_Checkbox", (_DummyWidget,), {"__init__": lambda self, active=False, **k: setattr(self, "active", active)}
@@ -76,7 +84,7 @@ kivymd_modules["kivymd.uix.screen"].MDScreen = _DummyWidget
 kivymd_modules["kivymd.uix.boxlayout"].MDBoxLayout = _BoxLayout
 kivymd_modules["kivymd.uix.textfield"].MDTextField = _TextField
 kivymd_modules["kivymd.uix.slider"].MDSlider = _Slider
-kivymd_modules["kivymd.uix.label"].MDLabel = _DummyWidget
+kivymd_modules["kivymd.uix.label"].MDLabel = _Label
 kivy_modules["kivy.uix.spinner"].Spinner = _Spinner
 kivy_modules["kivy.uix.scrollview"].ScrollView = _DummyWidget
 
@@ -227,4 +235,19 @@ def test_save_future_metrics_preserves_session_state():
     assert dummy_session.current_exercise == 0
     assert dummy_session.current_set == 0
     assert len(dummy_session.exercises[1]["results"]) == 1
+
+
+def test_slider_row_updates_label():
+    screen = MetricInputScreen()
+    row = screen._create_row({"name": "Intensity", "type": "slider"}, value=0.5)
+    slider = row.input_widget
+    value_label = next(
+        child
+        for child in row.children
+        if getattr(child, "text", None) is not None and child.text != "Intensity"
+    )
+    assert value_label.text == "0.50"
+    slider.value = 0.72
+    slider._binding(slider, slider.value)
+    assert value_label.text == "0.72"
 

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -308,7 +308,12 @@ class MetricInputScreen(MDScreen):
 
         if mtype == "slider":
             widget = MDSlider(min=0, max=1, value=value or 0)
+            widget.size_hint_x = 0.4
+            value_label = MDLabel(
+                text=f"{widget.value:.2f}", size_hint_x=0.2
+            )
             widget.bind(
+                value=lambda _w, val: setattr(value_label, "text", f"{val:.2f}"),
                 on_touch_down=self.on_slider_touch_down,
                 on_touch_up=self.on_slider_touch_up,
             )
@@ -334,6 +339,8 @@ class MetricInputScreen(MDScreen):
 
         row.input_widget = widget
         row.add_widget(widget)
+        if mtype == "slider":
+            row.add_widget(value_label)
         return row
 
     def _collect_metrics(self, widget_list):


### PR DESCRIPTION
## Summary
- Display numeric value next to slider-based metrics with two decimal precision
- Test slider row label updates when value changes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891f0f85d508332ac384f76f82eb28b