### PR TITLE
Isolate pending pre-set metrics per set

### DIFF
--- a/core.py
+++ b/core.py
@@ -967,8 +967,8 @@ class WorkoutSession:
 
         # store session-level metrics
         self.session_metrics: dict[str, object] = {}
-        # store metrics entered prior to the upcoming set
-        self.pending_pre_set_metrics: dict[str, object] = {}
+        # store metrics entered prior to individual upcoming sets
+        self.pending_pre_set_metrics: dict[tuple[int, int], dict[str, object]] = {}
         # track whether post-set metrics still need to be recorded
         self.awaiting_post_set_metrics: bool = False
         # track whether this session has been saved to the database
@@ -1073,9 +1073,11 @@ class WorkoutSession:
         """Return ``True`` if all required pre-set metrics have been entered."""
 
         required = self.required_pre_set_metric_names()
+        pending = self.pending_pre_set_metrics.get(
+            (self.current_exercise, self.current_set), {}
+        )
         return all(
-            name in self.pending_pre_set_metrics
-            and self.pending_pre_set_metrics.get(name) not in (None, "")
+            name in pending and pending.get(name) not in (None, "")
             for name in required
         )
 
@@ -1112,10 +1114,17 @@ class WorkoutSession:
         required = self.required_post_set_metric_names()
         return len(required) == 0
 
-    def set_pre_set_metrics(self, metrics: dict) -> None:
-        """Store metrics to be applied to the upcoming set."""
+    def set_pre_set_metrics(
+        self,
+        metrics: dict,
+        exercise_index: int | None = None,
+        set_index: int | None = None,
+    ) -> None:
+        """Store metrics to be applied to a specific upcoming set."""
 
-        self.pending_pre_set_metrics = metrics.copy()
+        ex = self.current_exercise if exercise_index is None else exercise_index
+        st = self.current_set if set_index is None else set_index
+        self.pending_pre_set_metrics[(ex, st)] = metrics.copy()
 
     def set_session_metrics(self, metrics: dict) -> None:
         """Store metrics that apply to the entire session."""
@@ -1128,8 +1137,8 @@ class WorkoutSession:
                 self.end_time = time.time()
             return True
 
-        metrics = {**self.pending_pre_set_metrics, **metrics}
-        self.pending_pre_set_metrics = {}
+        key = (self.current_exercise, self.current_set)
+        metrics = {**self.pending_pre_set_metrics.pop(key, {}), **metrics}
 
         end_time = time.time()
         start_time = self.current_set_start_time
@@ -1186,7 +1195,7 @@ class WorkoutSession:
         self.current_set = set_idx
 
         # Preserve any previously entered metrics for the set
-        self.pending_pre_set_metrics = last.get("metrics", {}).copy()
+        self.pending_pre_set_metrics[(ex_idx, set_idx)] = last.get("metrics", {}).copy()
         self.awaiting_post_set_metrics = False
 
         # Resume timer from the original start time

--- a/tests/test_metric_input_tabs.py
+++ b/tests/test_metric_input_tabs.py
@@ -200,13 +200,14 @@ def test_save_future_metrics_preserves_session_state():
             self.awaiting_post_set_metrics = False
 
         def record_metrics(self, metrics):
+            key = (self.current_exercise, self.current_set)
+            metrics = {**self.pending_pre_set_metrics.pop(key, {}), **metrics}
             ex = self.exercises[self.current_exercise]
             ex.setdefault("results", []).append({"metrics": metrics})
             self.current_set += 1
             if self.current_set >= ex["sets"]:
                 self.current_set = 0
                 self.current_exercise += 1
-            self.pending_pre_set_metrics = {}
             self.awaiting_post_set_metrics = False
             return False
 
@@ -267,13 +268,14 @@ def test_save_future_metrics_returns_to_rest():
             self.awaiting_post_set_metrics = False
 
         def record_metrics(self, metrics):
+            key = (self.current_exercise, self.current_set)
+            metrics = {**self.pending_pre_set_metrics.pop(key, {}), **metrics}
             ex = self.exercises[self.current_exercise]
             ex.setdefault("results", []).append({"metrics": metrics})
             self.current_set += 1
             if self.current_set >= ex["sets"]:
                 self.current_set = 0
                 self.current_exercise += 1
-            self.pending_pre_set_metrics = {}
             self.awaiting_post_set_metrics = False
             return False
 
@@ -300,4 +302,62 @@ def test_save_future_metrics_returns_to_rest():
     screen.save_metrics()
 
     assert screen.manager.current == "rest"
