### PR TITLE
Add workout stopwatch to rest screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -405,8 +405,10 @@ ScreenManager:
         spacing: "10dp"
         padding: "20dp"
         MDLabel:
-            text: "Rest – The main screen shown between exercises. Displays a countdown timer while the user rests before the next exercise begins."
+            id: workout_time_label
+            text: root.workout_timer_label
             halign: "center"
+            font_style: "H4"
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1
         BoxLayout:

--- a/ui/screens/rest_screen.py
+++ b/ui/screens/rest_screen.py
@@ -61,6 +61,7 @@ class RestScreen(MDScreen):
     """Screen shown between exercises with a rest timer."""
 
     timer_label = StringProperty("00:20")
+    workout_timer_label = StringProperty("00:00")
     target_time = NumericProperty(0)
     next_exercise_name = StringProperty("")
     next_exercise_desc = StringProperty("")
@@ -202,6 +203,15 @@ class RestScreen(MDScreen):
         return super().on_touch_down(touch)
 
     def update_timer(self, dt):
+        app = MDApp.get_running_app()
+        session = app.workout_session if app else None
+        if session:
+            elapsed = int(time.time() - session.start_time)
+            minutes, seconds = divmod(elapsed, 60)
+            self.workout_timer_label = f"{minutes:02d}:{seconds:02d}"
+        else:
+            self.workout_timer_label = "00:00"
+
         remaining = self.target_time - time.time()
         if remaining <= 0:
             self.timer_label = "00:00"


### PR DESCRIPTION
## Summary
- show total workout time on RestScreen using session start time
- replace static description label with dynamic stopwatch display

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895509b95848332b4a0f811d72cc91f