### PR TITLE
Fix WorkoutSession record_metrics overwrite behavior

### DIFF
--- a/core.py
+++ b/core.py
@@ -1122,8 +1122,8 @@ class WorkoutSession:
 
         self.session_metrics = metrics.copy()
 
-    def record_metrics(self, metrics):
-        if self.current_exercise >= len(self.exercises):
+    def record_metrics(self, exercise_index: int, set_index: int, metrics):
+        if exercise_index >= len(self.exercises):
             if self.end_time is None:
                 self.end_time = time.time()
             return True
@@ -1132,29 +1132,36 @@ class WorkoutSession:
         self.pending_pre_set_metrics = {}
 
         end_time = time.time()
-        start_time = self.current_set_start_time
         notes = str(metrics.get("Notes", ""))
 
-        ex = self.exercises[self.current_exercise]
-        ex["results"].append(
-            {
-                "metrics": metrics,
-                "started_at": start_time,
-                "ended_at": end_time,
-                "notes": notes,
-            }
+        ex = self.exercises[exercise_index]
+        results = ex["results"]
+        while len(results) <= set_index:
+            results.append(None)
+        start_time = (
+            self.current_set_start_time
+            if exercise_index == self.current_exercise and set_index == self.current_set
+            else end_time
         )
-        self.current_set_start_time = end_time
-        self.current_set += 1
-        self.awaiting_post_set_metrics = False
+        results[set_index] = {
+            "metrics": metrics,
+            "started_at": start_time,
+            "ended_at": end_time,
+            "notes": notes,
+        }
 
-        if self.current_set >= ex["sets"]:
-            self.current_set = 0
-            self.current_exercise += 1
+        if exercise_index == self.current_exercise and set_index == self.current_set:
+            self.current_set_start_time = end_time
+            self.current_set += 1
+            self.awaiting_post_set_metrics = False
 
-        if self.current_exercise >= len(self.exercises):
-            self.end_time = end_time
-            return True
+            if self.current_set >= ex["sets"]:
+                self.current_set = 0
+                self.current_exercise += 1
+
+            if self.current_exercise >= len(self.exercises):
+                self.end_time = end_time
+                return True
 
         return False
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -142,7 +142,7 @@ def test_workout_session_progress(sample_db, monkeypatch):
     complete = False
     count = 0
     while not complete:
-        complete = session.record_metrics({"Reps": 10})
+        complete = session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
         count += 1
     assert count == 5  # two sets push up + three sets bench press
     assert session.end_time is not None

--- a/tests/test_metric_input_tabs.py
+++ b/tests/test_metric_input_tabs.py
@@ -199,13 +199,16 @@ def test_save_future_metrics_preserves_session_state():
             self.pending_pre_set_metrics = {}
             self.awaiting_post_set_metrics = False
 
-        def record_metrics(self, metrics):
-            ex = self.exercises[self.current_exercise]
-            ex.setdefault("results", []).append({"metrics": metrics})
-            self.current_set += 1
-            if self.current_set >= ex["sets"]:
-                self.current_set = 0
-                self.current_exercise += 1
+        def record_metrics(self, ex_idx, set_idx, metrics):
+            ex = self.exercises[ex_idx]
+            while len(ex.setdefault("results", [])) <= set_idx:
+                ex["results"].append(None)
+            ex["results"][set_idx] = {"metrics": metrics}
+            if ex_idx == self.current_exercise and set_idx == self.current_set:
+                self.current_set += 1
+                if self.current_set >= ex["sets"]:
+                    self.current_set = 0
+                    self.current_exercise += 1
             self.pending_pre_set_metrics = {}
             self.awaiting_post_set_metrics = False
             return False
@@ -266,13 +269,16 @@ def test_save_future_metrics_returns_to_rest():
             self.pending_pre_set_metrics = {}
             self.awaiting_post_set_metrics = False
 
-        def record_metrics(self, metrics):
-            ex = self.exercises[self.current_exercise]
-            ex.setdefault("results", []).append({"metrics": metrics})
-            self.current_set += 1
-            if self.current_set >= ex["sets"]:
-                self.current_set = 0
-                self.current_exercise += 1
+        def record_metrics(self, ex_idx, set_idx, metrics):
+            ex = self.exercises[ex_idx]
+            while len(ex.setdefault("results", [])) <= set_idx:
+                ex["results"].append(None)
+            ex["results"][set_idx] = {"metrics": metrics}
+            if ex_idx == self.current_exercise and set_idx == self.current_set:
+                self.current_set += 1
+                if self.current_set >= ex["sets"]:
+                    self.current_set = 0
+                    self.current_exercise += 1
             self.pending_pre_set_metrics = {}
             self.awaiting_post_set_metrics = False
             return False

--- a/tests/test_session_save.py
+++ b/tests/test_session_save.py
@@ -25,13 +25,13 @@ def _complete_session(db_path):
 
     session = core.WorkoutSession("Push Day", db_path=db_path, rest_duration=1)
     session.set_session_metrics({"Session Reps": 28})
-    session.record_metrics({"Reps": 10})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     session.mark_set_completed()
-    session.record_metrics({"Reps": 8})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 8})
     session.mark_set_completed()
