### PR TITLE
Support editing presets during active sessions

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -458,7 +458,7 @@ ScreenManager:
             IconTextButton:
                 icon: "pencil"
                 text: "edit"
-                on_release: app.root.current = "workout_edit"
+                on_release: app.edit_active_preset()
             IconTextButton:
                 icon: "cog"
                 text: "settings"
@@ -677,6 +677,7 @@ ScreenManager:
             multiline: False
             hint_text: "Section Name"
             on_text: root.section_name = self.text
+            disabled: root.locked
         MDIconButton:
             icon: "chevron-down" if root.expanded else "chevron-right"
             on_release: root.toggle()
@@ -697,10 +698,14 @@ ScreenManager:
             MDRaisedButton:
                 text: "Add Exercise"
                 on_release: root.open_exercise_selection()
+                disabled: root.locked
+                opacity: 1 if not root.locked else 0
             MDRaisedButton:
                 text: "Delete"
                 md_bg_color: 1, 0, 0, 1
                 on_release: root.confirm_delete()
+                disabled: root.locked
+                opacity: 1 if not root.locked else 0
 
 <EditPresetScreen>:
     sections_box: sections_box
@@ -853,7 +858,8 @@ ScreenManager:
                 spacing: "10dp"
                 MDRaisedButton:
                     text: "Save"
-                    disabled: not root.save_enabled
+                    disabled: root.mode == "session" or not root.save_enabled
+                    opacity: 1 if root.mode != "session" else 0
                     on_release: root.save_preset()
                 MDRaisedButton:
                     text: "Back"
@@ -881,14 +887,16 @@ ScreenManager:
         MDIcon:
             icon: "arrow-up"
             font_size: "20sp"
-            on_touch_down: if self.collide_point(*args[1].pos): root.move_up()
+            on_touch_down: if not root.locked and self.collide_point(*args[1].pos): root.move_up()
             pos_hint: {"center_y": 0.5}
+            opacity: 1 if not root.locked else 0
 
         MDIcon:
             icon: "arrow-down"
             font_size: "20sp"
-            on_touch_down: if self.collide_point(*args[1].pos): root.move_down()
+            on_touch_down: if not root.locked and self.collide_point(*args[1].pos): root.move_down()
             pos_hint: {"center_y": 0.5}
+            opacity: 1 if not root.locked else 0
     MDLabel:
         size_hint_x: 1
         text: root.text
@@ -904,7 +912,8 @@ ScreenManager:
             icon: "pencil"
             font_size: "20sp"  # smaller icon size
             pos_hint: {"center_y": 0.5}  # center vertically
-            on_touch_down: if self.collide_point(*args[1].pos): root.edit()
+            on_touch_down: if not root.locked and self.collide_point(*args[1].pos): root.edit()
+            opacity: 1 if not root.locked else 0
 
         MDIcon:
             icon: "delete"
@@ -912,7 +921,8 @@ ScreenManager:
             theme_text_color: "Custom"
             text_color: 1, 0, 0, 1
             pos_hint: {"center_y": 0.5}  # center vertically
-            on_touch_down: if self.collide_point(*args[1].pos): root.remove_self()
+            on_touch_down: if not root.locked and self.collide_point(*args[1].pos): root.remove_self()
+            opacity: 1 if not root.locked else 0
 
 <ExerciseSelectionPanel>:
     exercise_list: exercise_list

--- a/main.py
+++ b/main.py
@@ -437,6 +437,38 @@ class WorkoutApp(MDApp):
         # ensure metric input doesn't accidentally advance sets
         self.record_new_set = False
 
