### PR TITLE
Refactor WorkoutSession imports after move

### DIFF
--- a/backend/workout_session.py
+++ b/backend/workout_session.py
@@ -1,3 +1,16 @@
+import sqlite3
+import time
+from pathlib import Path
+
+from core import (
+    DEFAULT_DB_PATH,
+    DEFAULT_REST_DURATION,
+    DEFAULT_SETS_PER_EXERCISE,
+    get_metrics_for_exercise,
+    get_metrics_for_preset,
+)
+
+
 class WorkoutSession:
     """In-memory representation of a workout session.
 

--- a/core.py
+++ b/core.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sqlite3
 from pathlib import Path
 import time

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,6 +5,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import core
+from backend.workout_session import WorkoutSession
 
 
 @pytest.fixture()
@@ -128,7 +129,7 @@ def test_add_and_remove_metric(sample_db):
 
 
 def test_workout_session_progress(sample_db, monkeypatch):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     assert session.next_exercise_name() == "Push Up"
     assert session.next_exercise_display() == "Push Up set 1 of 2"
     # speed up time by patching time.time

--- a/tests/test_session_save.py
+++ b/tests/test_session_save.py
@@ -1,6 +1,7 @@
 import sqlite3
 import pytest
 import core
+from backend.workout_session import WorkoutSession
 
 
 def _complete_session(db_path):
@@ -23,7 +24,7 @@ def _complete_session(db_path):
     conn.commit()
     conn.close()
 
-    session = core.WorkoutSession("Push Day", db_path=db_path, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=db_path, rest_duration=1)
     session.set_session_metrics({"Session Reps": 28})
     session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     session.mark_set_completed()
@@ -60,6 +61,6 @@ def test_save_completed_session(sample_db):
 
 
 def test_save_session_validation(sample_db):
-    session = core.WorkoutSession("Push Day", db_path=sample_db)
+    session = WorkoutSession("Push Day", db_path=sample_db)
     with pytest.raises(ValueError):
         core.save_completed_session(session, db_path=sample_db)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -17,6 +17,7 @@ if kivy_available:
     from kivy.app import App
     from kivy.properties import ObjectProperty
     import core
+    from backend.workout_session import WorkoutSession
 
     from main import (
         RestScreen,
@@ -430,7 +431,7 @@ def test_open_metric_input_prefers_pre_set(monkeypatch):
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_active_screen_resumes_from_session(monkeypatch, sample_db):
     screen = WorkoutActiveScreen()
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     session.current_set_start_time = 100.0
     session.resume_from_last_start = True
     dummy_app = _DummyApp()
@@ -1418,7 +1419,7 @@ def test_refresh_sections_preserves_names(monkeypatch):
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_session_edit_locking(monkeypatch, sample_db):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     app = _DummyApp()
     app.workout_session = session
     monkeypatch.setattr(App, "get_running_app", lambda: app)
@@ -1433,7 +1434,7 @@ def test_session_edit_locking(monkeypatch, sample_db):
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_reordering_current_exercise_updates_index(monkeypatch, sample_db):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     editor = core.PresetEditor("Push Day", db_path=sample_db)
     app = _DummyApp()
     app.workout_session = session

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -1,13 +1,14 @@
 import core
 import sqlite3
 import pytest
+from backend.workout_session import WorkoutSession
 
 
 def test_workout_session_flow(sample_db):
     presets = core.load_workout_presets(sample_db)
     assert any(p["name"] == "Push Day" for p in presets)
 
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     assert session.next_exercise_display() == "Push-up set 1 of 2"
     assert session.upcoming_exercise_display() == "Push-up set 2 of 2"
 
@@ -32,7 +33,7 @@ def test_workout_session_flow(sample_db):
 
 
 def test_pre_set_metrics_flow(sample_db):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
 
     # complete push-up sets to reach Bench Press
     session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
@@ -54,7 +55,7 @@ def test_pre_set_metrics_flow(sample_db):
 
 
 def test_pre_set_metrics_require_selection(sample_db):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
 
     session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     session.mark_set_completed()
@@ -79,7 +80,7 @@ def test_rest_time_uses_next_exercise(sample_db):
     conn.commit()
     conn.close()
 
-    session = core.WorkoutSession("Push Day", db_path=sample_db)
+    session = WorkoutSession("Push Day", db_path=sample_db)
     assert session.rest_duration == 10
 
     session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
@@ -92,7 +93,7 @@ def test_rest_time_uses_next_exercise(sample_db):
 
 
 def test_required_post_set_metrics(sample_db):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     session.mark_set_completed()
     assert not session.has_required_post_set_metrics()
     session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
@@ -100,7 +101,7 @@ def test_required_post_set_metrics(sample_db):
 
 
 def test_mark_set_completed_time_adjustment(sample_db, monkeypatch):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=30)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=30)
     session.exercises[0]["rest"] = 30
     session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     monkeypatch.setattr(core.time, "time", lambda: 165.0)
@@ -110,7 +111,7 @@ def test_mark_set_completed_time_adjustment(sample_db, monkeypatch):
 
 
 def test_undo_last_set_restores_metrics_and_timer(sample_db, monkeypatch):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     start = session.current_set_start_time
 
     monkeypatch.setattr(core.time, "time", lambda: start + 5)
@@ -128,7 +129,7 @@ def test_undo_last_set_restores_metrics_and_timer(sample_db, monkeypatch):
 
 
 def test_undo_set_start_returns_to_rest(sample_db, monkeypatch):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=10)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=10)
     start = session.current_set_start_time
 
     # simulate beginning a set 5 seconds later
@@ -143,7 +144,7 @@ def test_undo_set_start_returns_to_rest(sample_db, monkeypatch):
 
 
 def test_edit_set_overwrites_in_place(sample_db):
-    session = core.WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     session.mark_set_completed()
     session.record_metrics(session.current_exercise, session.current_set, {"Reps": 8})


### PR DESCRIPTION
## Summary
- ensure `WorkoutSession` is imported from `backend.workout_session`
- update tests to use `WorkoutSession` from the backend module
- add postponed evaluation of annotations in `core.py`

## Testing
- `pytest` *(fails: ImportError: cannot import name 'PresetEditor' from 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6898a6e4e5288332846d2c060604857a