### PR TITLE
Fix current exercise selection after reordering

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1422,3 +1422,18 @@ def test_session_edit_locking(monkeypatch, sample_db):
     assert screen._is_section_locked(0)
     assert screen._is_exercise_locked(0, 0)
     assert not screen._is_exercise_locked(0, 1)
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_reordering_current_exercise_updates_index(monkeypatch, sample_db):
+    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    editor = core.PresetEditor("Push Day", db_path=sample_db)
+    app = _DummyApp()
+    app.workout_session = session
+    app.preset_editor = editor
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+    screen = EditPresetScreen(mode="session")
+    editor.move_exercise(0, 0, 1)
+    screen.apply_session_changes()
+    assert [e["name"] for e in session.exercises] == ["Bench Press", "Push-up"]
+    assert session.current_exercise == 0

--- a/ui/screens/edit_preset_screen.py
+++ b/ui/screens/edit_preset_screen.py
@@ -300,9 +300,10 @@ class EditPresetScreen(MDScreen):
         editor = getattr(app, "preset_editor", None)
         if not session or not editor:
             return
+        old_index = session.current_exercise
         current_id = None
-        if session.current_exercise < len(session.exercises):
-            current_id = session.exercises[session.current_exercise].get(
+        if old_index < len(session.exercises):
+            current_id = session.exercises[old_index].get(
                 "preset_section_exercise_id"
             )
 
@@ -351,12 +352,17 @@ class EditPresetScreen(MDScreen):
         session.section_starts = new_section_starts
         session.exercise_sections = new_exercise_sections
 
+        new_idx = None
         if current_id is not None:
             for idx, ex in enumerate(session.exercises):
                 if ex.get("preset_section_exercise_id") == current_id:
-                    session.current_exercise = idx
+                    new_idx = idx
                     break
-        session.current_exercise = min(session.current_exercise, len(session.exercises) - 1)
+
+        if new_idx is not None:
+            session.current_exercise = min(old_index, new_idx)
+        else:
+            session.current_exercise = min(old_index, len(session.exercises) - 1)
 
     def refresh_sections(self):
         """Repopulate the section widgets from the preset editor."""


### PR DESCRIPTION
## Summary
- ensure reordering exercises in an active session keeps the current index on the new exercise
- test that moving current exercise updates the session index

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892157d86b08332ba884102774ce2be