### PR TITLE
Add multiline notes field for workout metrics

### DIFF
--- a/tests/test_metric_input_tabs.py
+++ b/tests/test_metric_input_tabs.py
@@ -61,8 +61,10 @@ class _Spinner(_DummyWidget):
         self.values = values
 
 class _TextField(_DummyWidget):
-    def __init__(self, text="", **kwargs):
+    def __init__(self, text="", multiline=False, input_filter=None, **kwargs):
         self.text = text
+        self.multiline = multiline
+        self.input_filter = input_filter
 
 class _Slider(_DummyWidget):
     def __init__(self, value=0, **kwargs):
@@ -203,7 +205,8 @@ def test_save_future_metrics_preserves_session_state():
             ex = self.exercises[ex_idx]
             while len(ex.setdefault("results", [])) <= set_idx:
                 ex["results"].append(None)
-            ex["results"][set_idx] = {"metrics": metrics}
+            notes = metrics.pop("Notes", "")
+            ex["results"][set_idx] = {"metrics": metrics, "notes": notes}
             if ex_idx == self.current_exercise and set_idx == self.current_set:
                 self.current_set += 1
                 if self.current_set >= ex["sets"]:
@@ -279,7 +282,8 @@ def test_save_future_metrics_returns_to_rest():
             ex = self.exercises[ex_idx]
             while len(ex.setdefault("results", [])) <= set_idx:
                 ex["results"].append(None)
-            ex["results"][set_idx] = {"metrics": metrics}
+            notes = metrics.pop("Notes", "")
+            ex["results"][set_idx] = {"metrics": metrics, "notes": notes}
             if ex_idx == self.current_exercise and set_idx == self.current_set:
                 self.current_set += 1
                 if self.current_set >= ex["sets"]:
@@ -343,12 +347,14 @@ def test_edit_previous_set_does_not_leak_future_pending():
 
         def record_metrics(self, ex_idx, set_idx, metrics):
             key = (ex_idx, set_idx)
-            metrics = {**self.pending_pre_set_metrics.pop(key, {}), **metrics}
+            combined = {**self.pending_pre_set_metrics.pop(key, {}), **metrics}
+            notes = combined.pop("Notes", "")
             ex = self.exercises[ex_idx]
             if set_idx < len(ex["results"]):
-                ex["results"][set_idx]["metrics"] = metrics
+                ex["results"][set_idx]["metrics"] = combined
+                ex["results"][set_idx]["notes"] = notes
             else:
-                ex.setdefault("results", []).append({"metrics": metrics})
+                ex.setdefault("results", []).append({"metrics": combined, "notes": notes})
             if ex_idx == self.current_exercise and set_idx == self.current_set:
                 self.current_set += 1
             return False
@@ -382,4 +388,41 @@ def test_edit_previous_set_does_not_leak_future_pending():
 
     assert dummy_session.exercises[0]["results"][0]["metrics"] == {"Reps": 7}
     assert dummy_session.pending_pre_set_metrics == {(0, 1): {"Weight": 100}}
+
+
+def test_notes_row_is_multiline_and_last():
+    screen = MetricInputScreen()
+
+    class DummyList:
+        def __init__(self):
+            self.children = []
+
+        def clear_widgets(self):
+            self.children.clear()
+
+        def add_widget(self, widget):
+            self.children.append(widget)
+
+    screen.metrics_list = DummyList()
+    screen.session = types.SimpleNamespace(
+        exercises=[
+            {
+                "name": "Bench",
+                "sets": 1,
+                "metric_defs": [{"name": "Reps", "type": "int", "is_required": True}],
+                "results": [{"metrics": {"Reps": 5}, "notes": "prev note"}],
+            }
+        ],
+        pending_pre_set_metrics={},
+    )
+    screen.exercise_idx = 0
+    screen.set_idx = 0
+
+    screen.update_metrics()
+
+    assert screen.metrics_list.children[-1].metric_name == "Notes"
+    notes_row = screen.metrics_list.children[-1]
+    assert isinstance(notes_row.input_widget, metric_module.MDTextField)
+    assert notes_row.input_widget.multiline is True
+    assert notes_row.input_widget.text == "prev note"
 

--- a/tests/test_session_save.py
+++ b/tests/test_session_save.py
@@ -59,6 +59,18 @@ def test_save_completed_session(sample_db):
     conn.close()
 
 
