### PR TITLE
Reset rest timer on app minimize

### DIFF
--- a/main.py
+++ b/main.py
@@ -412,12 +412,29 @@ class WorkoutApp(MDApp):
     def build(self):
         root = Builder.load_file(str(Path(__file__).with_name("main.kv")))
         Window.bind(on_keyboard=self._on_keyboard)
+        Window.bind(on_focus=self._on_focus)
         return root
 
     def _on_keyboard(self, window, key, scancode, codepoint, modifiers):
         if key in (27, 1001):
             return True
         return False
+
+    def _reset_rest_ready(self):
+        """Unset ready state when the rest screen loses focus."""
+        if not self.root or self.root.current != "rest":
+            return
+        screen = self.root.get_screen("rest")
+        screen.is_ready = False
+        screen.timer_color = (1, 0, 0, 1)
+
+    def _on_focus(self, window, focus):
+        if not focus:
+            self._reset_rest_ready()
+
+    def on_pause(self):
+        self._reset_rest_ready()
+        return True
 
     def init_preset_editor(self, force_reload: bool = False):
         """Create or reload the ``PresetEditor`` for the selected preset."""

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -29,6 +29,7 @@ if kivy_available:
         EditPresetScreen,
         PresetDetailScreen,
         PresetOverviewScreen,
+        WorkoutApp,
     )
     from ui.popups import AddMetricPopup, EditMetricPopup
     from ui.expandable_list_item import ExerciseSummaryItem
@@ -356,6 +357,28 @@ def test_rest_screen_toggle_ready_changes_state():
     screen.toggle_ready()
     assert screen.is_ready is True
     assert screen.timer_color == (0, 1, 0, 1)
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_rest_screen_unreadies_when_app_minimized():
+    screen = RestScreen()
+    screen.is_ready = True
+    screen.timer_color = (0, 1, 0, 1)
+
+    app = WorkoutApp()
+
+    class Root:
+        current = "rest"
+
+        def get_screen(self, name):
+            return screen
+
+    app.root = Root()
+
+    app._on_focus(None, False)
+
+    assert screen.is_ready is False
+    assert screen.timer_color == (1, 0, 0, 1)
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")


### PR DESCRIPTION
## Summary
- Ensure rest screen unready state when the app loses focus or is paused
- Test that minimizing the app resets the rest screen's ready state

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68955354d6188332bc7a61adf5843197