### PR TITLE
Add usage modes to editing screens and popups

### DIFF
--- a/ui/popups.py
+++ b/ui/popups.py
@@ -36,13 +36,20 @@ METRIC_FIELD_ORDER = [
 class AddMetricPopup(MDDialog):
     """Popup dialog for selecting or creating metrics."""
 
-    def __init__(self, screen: "EditExerciseScreen", mode: str = "select", **kwargs):
+    def __init__(
+        self,
+        screen: "EditExerciseScreen",
+        popup_mode: str = "select",
+        mode: str = "library",
+        **kwargs,
+    ):
         self.screen = screen
         self.mode = mode
+        self.popup_mode = popup_mode
 
-        if mode == "select":
+        if popup_mode == "select":
             content, buttons, title = self._build_select_widgets()
-        elif mode == "new":
+        elif popup_mode == "new":
             content, buttons, title = self._build_new_metric_widgets()
         else:
             content, buttons, title = self._build_choice_widgets()
@@ -219,12 +226,12 @@ class AddMetricPopup(MDDialog):
     # ------------------------------------------------------------------
     def show_new_metric_form(self, *args):
         self.dismiss()
-        popup = AddMetricPopup(self.screen, mode="new")
+        popup = AddMetricPopup(self.screen, popup_mode="new", mode=self.mode)
         popup.open()
 
     def show_metric_list(self, *args):
         self.dismiss()
-        popup = AddMetricPopup(self.screen, mode="select")
+        popup = AddMetricPopup(self.screen, popup_mode="select", mode=self.mode)
         popup.open()
 
     def add_metric(self, name, *args):
@@ -314,9 +321,16 @@ class AddMetricPopup(MDDialog):
 class EditMetricPopup(MDDialog):
     """Popup for editing an existing metric."""
 
-    def __init__(self, screen: "EditExerciseScreen", metric: dict, **kwargs):
+    def __init__(
+        self,
+        screen: "EditExerciseScreen",
+        metric: dict,
+        mode: str = "library",
+        **kwargs,
+    ):
         self.screen = screen
         self.metric = metric
+        self.mode = mode
         content, buttons, title = self._build_widgets()
         super().__init__(
             title=title, type="custom", content_cls=content, buttons=buttons, **kwargs

--- a/ui/screens/edit_exercise_screen.py
+++ b/ui/screens/edit_exercise_screen.py
@@ -57,6 +57,11 @@ class EditExerciseScreen(MDScreen):
     exercise_sets = NumericProperty(DEFAULT_SETS_PER_EXERCISE)
     exercise_rest = NumericProperty(DEFAULT_REST_DURATION)
     section_length = NumericProperty(0)
+    mode = StringProperty("library")
+
+    def __init__(self, mode: str = "library", **kwargs):
+        super().__init__(**kwargs)
+        self.mode = mode
 
     def switch_tab(self, tab: str):
         """Switch between available tabs."""
@@ -269,15 +274,15 @@ class EditExerciseScreen(MDScreen):
         dialog.open()
 
     def open_add_metric_popup(self):
-        popup = AddMetricPopup(self, mode="select")
+        popup = AddMetricPopup(self, popup_mode="select", mode=self.mode)
         popup.open()
 
     def open_new_metric_popup(self):
-        popup = AddMetricPopup(self, mode="new")
+        popup = AddMetricPopup(self, popup_mode="new", mode=self.mode)
         popup.open()
 
     def open_edit_metric_popup(self, metric):
-        popup = EditMetricPopup(self, metric)
+        popup = EditMetricPopup(self, metric, mode=self.mode)
         popup.open()
 
     def save_exercise(self):

--- a/ui/screens/edit_preset_screen.py
+++ b/ui/screens/edit_preset_screen.py
@@ -154,6 +154,7 @@ class EditPresetScreen(MDScreen):
     session_metric_list = ObjectProperty(None)
     save_enabled = BooleanProperty(False)
     loading_dialog = ObjectProperty(None, allownone=True)
+    mode = StringProperty("library")
 
     preset_metric_widgets: dict = {}
 
@@ -165,6 +166,10 @@ class EditPresetScreen(MDScreen):
         (0.9, 1, 1, 1),
         (1, 0.9, 1, 1),
     ]
+
+    def __init__(self, mode: str = "library", **kwargs):
+        super().__init__(**kwargs)
+        self.mode = mode
 
     def update_save_enabled(self):
         """Refresh ``save_enabled`` based on preset modifications."""


### PR DESCRIPTION
## Summary
- allow EditPresetScreen and EditExerciseScreen to be initialized with a context mode
- propagate mode to AddMetricPopup and EditMetricPopup with separate popup_mode for existing behaviors
- adjust tests for new popup signature

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892016d6c4c8332960e911b99a20be3