+    def edit_active_preset(self):
+        """Open the preset editor for the active workout session."""
+        if not self.workout_session or not self.root:
+            return
+        editor = PresetEditor(db_path=DEFAULT_DB_PATH)
+        editor.preset_name = self.workout_session.preset_name
+        editor.sections = []
+        for s_idx, name in enumerate(self.workout_session.section_names):
+            start = self.workout_session.section_starts[s_idx]
+            end = (
+                self.workout_session.section_starts[s_idx + 1]
+                if s_idx + 1 < len(self.workout_session.section_starts)
+                else len(self.workout_session.exercises)
+            )
+            exercises = []
+            for ex in self.workout_session.exercises[start:end]:
+                exercises.append(
+                    {
+                        "name": ex.get("name"),
+                        "sets": ex.get("sets"),
+                        "rest": ex.get("rest"),
+                        "library_id": ex.get("library_exercise_id"),
+                        "id": ex.get("preset_section_exercise_id"),
+                    }
+                )
+            editor.sections.append({"name": name, "exercises": exercises})
+        editor.mark_saved()
+        self.preset_editor = editor
+        screen = self.root.get_screen("edit_preset")
+        screen.mode = "session"
+        self.root.current = "edit_preset"
+
     def mark_set_complete(self, adjust_seconds=0):
         if self.workout_session:
             self.workout_session.mark_set_completed(adjust_seconds=adjust_seconds)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1407,3 +1407,18 @@ def test_refresh_sections_preserves_names(monkeypatch):
         "Skill work",
         "Workout",
     ]
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_session_edit_locking(monkeypatch, sample_db):
+    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    app = _DummyApp()
+    app.workout_session = session
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+    screen = EditPresetScreen(mode="session")
+    assert not screen._is_section_locked(0)
+    assert not screen._is_exercise_locked(0, 0)
+    session.current_set = 1
+    assert screen._is_section_locked(0)
+    assert screen._is_exercise_locked(0, 0)
+    assert not screen._is_exercise_locked(0, 1)

--- a/ui/screens/edit_preset_screen.py
+++ b/ui/screens/edit_preset_screen.py
@@ -38,9 +38,12 @@ class SectionWidget(MDBoxLayout):
     color = ListProperty([1, 1, 1, 1])
     expanded = BooleanProperty(True)
     visible = BooleanProperty(True)
+    locked = BooleanProperty(False)
 
     def on_section_name(self, instance, value):
         """Update the section name in the preset editor."""
+        if self.locked:
+            return
         app = MDApp.get_running_app()
         if app and app.preset_editor:
             try:
@@ -55,6 +58,8 @@ class SectionWidget(MDBoxLayout):
         self.expanded = not self.expanded
 
     def open_exercise_selection(self):
+        if self.locked:
+            return
         app = MDApp.get_running_app()
         app.editing_section_index = self.section_index
         if app.root:
@@ -70,14 +75,19 @@ class SectionWidget(MDBoxLayout):
             return
         box = self.ids.exercise_list
         box.clear_widgets()
+        edit = app.root.get_screen("edit_preset") if app.root else None
         for idx, ex in enumerate(
             app.preset_editor.sections[self.section_index]["exercises"]
         ):
+            locked = self.locked
+            if edit:
+                locked = locked or edit._is_exercise_locked(self.section_index, idx)
             box.add_widget(
                 SelectedExerciseItem(
                     text=ex["name"],
                     section_index=self.section_index,
                     exercise_index=idx,
+                    locked=locked,
                 )
             )
 
@@ -108,15 +118,22 @@ class SectionWidget(MDBoxLayout):
     def add_exercise_widget(self, name: str, idx: int) -> None:
         """Append a single exercise widget to the list."""
         box = self.ids.exercise_list
+        edit = MDApp.get_running_app().root.get_screen("edit_preset") if MDApp.get_running_app().root else None
+        locked = self.locked
+        if edit:
+            locked = locked or edit._is_exercise_locked(self.section_index, idx)
         box.add_widget(
             SelectedExerciseItem(
                 text=name,
                 section_index=self.section_index,
                 exercise_index=idx,
+                locked=locked,
             )
         )
 
     def confirm_delete(self):
+        if self.locked:
+            return
         dialog = None
 
         def do_delete(*args):
@@ -209,19 +226,137 @@ class EditPresetScreen(MDScreen):
 
     def _load_preset(self):
         app = MDApp.get_running_app()
-        app.init_preset_editor()
-        self.preset_name = app.preset_editor.preset_name or "Preset"
-        self.current_tab = "sections"
-        if self.sections_box:
-            self.sections_box.clear_widgets()
-            for idx, sec in enumerate(app.preset_editor.sections):
-                self.add_section(sec["name"], index=idx)
-            if not app.preset_editor.sections:
-                self.add_section()
-        self.update_save_enabled()
+        if self.mode == "session":
+            self.preset_name = (
+                app.preset_editor.preset_name if app.preset_editor else "Preset"
+            )
+            self.current_tab = "sections"
+            if self.sections_box:
+                self.sections_box.clear_widgets()
+                for idx, sec in enumerate(app.preset_editor.sections):
+                    locked = self._is_section_locked(idx)
+                    self.add_section(sec["name"], index=idx, locked=locked)
+                if not app.preset_editor.sections:
+                    self.add_section()
+            self.update_save_enabled()
+        else:
+            app.init_preset_editor()
+            self.preset_name = app.preset_editor.preset_name or "Preset"
+            self.current_tab = "sections"
+            if self.sections_box:
+                self.sections_box.clear_widgets()
+                for idx, sec in enumerate(app.preset_editor.sections):
+                    self.add_section(sec["name"], index=idx)
+                if not app.preset_editor.sections:
+                    self.add_section()
+            self.update_save_enabled()
         if self.loading_dialog:
             self.loading_dialog.dismiss()
             self.loading_dialog = None