-    session.record_metrics({"Reps": 5, "Weight": 100, "Machine": "A"})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 5, "Weight": 100, "Machine": "A"})
     session.mark_set_completed()
-    session.record_metrics({"Reps": 5, "Weight": 100, "Machine": "A"})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 5, "Weight": 100, "Machine": "A"})
     return session
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -234,8 +234,10 @@ def test_save_metrics_clears_next_metrics(monkeypatch):
         def upcoming_exercise_name(self):
             return "Bench"
 
-        def record_metrics(self, metrics):
-            self.exercises[0]["results"].append(metrics)
+        def record_metrics(self, ex_idx, set_idx, metrics):
+            while len(self.exercises[0]["results"]) <= set_idx:
+                self.exercises[0]["results"].append(None)
+            self.exercises[0]["results"][set_idx] = metrics
             self.current_set += 1
             self.pending_pre_set_metrics = {}
             return False
@@ -313,8 +315,10 @@ def test_pre_set_metrics_do_not_advance(monkeypatch):
             }
         ]
 
-        def record_metrics(self, metrics):
-            self.exercises[0]["results"].append({"metrics": metrics})
+        def record_metrics(self, ex_idx, set_idx, metrics):
+            while len(self.exercises[0]["results"]) <= set_idx:
+                self.exercises[0]["results"].append(None)
+            self.exercises[0]["results"][set_idx] = {"metrics": metrics}
             self.current_set += 1
             return False
 

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -11,9 +11,9 @@ def test_workout_session_flow(sample_db):
     assert session.next_exercise_display() == "Push-up set 1 of 2"
     assert session.upcoming_exercise_display() == "Push-up set 2 of 2"
 
-    session.record_metrics({"Reps": 10})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     session.mark_set_completed()
-    session.record_metrics({"Reps": 8})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 8})
     session.mark_set_completed()
 
     assert session.next_exercise_display().startswith("Bench Press")
@@ -21,9 +21,9 @@ def test_workout_session_flow(sample_db):
     session.adjust_rest_timer(5)
     assert session.rest_target_time - before >= 5
 
-    session.record_metrics({"Reps": 5, "Weight": 100, "Machine": "A"})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 5, "Weight": 100, "Machine": "A"})
     session.mark_set_completed()
-    finished = session.record_metrics({"Reps": 5, "Weight": 100, "Machine": "A"})
+    finished = session.record_metrics(session.current_exercise, session.current_set, {"Reps": 5, "Weight": 100, "Machine": "A"})
     assert finished
 
     summary = session.summary()
@@ -35,9 +35,9 @@ def test_pre_set_metrics_flow(sample_db):
     session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
 
     # complete push-up sets to reach Bench Press
-    session.record_metrics({"Reps": 10})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     session.mark_set_completed()
-    session.record_metrics({"Reps": 8})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 8})
     session.mark_set_completed()
 
     assert session.next_exercise_name() == "Bench Press"
@@ -45,16 +45,16 @@ def test_pre_set_metrics_flow(sample_db):
     assert not session.has_required_pre_set_metrics()
     session.set_pre_set_metrics({"Reps": 5})
     assert session.has_required_pre_set_metrics()
