### PR TITLE
Lock preset editing in session mode

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -168,6 +168,7 @@ ScreenManager:
     is_user_created: False
     edit_callback: None
     delete_callback: None
+    locked: False
     orientation: "horizontal"
     size_hint_y: None
     height: "56dp"
@@ -181,7 +182,7 @@ ScreenManager:
         valign: "center"
     MDBoxLayout:
         size_hint_x: None
-        width: "36dp"
+        width: "36dp" if not root.locked else 0
         orientation: "horizontal"
         spacing: "5dp"
         valign: "center"
@@ -189,16 +190,18 @@ ScreenManager:
             icon: "pencil"
             font_size: "20sp"
             pos_hint: {"center_y": 0.5}
-            on_touch_down: if self.collide_point(*args[1].pos) and root.edit_callback: root.edit_callback(root.name, root.is_user_created)
+            opacity: 1 if not root.locked else 0
+            disabled: root.locked
+            on_touch_down: if not root.locked and self.collide_point(*args[1].pos) and root.edit_callback: root.edit_callback(root.name, root.is_user_created)
         MDIcon:
             icon: "delete"
             font_size: "20sp"
             theme_text_color: "Custom"
             text_color: 1, 0, 0, 1
             pos_hint: {"center_y": 0.5}
-            opacity: 1 if root.is_user_created else 0
-            disabled: not root.is_user_created
-            on_touch_down: if self.collide_point(*args[1].pos) and root.delete_callback: root.delete_callback(root.name)
+            opacity: 1 if root.is_user_created and not root.locked else 0
+            disabled: not root.is_user_created or root.locked
+            on_touch_down: if not root.locked and self.collide_point(*args[1].pos) and root.delete_callback: root.delete_callback(root.name)
 
 <ExerciseLibraryScreen>:
     exercise_list: exercise_list
@@ -805,6 +808,7 @@ ScreenManager:
                                         multiline: False
                                         on_text: root.update_preset_name(self.text)
                                         size_hint_x: 1
+                                        readonly: root.mode == "session"
                                 MDBoxLayout:
                                     id: metrics_box
                                     orientation: "vertical"

--- a/ui/screens/edit_preset_screen.py
+++ b/ui/screens/edit_preset_screen.py
@@ -489,6 +489,11 @@ class EditPresetScreen(MDScreen):
                 elif mtype == "float":
                     input_filter = "float"
                 widget = MDTextField(text=str(value if value is not None else ""), multiline=False, input_filter=input_filter)
+                if self.mode == "session":
+                    widget.readonly = True
+
+            if self.mode == "session" and not isinstance(widget, MDTextField):
+                widget.disabled = True
 
             self.preset_metric_widgets[name] = widget
 
@@ -563,6 +568,7 @@ class EditPresetScreen(MDScreen):
                 ).get(
                     "is_user_created", False
                 ),
+                "locked": self.mode == "session",
             }
             for m in metrics
         ]


### PR DESCRIPTION
## Summary
- Make preset name and detail fields read-only during workout sessions
- Hide edit/delete icons for session metrics and prevent interaction

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68921566a50c8332bfffa6ad8f06a8b4