+
+    def _is_section_locked(self, section_index: int) -> bool:
+        """Return ``True`` if the section at ``section_index`` is locked."""
+        if self.mode != "session":
+            return False
+        app = MDApp.get_running_app()
+        session = getattr(app, "workout_session", None)
+        if not session:
+            return False
+        if section_index >= len(session.section_starts):
+            return False
+        start = session.section_starts[section_index]
+        end = (
+            session.section_starts[section_index + 1]
+            if section_index + 1 < len(session.section_starts)
+            else len(session.exercises)
+        )
+        if session.current_exercise >= end:
+            return True
+        if start <= session.current_exercise < end and session.current_set > 0:
+            return True
+        return False
+
+    def _is_exercise_locked(self, section_index: int, exercise_index: int) -> bool:
+        """Return ``True`` if the exercise is locked."""
+        if self.mode != "session":
+            return False
+        app = MDApp.get_running_app()
+        session = getattr(app, "workout_session", None)
+        if not session:
+            return False
+        if section_index >= len(session.section_starts):
+            return False
+        global_index = session.section_starts[section_index] + exercise_index
+        if global_index < session.current_exercise:
+            return True
+        if global_index == session.current_exercise and session.current_set > 0:
+            return True
+        return False
+
+    def apply_session_changes(self):
+        """Merge edits back into the active workout session."""
+        app = MDApp.get_running_app()
+        session = getattr(app, "workout_session", None)
+        editor = getattr(app, "preset_editor", None)
+        if not session or not editor:
+            return
+        current_id = None
+        if session.current_exercise < len(session.exercises):
+            current_id = session.exercises[session.current_exercise].get(
+                "preset_section_exercise_id"
+            )
+
+        id_map = {
+            ex.get("preset_section_exercise_id"): ex for ex in session.exercises
+        }
+        new_exercises = []
+        new_section_names = []
+        new_section_starts = []
+        new_exercise_sections = []
+        for s_idx, sec in enumerate(editor.sections):
+            new_section_names.append(sec["name"])
+            new_section_starts.append(len(new_exercises))
+            for ex in sec.get("exercises", []):
+                old = id_map.get(ex.get("id"))
+                if old:
+                    results = old.get("results", [])
+                    description = old.get("exercise_description", "")
+                    metric_defs = old.get("metric_defs")
+                else:
+                    results = []
+                    description = ""
+                    metric_defs = core.get_metrics_for_exercise(
+                        ex["name"],
+                        db_path=session.db_path,
+                        preset_name=session.preset_name,
+                    )
+                new_exercises.append(
+                    {
+                        "name": ex.get("name"),
+                        "sets": ex.get("sets") or core.DEFAULT_SETS_PER_EXERCISE,
+                        "rest": ex.get("rest") or session.rest_duration,
+                        "results": results,
+                        "library_exercise_id": ex.get("library_id"),
+                        "preset_section_exercise_id": ex.get("id"),
+                        "exercise_description": description,
+                        "metric_defs": metric_defs,
+                        "section_index": s_idx,
+                        "section_name": sec.get("name"),
+                    }
+                )
+                new_exercise_sections.append(s_idx)
+
+        session.exercises = new_exercises
+        session.section_names = new_section_names
+        session.section_starts = new_section_starts
+        session.exercise_sections = new_exercise_sections
+
+        if current_id is not None:
+            for idx, ex in enumerate(session.exercises):
+                if ex.get("preset_section_exercise_id") == current_id:
+                    session.current_exercise = idx
+                    break
+        session.current_exercise = min(session.current_exercise, len(session.exercises) - 1)
 
     def refresh_sections(self):
         """Repopulate the section widgets from the preset editor."""
@@ -230,7 +365,8 @@ class EditPresetScreen(MDScreen):
             return
         self.sections_box.clear_widgets()
         for idx, sec in enumerate(app.preset_editor.sections):