-    session.record_metrics({"Weight": 100})
+    session.record_metrics(session.current_exercise, session.current_set, {"Weight": 100})
     assert session.exercises[1]["results"][0]["metrics"] == {"Reps": 5, "Weight": 100}
 
 
 def test_pre_set_metrics_require_selection(sample_db):
     session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
 
-    session.record_metrics({"Reps": 10})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     session.mark_set_completed()
-    session.record_metrics({"Reps": 8})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 8})
     session.mark_set_completed()
 
     assert session.next_exercise_name() == "Bench Press"
@@ -78,11 +78,11 @@ def test_rest_time_uses_next_exercise(sample_db):
     session = core.WorkoutSession("Push Day", db_path=sample_db)
     assert session.rest_duration == 10
 
-    session.record_metrics({"Reps": 10})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     session.mark_set_completed()
     assert session.rest_duration == 10
 
-    session.record_metrics({"Reps": 8})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 8})
     session.mark_set_completed()
     assert session.rest_duration == 30
 
@@ -91,14 +91,14 @@ def test_required_post_set_metrics(sample_db):
     session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     session.mark_set_completed()
     assert not session.has_required_post_set_metrics()
-    session.record_metrics({"Reps": 10})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     assert session.has_required_post_set_metrics()
 
 
 def test_mark_set_completed_time_adjustment(sample_db, monkeypatch):
     session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=30)
     session.exercises[0]["rest"] = 30
-    session.record_metrics({"Reps": 10})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     monkeypatch.setattr(core.time, "time", lambda: 165.0)
     session.mark_set_completed(adjust_seconds=-5)
     assert session.last_set_time == pytest.approx(160.0)
@@ -111,7 +111,7 @@ def test_undo_last_set_restores_metrics_and_timer(sample_db, monkeypatch):
 
     monkeypatch.setattr(core.time, "time", lambda: start + 5)
     session.mark_set_completed()
-    session.record_metrics({"Reps": 10})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
 
     monkeypatch.setattr(core.time, "time", lambda: start + 6)
     assert session.undo_last_set()
@@ -136,3 +136,16 @@ def test_undo_set_start_returns_to_rest(sample_db, monkeypatch):
     assert session.current_set_start_time == start
     assert session.resume_from_last_start is False
     assert session.rest_target_time == start + session.rest_duration
+
+
+def test_edit_set_overwrites_in_place(sample_db):
+    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
+    session.mark_set_completed()
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 8})
+
+    session.record_metrics(0, 0, {"Reps": 12})
+    ex = session.exercises[0]
+    assert len(ex["results"]) == 2
+    assert ex["results"][0]["metrics"]["Reps"] == 12
+    assert ex["results"][1]["metrics"]["Reps"] == 8

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -398,13 +398,8 @@ class MetricInputScreen(MDScreen):
 
         orig_ex = session.current_exercise
         orig_set = session.current_set
-        orig_start = session.current_set_start_time
-        orig_pending = session.pending_pre_set_metrics.copy()
-        orig_awaiting = session.awaiting_post_set_metrics
 
-        session.current_exercise = target_ex
-        session.current_set = target_set
-        finished = session.record_metrics(metrics)
+        finished = session.record_metrics(target_ex, target_set, metrics)
 
         app.record_new_set = False
         app.record_pre_set = False
@@ -418,11 +413,6 @@ class MetricInputScreen(MDScreen):
             elif getattr(self, "manager", None):
                 self.manager.current = "rest"
         else:
-            session.current_exercise = orig_ex
-            session.current_set = orig_set
-            session.current_set_start_time = orig_start
-            session.pending_pre_set_metrics = orig_pending
-            session.awaiting_post_set_metrics = orig_awaiting
             self.exercise_idx = orig_ex
             self.set_idx = orig_set
             self.update_display()


### PR DESCRIPTION
## Summary
- allow record_metrics to accept exercise/set indices and overwrite existing data rather than append
- update MetricInputScreen to call record_metrics with explicit indices
- adjust tests and add regression test for editing sets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68922e9aad00833292007e6b9e74aef9