### PR TITLE
fix: correct MDIcon import path

### DIFF
--- a/codex_mistakes.md
+++ b/codex_mistakes.md
@@ -28,3 +28,11 @@ Add new entries below as issues are encountered. Over time this becomes a refere
 - **Problem** – App raised `AttributeError: 'MDFlatButton' object has no attribute 'texture_size'`
 - **Fix** – Removed dependency on `texture_size` and assigned fixed widths using `dp(110)`
 - **Lesson** – MDFlatButton doesn't expose `texture_size`; prefer fixed dimensions or other sizing methods
+
+### Incorrect MDIcon import path
+
+- **Context** – `EditExerciseScreen`
+- **Mistake** – Imported `MDIcon` from `kivymd.uix.icon`, which doesn't exist in KivyMD 1.x
+- **Problem** – App crashed with `ModuleNotFoundError: No module named 'kivymd.uix.icon'`
+- **Fix** – Import `MDIcon` from `kivymd.uix.label`
+- **Lesson** – In KivyMD 1.x, use `kivymd.uix.label.MDIcon`; `kivymd.uix.icon` only exists in KivyMD 2.x

--- a/ui/screens/edit_exercise_screen.py
+++ b/ui/screens/edit_exercise_screen.py
@@ -22,7 +22,7 @@ from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.button import MDIconButton, MDRaisedButton
 from kivymd.uix.card import MDSeparator
 from kivymd.uix.dialog import MDDialog
-from kivymd.uix.icon import MDIcon
+from kivymd.uix.label import MDIcon
 from ui.popups import AddMetricPopup, EditMetricPopup
 
 import os


### PR DESCRIPTION
## Summary
- fix MDIcon import to use kivymd.uix.label
- document MDIcon import path issue in codex_mistakes log

## Testing
- `KIVY_UNITTEST=1 pytest tests/test_ui.py`
- `pip install Kivy==2.3.0 kivymd==1.2.0` *(fails: Could not find a version that satisfies the requirement Kivy==2.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68920a2a31408332963213314b81a226