### PR TITLE
Add persistent Time metric and editing support

### DIFF
--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -14,6 +14,7 @@ from kivymd.uix.slider import MDSlider
 from kivy.uix.spinner import Spinner
 from kivymd.uix.label import MDLabel
 from kivymd.uix.selectioncontrol import MDCheckbox
+import time
 
 
 class MetricInputScreen(MDScreen):
@@ -258,6 +259,25 @@ class MetricInputScreen(MDScreen):
             values = self.session.pending_pre_set_metrics.get(
                 (self.exercise_idx, self.set_idx), {}
             )
+        start_time = None
+        end_time = None
+        if self.set_idx < len(results) and results[self.set_idx]:
+            start_time = results[self.set_idx].get("started_at")
+            end_time = results[self.set_idx].get("ended_at")
+        elif (
+            self.session.awaiting_post_set_metrics
+            and (self.exercise_idx, self.set_idx)
+            == (self.session.current_exercise, self.session.current_set)
+        ):
+            start_time = self.session.current_set_start_time
+            end_time = self.session.last_set_time
+        if start_time is not None and end_time is not None:
+            time_val = round(end_time - start_time, 1)
+        else:
+            time_val = 0.0
+        self.metrics_list.add_widget(
+            self._create_row({"name": "Time", "type": "float"}, time_val)
+        )
         for metric in self._apply_filters(metrics):
             name = metric.get("name")
             self.metrics_list.add_widget(
@@ -391,20 +411,34 @@ class MetricInputScreen(MDScreen):
                 self.manager.current = "rest"
             return
 
-        orig_ex = session.current_exercise
-        orig_set = session.current_set
-
         sel_ex = self.exercise_idx
         sel_set = self.set_idx
+        time_val = metrics.pop("Time", None)
+        end_override = None
+        if time_val is not None:
+            try:
+                time_val = round(float(time_val), 1)
+            except ValueError:
+                time_val = 0.0
+            results = session.exercises[sel_ex].get("results", [])
+            if sel_set < len(results) and results[sel_set]:
+                start = results[sel_set].get("started_at", session.current_set_start_time)
+            else:
+                start = session.current_set_start_time
+            end_override = start + time_val
+
+        orig_ex = session.current_exercise
+        orig_set = session.current_set
 
         finished = False
         if getattr(app, "record_new_set", False):
             post_metrics = metrics if (sel_ex == orig_ex and sel_set == orig_set) else {}
-            finished = session.record_metrics(orig_ex, orig_set, post_metrics)
+            end_param = end_override if (sel_ex == orig_ex and sel_set == orig_set) else None
+            finished = session.record_metrics(orig_ex, orig_set, post_metrics, end_time=end_param)
             if (sel_ex, sel_set) != (orig_ex, orig_set):
                 session.set_pre_set_metrics(metrics, sel_ex, sel_set)
         else:
-            finished = session.record_metrics(sel_ex, sel_set, metrics)
+            finished = session.record_metrics(sel_ex, sel_set, metrics, end_time=end_override)
 
         app.record_new_set = False
         app.record_pre_set = False


### PR DESCRIPTION
## Summary
- Always display a derived Time metric at the top of workout metric inputs
- Allow Time edits to recompute set end times and adjust rest timers
- Cover Time metric ordering and end-time updates with new tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68954ed99eb483329d23435108b19375