### PR TITLE
Support editing existing set metrics

### DIFF
--- a/core.py
+++ b/core.py
@@ -1158,6 +1158,18 @@ class WorkoutSession:
 
         return False
 
+    def update_metrics(self, ex_idx: int, set_idx: int, metrics: dict) -> None:
+        """Replace metrics for an existing set while preserving timestamps."""
+
+        ex = self.exercises[ex_idx]
+        if set_idx >= len(ex["results"]):
+            raise IndexError("Set index out of range")
+
+        result = ex["results"][set_idx]
+        notes = str(metrics.get("Notes", ""))
+        result["metrics"] = metrics.copy()
+        result["notes"] = notes
+
     def undo_last_set(self) -> bool:
         """Reopen the most recently completed set.
 

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -136,3 +136,18 @@ def test_undo_set_start_returns_to_rest(sample_db, monkeypatch):
     assert session.current_set_start_time == start
     assert session.resume_from_last_start is False
     assert session.rest_target_time == start + session.rest_duration
+
+
+def test_update_metrics_preserves_times(sample_db):
+    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session.record_metrics({"Reps": 10})
+    result = session.exercises[0]["results"][0]
+    start, end = result["started_at"], result["ended_at"]
+
+    session.update_metrics(0, 0, {"Reps": 12})
+
+    updated = session.exercises[0]["results"][0]
+    assert updated["metrics"] == {"Reps": 12}
+    assert updated["started_at"] == start
+    assert updated["ended_at"] == end
+    assert len(session.exercises[0]["results"]) == 1

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -402,22 +402,23 @@ class MetricInputScreen(MDScreen):
         orig_pending = session.pending_pre_set_metrics.copy()
         orig_awaiting = session.awaiting_post_set_metrics
 
-        session.current_exercise = target_ex
-        session.current_set = target_set
-        finished = session.record_metrics(metrics)
+        editing_different = target_ex != orig_ex or target_set != orig_set
+        if editing_different:
+            session.pending_pre_set_metrics = {}
+
+        results = session.exercises[target_ex]["results"]
+        if target_set < len(results):
+            session.update_metrics(target_ex, target_set, metrics)
+            finished = False
+        else:
+            session.current_exercise = target_ex
+            session.current_set = target_set
+            finished = session.record_metrics(metrics)
 
         app.record_new_set = False
         app.record_pre_set = False
 
-        if target_ex == orig_ex and target_set == orig_set:
-            self.exercise_idx = session.current_exercise
-            self.set_idx = session.current_set
-            self.update_display()
-            if finished and getattr(self, "manager", None):
-                self.manager.current = "workout_summary"
-            elif getattr(self, "manager", None):
-                self.manager.current = "rest"
-        else:
+        if editing_different:
             session.current_exercise = orig_ex
             session.current_set = orig_set
             session.current_set_start_time = orig_start
@@ -427,4 +428,12 @@ class MetricInputScreen(MDScreen):
             self.set_idx = orig_set
             self.update_display()
             if getattr(self, "manager", None):
+                self.manager.current = "rest"
+        else:
+            self.exercise_idx = session.current_exercise
+            self.set_idx = session.current_set
+            self.update_display()
+            if finished and getattr(self, "manager", None):
+                self.manager.current = "workout_summary"
+            elif getattr(self, "manager", None):
                 self.manager.current = "rest"


### PR DESCRIPTION
## Summary
- add `WorkoutSession.update_metrics` to replace metrics for an existing set while keeping timestamps intact
- adjust `MetricInputScreen.save_metrics` to update sets in place and guard against pending metric leakage
- cover past-set editing with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68922e5e87048332b4484762fd3f3e7c