### PR TITLE
Preserve metric input text when toggling filters

### DIFF
--- a/tests/test_filter_preserves_input.py
+++ b/tests/test_filter_preserves_input.py
@@ -1,0 +1,36 @@
+from tests.test_metric_input_tabs import MetricInputScreen
+
+class DummyList:
+    def __init__(self):
+        self.children = []
+    def add_widget(self, widget):
+        self.children.append(widget)
+    def clear_widgets(self):
+        self.children.clear()
+
+def test_filter_toggle_preserves_input():
+    screen = MetricInputScreen()
+    screen.metrics_list = DummyList()
+
+    class DummySession:
+        def __init__(self):
+            self.exercises = [{
+                "name": "Bench",
+                "sets": 1,
+                "metric_defs": [
+                    {"name": "Weight", "type": "int", "is_required": True, "input_timing": "post_set"},
+                    {"name": "Comment", "type": "str", "is_required": False, "input_timing": "post_set"},
+                ],
+                "results": [],
+            }]
+            self.pending_pre_set_metrics = {}
+    screen.session = DummySession()
+    screen.update_metrics()
+
+    weight_row = next(r for r in screen.metrics_list.children if r.metric_name == "Weight")
+    weight_row.input_widget.text = "123"
+
+    screen.toggle_filter("additional")
+
+    weight_row = next(r for r in screen.metrics_list.children if r.metric_name == "Weight")
+    assert getattr(weight_row.input_widget, "text", "") == "123"


### PR DESCRIPTION
## Summary
- Keep current metric inputs when changing filter buttons
- Add regression test ensuring metric inputs persist across filter toggles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895532bc0ec83329b25a7dc05d72deb