+def test_save_session_with_notes(sample_db):
+    session = _complete_session(sample_db)
+    session.exercises[0]["results"][0]["notes"] = "Felt easy"
+    core.save_completed_session(session, db_path=sample_db)
+    conn = sqlite3.connect(sample_db)
+    cur = conn.cursor()
+    cur.execute("SELECT notes FROM session_exercise_sets")
+    notes = [row[0] for row in cur.fetchall()]
+    assert "Felt easy" in notes
+    conn.close()
+
+
 def test_save_session_validation(sample_db):
     session = core.WorkoutSession("Push Day", db_path=sample_db)
     with pytest.raises(ValueError):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -111,7 +111,11 @@ def test_populate_blank_for_new_set(monkeypatch):
         current_set = 1
         awaiting_post_set_metrics = True
         exercises = [
-            {"name": "Bench", "sets": 3, "results": [{"Weight": 100, "Notes": "prev"}]}
+            {
+                "name": "Bench",
+                "sets": 3,
+                "results": [{"metrics": {"Weight": 100}, "notes": "prev"}],
+            }
         ]
 
         def next_exercise_name(self):
@@ -171,7 +175,7 @@ def test_prev_metrics_use_last_set(monkeypatch):
         current_set = 0
         awaiting_post_set_metrics = True
         exercises = [
-            {"name": "Push", "sets": 1, "results": [{"Reps": 10}]},
+            {"name": "Push", "sets": 1, "results": [{"metrics": {"Reps": 10}, "notes": ""}]},
             {"name": "Run", "sets": 1, "results": []},
         ]
 
@@ -237,8 +241,11 @@ def test_save_metrics_clears_next_metrics(monkeypatch):
         def record_metrics(self, ex_idx, set_idx, metrics):
             while len(self.exercises[0]["results"]) <= set_idx:
                 self.exercises[0]["results"].append(None)
-            self.exercises[0]["results"][set_idx] = metrics
-
+            notes = metrics.pop("Notes", "")
+            self.exercises[0]["results"][set_idx] = {
+                "metrics": metrics,
+                "notes": notes,
+            }
             self.current_set += 1
             return False
 
@@ -319,8 +326,11 @@ def test_pre_set_metrics_do_not_advance(monkeypatch):
         def record_metrics(self, ex_idx, set_idx, metrics):
             while len(self.exercises[0]["results"]) <= set_idx:
                 self.exercises[0]["results"].append(None)
-            self.exercises[0]["results"][set_idx] = {"metrics": metrics}
-
+            notes = metrics.pop("Notes", "")
+            self.exercises[0]["results"][set_idx] = {
+                "metrics": metrics,
+                "notes": notes,
+            }
             self.current_set += 1
             return False
 

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -249,20 +249,27 @@ class MetricInputScreen(MDScreen):
             return
         exercise = self.session.exercises[self.exercise_idx]
         metrics = exercise.get("metric_defs", [])
-        # Determine any previously recorded values for this set
-        values = {}
+        # Determine previously recorded values and notes for this set
         results = exercise.get("results", [])
-        if self.set_idx < len(results):
-            values = results[self.set_idx].get("metrics", {})
-        else:
-            values = self.session.pending_pre_set_metrics.get(
-                (self.exercise_idx, self.set_idx), {}
-            )
+        record = (
+            results[self.set_idx]
+            if self.set_idx < len(results) and results[self.set_idx]
+            else None
+        )
+        values = record.get("metrics", {}) if record else {}
+        notes_val = record.get("notes", "") if record else ""
+        pending = self.session.pending_pre_set_metrics.get(
+            (self.exercise_idx, self.set_idx), {}
+        )
+        values = {**values, **{k: v for k, v in pending.items() if k != "Notes"}}
+        notes_val = pending.get("Notes", notes_val)
         for metric in self._apply_filters(metrics):
             name = metric.get("name")
             self.metrics_list.add_widget(
                 self._create_row(metric, values.get(name))
             )
+        # Notes field always appears at the bottom
+        self.metrics_list.add_widget(self._create_row("Notes", notes_val))
 
     # ------------------------------------------------------------------
     # Metric row helpers
@@ -299,7 +306,10 @@ class MetricInputScreen(MDScreen):
             mtype = metric.get("type", "str")
             values = metric.get("values", [])
 
-        row = MDBoxLayout(orientation="horizontal", size_hint_y=None, height=dp(48))
+        row_height = dp(120) if name == "Notes" else dp(48)
+        row = MDBoxLayout(
+            orientation="horizontal", size_hint_y=None, height=row_height
+        )
         row.metric_name = name
         row.type = mtype
         row.add_widget(MDLabel(text=name, size_hint_x=0.4))
@@ -333,7 +343,11 @@ class MetricInputScreen(MDScreen):
                 multiline=multiline,
                 input_filter=input_filter,
                 text=str(value) if value not in (None, "") else "",
+                mode="rectangle" if multiline else "fill",
             )
+            if multiline:
+                widget.size_hint_y = None
+                widget.height = dp(96)
 
         row.input_widget = widget
         row.add_widget(widget)


### PR DESCRIPTION
## Summary
- Always show a multi-line Notes field at the end of the workout metric list
- Support text wrapping and persistence of notes in saved sessions
- Add tests for notes UI placement and database storage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895500f7cfc833281a0caa93d494888