+
+
+def test_edit_previous_set_does_not_leak_future_pending():
+    screen = MetricInputScreen()
+
+    class DummySession:
+        def __init__(self):
+            self.exercises = [
+                {
+                    "name": "Bench",
+                    "sets": 2,
+                    "results": [
+                        {"metrics": {"Reps": 10}},
+                        {"metrics": {}},
+                    ],
+                }
+            ]
+            self.current_exercise = 0
+            self.current_set = 1
+            self.current_set_start_time = 0
+            self.pending_pre_set_metrics = {(0, 1): {"Weight": 100}}
+            self.awaiting_post_set_metrics = False
+
+        def record_metrics(self, metrics):
+            key = (self.current_exercise, self.current_set)
+            metrics = {**self.pending_pre_set_metrics.pop(key, {}), **metrics}
+            ex = self.exercises[self.current_exercise]
+            if self.current_set < len(ex["results"]):
+                ex["results"][self.current_set]["metrics"] = metrics
+            else:
+                ex.setdefault("results", []).append({"metrics": metrics})
+            self.current_set += 1
+            return False
+
+    dummy_session = DummySession()
+    dummy_app = types.SimpleNamespace(workout_session=dummy_session)
+    metric_module.MDApp.get_running_app = classmethod(lambda cls: dummy_app)
+
+    class DummyList:
+        def __init__(self):
+            self.children = []
+
+        def clear_widgets(self):
+            pass
+
+        def add_widget(self, widget):
+            pass
+
+    screen.metrics_list = DummyList()
+    screen._collect_metrics = lambda _w: {"Reps": 7}
+    screen.session = dummy_session
+    screen.exercise_idx = 0
+    screen.set_idx = 0
+
+    screen.save_metrics()
+
+    assert dummy_session.exercises[0]["results"][0]["metrics"] == {"Reps": 7}
+    assert dummy_session.pending_pre_set_metrics == {(0, 1): {"Weight": 100}}
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -235,13 +235,15 @@ def test_save_metrics_clears_next_metrics(monkeypatch):
             return "Bench"
 
         def record_metrics(self, metrics):
+            key = (self.current_exercise, self.current_set)
+            metrics = {**self.pending_pre_set_metrics.pop(key, {}), **metrics}
             self.exercises[0]["results"].append(metrics)
             self.current_set += 1
-            self.pending_pre_set_metrics = {}
             return False
 
         def set_pre_set_metrics(self, metrics):
-            self.pending_pre_set_metrics = metrics.copy()
+            key = (self.current_exercise, self.current_set)
+            self.pending_pre_set_metrics[key] = metrics.copy()
 
     dummy_app = _DummyApp()
     dummy_app.workout_session = DummySession()
@@ -314,12 +316,15 @@ def test_pre_set_metrics_do_not_advance(monkeypatch):
         ]
 
         def record_metrics(self, metrics):
+            key = (self.current_exercise, self.current_set)
+            metrics = {**self.pending_pre_set_metrics.pop(key, {}), **metrics}
             self.exercises[0]["results"].append({"metrics": metrics})
             self.current_set += 1
             return False
 
         def set_pre_set_metrics(self, metrics):
-            self.pending_pre_set_metrics = metrics.copy()
+            key = (self.current_exercise, self.current_set)
+            self.pending_pre_set_metrics[key] = metrics.copy()
 
     dummy_app = _DummyApp()
     dummy_app.workout_session = DummySession()
@@ -338,7 +343,7 @@ def test_pre_set_metrics_do_not_advance(monkeypatch):
     screen.save_metrics()
 
     assert dummy_app.workout_session.current_set == 0
-    assert dummy_app.workout_session.pending_pre_set_metrics == {"Goal": 5}
+    assert dummy_app.workout_session.pending_pre_set_metrics == {(0, 0): {"Goal": 5}}
     assert dummy_app.root.current == "rest"
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -118,7 +118,7 @@ def test_undo_last_set_restores_metrics_and_timer(sample_db, monkeypatch):
     assert session.current_exercise == 0
     assert session.current_set == 0
     assert session.exercises[0]["results"] == []
-    assert session.pending_pre_set_metrics == {"Reps": 10}
+    assert session.pending_pre_set_metrics == {(0, 0): {"Reps": 10}}
     assert session.current_set_start_time == start
     assert session.resume_from_last_start is True
 

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -254,12 +254,10 @@ class MetricInputScreen(MDScreen):
         results = exercise.get("results", [])
         if self.set_idx < len(results):
             values = results[self.set_idx].get("metrics", {})
-        elif (
-            getattr(self.session, "current_exercise", None) == self.exercise_idx
-            and getattr(self.session, "current_set", None) == self.set_idx
-        ):
-            # show pending pre-set metrics for the upcoming set
-            values = getattr(self.session, "pending_pre_set_metrics", {})
+        else:
+            values = self.session.pending_pre_set_metrics.get(
+                (self.exercise_idx, self.set_idx), {}
+            )
         for metric in self._apply_filters(metrics):
             name = metric.get("name")
             self.metrics_list.add_widget(
@@ -387,7 +385,7 @@ class MetricInputScreen(MDScreen):
         if getattr(app, "record_pre_set", False) and not getattr(
             app, "record_new_set", False
         ):
-            session.set_pre_set_metrics(metrics)
+            session.set_pre_set_metrics(metrics, self.exercise_idx, self.set_idx)
             app.record_pre_set = False
             if getattr(self, "manager", None):
                 self.manager.current = "rest"
@@ -421,6 +419,7 @@ class MetricInputScreen(MDScreen):
             session.current_exercise = orig_ex
             session.current_set = orig_set
             session.current_set_start_time = orig_start
+            orig_pending.pop((target_ex, target_set), None)
             session.pending_pre_set_metrics = orig_pending
             session.awaiting_post_set_metrics = orig_awaiting
             self.exercise_idx = orig_ex


### PR DESCRIPTION
## Summary
- Track pending pre-set metrics per (exercise, set) instead of globally
- Update MetricInputScreen to use set-specific pending metrics and clear them after save
- Add regression test ensuring editing a previous set doesn't overwrite future set metrics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68922ea8df0083329efc0ca10888504d