### PR TITLE
Refactor metric storage in workout session

### DIFF
--- a/tests/test_metric_input_tabs.py
+++ b/tests/test_metric_input_tabs.py
@@ -331,15 +331,16 @@ def test_edit_previous_set_does_not_leak_future_pending():
             self.pending_pre_set_metrics = {(0, 1): {"Weight": 100}}
             self.awaiting_post_set_metrics = False
 
-        def record_metrics(self, metrics):
-            key = (self.current_exercise, self.current_set)
+        def record_metrics(self, ex_idx, set_idx, metrics):
+            key = (ex_idx, set_idx)
             metrics = {**self.pending_pre_set_metrics.pop(key, {}), **metrics}
-            ex = self.exercises[self.current_exercise]
-            if self.current_set < len(ex["results"]):
-                ex["results"][self.current_set]["metrics"] = metrics
+            ex = self.exercises[ex_idx]
+            if set_idx < len(ex["results"]):
+                ex["results"][set_idx]["metrics"] = metrics
             else:
                 ex.setdefault("results", []).append({"metrics": metrics})
-            self.current_set += 1
+            if ex_idx == self.current_exercise and set_idx == self.current_set:
+                self.current_set += 1
             return False
 
     dummy_session = DummySession()

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -46,7 +46,11 @@ def test_pre_set_metrics_flow(sample_db):
     session.set_pre_set_metrics({"Reps": 5})
     assert session.has_required_pre_set_metrics()
     session.record_metrics(session.current_exercise, session.current_set, {"Weight": 100})
-    assert session.exercises[1]["results"][0]["metrics"] == {"Reps": 5, "Weight": 100}
+    assert session.exercises[1]["results"][0]["metrics"] == {
+        "Reps": 5,
+        "Weight": 100,
+        "Machine": None,
+    }
 
 
 def test_pre_set_metrics_require_selection(sample_db):

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -396,6 +396,9 @@ class MetricInputScreen(MDScreen):
 
         orig_ex = session.current_exercise
         orig_set = session.current_set
+        orig_start = session.current_set_start_time
+        orig_pending = session.pending_pre_set_metrics.copy()
+        orig_awaiting = session.awaiting_post_set_metrics
 
         finished = session.record_metrics(target_ex, target_set, metrics)
 


### PR DESCRIPTION
## Summary
- Build per-set metric storage in `WorkoutSession` to track all exercise metrics and enforce valid keys.
- Update pre-set and recording logic to use the new storage and validate required metrics.
- Preserve session state when editing metrics and adjust tests for expanded metric data.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68930ea542488332bc07b7e14efae033