-            self.add_section(sec["name"], index=idx)
+            locked = self._is_section_locked(idx)
+            self.add_section(sec["name"], index=idx, locked=locked)
         if not app.preset_editor.sections:
             self.add_section()
 
@@ -262,7 +398,12 @@ class EditPresetScreen(MDScreen):
             if isinstance(child, SectionWidget):
                 child.visible = True
 
-    def add_section(self, name: str | None = None, index: int | None = None):
+    def add_section(
+        self,
+        name: str | None = None,
+        index: int | None = None,
+        locked: bool = False,
+    ):
         """Add a new section to the preset and return the widget."""
         if not self.sections_box:
             return None
@@ -272,7 +413,9 @@ class EditPresetScreen(MDScreen):
                 name = f"Section {len(app.preset_editor.sections) + 1}"
             index = app.preset_editor.add_section(name)
         color = self._colors[len(self.sections_box.children) % len(self._colors)]
-        section = SectionWidget(section_index=index, section_name=name, color=color)
+        section = SectionWidget(
+            section_index=index, section_name=name, color=color, locked=locked
+        )
         self.sections_box.add_widget(section)
         section.refresh_exercises()
         self.update_save_enabled()
@@ -487,30 +630,36 @@ class EditPresetScreen(MDScreen):
 
     def go_back(self):
         app = MDApp.get_running_app()
-        if app.preset_editor and app.preset_editor.is_modified():
-            dialog = None
+        if self.mode == "session":
+            self.apply_session_changes()
+            if self.manager:
+                self.manager.current = "rest"
+            self.mode = "library"
+        else:
+            if app.preset_editor and app.preset_editor.is_modified():
+                dialog = None
 
-            def discard(*args):
-                if dialog:
-                    dialog.dismiss()
-                app.init_preset_editor(force_reload=True)
+                def discard(*args):
+                    if dialog:
+                        dialog.dismiss()
+                    app.init_preset_editor(force_reload=True)
+                    if self.manager:
+                        self.manager.current = "presets"
+
+                dialog = MDDialog(
+                    title="Discard Changes?",
+                    text="You have unsaved changes. Discard them?",
+                    buttons=[
+                        MDRaisedButton(
+                            text="Cancel", on_release=lambda *a: dialog.dismiss()
+                        ),
+                        MDRaisedButton(text="Discard", on_release=discard),
+                    ],
+                )
+                dialog.open()
+            else:
                 if self.manager:
                     self.manager.current = "presets"
-
-            dialog = MDDialog(
-                title="Discard Changes?",
-                text="You have unsaved changes. Discard them?",
-                buttons=[
-                    MDRaisedButton(
-                        text="Cancel", on_release=lambda *a: dialog.dismiss()
-                    ),
-                    MDRaisedButton(text="Discard", on_release=discard),
-                ],
-            )
-            dialog.open()
-        else:
-            if self.manager:
-                self.manager.current = "presets"
 
 
 class SelectedExerciseItem(MDBoxLayout):
@@ -519,9 +668,12 @@ class SelectedExerciseItem(MDBoxLayout):
     text = StringProperty("")
     section_index = NumericProperty(0)
     exercise_index = NumericProperty(0)
+    locked = BooleanProperty(False)
 
     def edit(self):
         """Open the EditExerciseScreen for this exercise."""
+        if self.locked:
+            return
         app = MDApp.get_running_app()
         if not app.root:
             return
@@ -535,6 +687,8 @@ class SelectedExerciseItem(MDBoxLayout):
         app.root.current = "edit_exercise"
 
     def move_up(self):
+        if self.locked:
+            return
         app = MDApp.get_running_app()
         if not app or not app.preset_editor:
             return
@@ -557,6 +711,8 @@ class SelectedExerciseItem(MDBoxLayout):
             edit.update_save_enabled()
 
     def move_down(self):
+        if self.locked:
+            return
         app = MDApp.get_running_app()
         if not app or not app.preset_editor:
             return
@@ -580,6 +736,8 @@ class SelectedExerciseItem(MDBoxLayout):
             edit.update_save_enabled()
 
     def remove_self(self):
+        if self.locked:
+            return
         dialog = None
 
         def do_delete(*args):


### PR DESCRIPTION
## Summary
- Enable editing of upcoming exercises within an active workout session
- Lock started sections and exercises from modification while in session mode
- Add tests for session edit locking behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68920fbcac788332b83f23d4187150ae