### PR TITLE
Refactor exercise library screen for testable UI

### DIFF
--- a/ui/screens/exercise_library_helpers.py
+++ b/ui/screens/exercise_library_helpers.py
@@ -1,0 +1,154 @@
+"""Helper functions for :mod:`exercise_library` screen."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from kivymd.app import MDApp
+from kivymd.uix.dialog import MDDialog
+from kivymd.uix.button import MDRaisedButton
+
+
+def populate_exercises(screen: Any) -> None:
+    if not screen.exercise_list:
+        if screen.loading_dialog:
+            screen.loading_dialog.dismiss()
+            screen.loading_dialog = None
+        return
+    screen.exercise_list.data = []
+    app = MDApp.get_running_app()
+    if screen.all_exercises is None or (
+        app and screen.cache_version != getattr(app, "exercise_library_version", 0)
+    ):
+        provider = getattr(screen, "data_provider", None)
+        screen.all_exercises = (
+            provider.get_all_exercises(include_user_created=True) if provider else []
+        )
+        if app:
+            screen.cache_version = app.exercise_library_version
+    exercises = screen.all_exercises or []
+
+    mode = screen.filter_mode
+    if mode == "user":
+        exercises = [ex for ex in exercises if ex[1]]
+    elif mode == "premade":
+        exercises = [ex for ex in exercises if not ex[1]]
+    if screen.search_text:
+        s = screen.search_text.lower()
+        exercises = [ex for ex in exercises if s in ex[0].lower()]
+    data = []
+    for name, is_user in exercises:
+        data.append(
+            {
+                "name": name,
+                "text": name,
+                "is_user_created": is_user,
+                "edit_callback": screen.open_edit_exercise_popup,
+                "delete_callback": screen.confirm_delete_exercise,
+            }
+        )
+    screen.exercise_list.data = data
+    if screen.loading_dialog:
+        screen.loading_dialog.dismiss()
+        screen.loading_dialog = None
+
+
+def populate_metrics(screen: Any) -> None:
+    if not screen.metric_list:
+        if screen.loading_dialog:
+            screen.loading_dialog.dismiss()
+            screen.loading_dialog = None
+        return
+    screen.metric_list.data = []
+    app = MDApp.get_running_app()
+    if screen.all_metrics is None or (
+        app and screen.metric_cache_version != getattr(app, "metric_library_version", 0)
+    ):
+        provider = getattr(screen, "data_provider", None)
+        screen.all_metrics = (
+            provider.get_all_metric_types(include_user_created=True) if provider else []
+        )
+        if app:
+            screen.metric_cache_version = app.metric_library_version
+    metrics = screen.all_metrics or []
+    mode = screen.metric_filter_mode
+    if mode == "user":
+        metrics = [m for m in metrics if m["is_user_created"]]
+    elif mode == "premade":
+        metrics = [m for m in metrics if not m["is_user_created"]]
+    if screen.metric_search_text:
+        s = screen.metric_search_text.lower()
+        metrics = [m for m in metrics if s in m["name"].lower()]
+    data = []
+    for m in metrics:
+        data.append(
+            {
+                "name": m["name"],
+                "text": m["name"],
+                "is_user_created": m["is_user_created"],
+                "edit_callback": screen.open_edit_metric_popup,
+                "delete_callback": screen.confirm_delete_metric,
+            }
+        )
+    screen.metric_list.data = data
+    if screen.loading_dialog:
+        screen.loading_dialog.dismiss()
+        screen.loading_dialog = None
+
+
+def confirm_delete_exercise(screen: Any, exercise_name: str) -> None:
+    dialog = None
+
+    def do_delete(*args):
+        try:
+            provider = getattr(screen, "data_provider", None)
+            if provider:
+                provider.delete_exercise(exercise_name)
+            app = MDApp.get_running_app()
+            if app:
+                app.exercise_library_version += 1
+        except Exception:
+            pass
+        screen.all_exercises = None
+        screen.populate()
+        if dialog:
+            dialog.dismiss()
+
+    dialog = MDDialog(
+        title="Delete Exercise?",
+        text=f"Delete {exercise_name}?",
+        buttons=[
+            MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
+            MDRaisedButton(text="Delete", on_release=do_delete),
+        ],
+    )
+    dialog.open()
+
+
+def confirm_delete_metric(screen: Any, metric_name: str) -> None:
+    dialog = None
+
+    def do_delete(*args):
+        try:
+            provider = getattr(screen, "data_provider", None)
+            if provider:
+                provider.delete_metric_type(metric_name)
+            app = MDApp.get_running_app()
+            if app:
+                app.metric_library_version += 1
+        except Exception:
+            pass
+        screen.all_metrics = None
+        screen.populate()
+        if dialog:
+            dialog.dismiss()
+
+    dialog = MDDialog(
+        title="Delete Metric?",
+        text=f"Delete {metric_name}?",
+        buttons=[
+            MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
+            MDRaisedButton(text="Delete", on_release=do_delete),
+        ],
+    )
+    dialog.open()

--- a/ui/stubs/exercise_library.py
+++ b/ui/stubs/exercise_library.py
@@ -1,0 +1,40 @@
+"""Stub data provider for ExerciseLibraryScreen."""
+
+from __future__ import annotations
+
+from typing import List, Tuple, Dict
+
+
+class StubExerciseLibraryProvider:
+    """Provides stub exercises and metric types for testing."""
+
+    def __init__(self) -> None:
+        self.exercises: List[Tuple[str, bool]] = [
+            ("Push Ups", False),
+            ("Custom Move", True),
+        ]
+        self.metrics: List[Dict[str, object]] = [
+            {"name": "Reps", "is_user_created": False},
+            {"name": "Weight", "is_user_created": False},
+            {"name": "Custom Metric", "is_user_created": True},
+        ]
+
+    # Exercise methods
+    def get_all_exercises(self, include_user_created: bool = True) -> List[Tuple[str, bool]]:
+        data = self.exercises
+        if include_user_created:
+            return list(data)
+        return [ex for ex in data if not ex[1]]
+
+    def delete_exercise(self, name: str) -> None:
+        self.exercises = [ex for ex in self.exercises if ex[0] != name]
+
+    # Metric methods
+    def get_all_metric_types(self, include_user_created: bool = True) -> List[Dict[str, object]]:
+        data = self.metrics
+        if include_user_created:
+            return list(data)
+        return [m for m in data if not m["is_user_created"]]
+
+    def delete_metric_type(self, name: str) -> None:
+        self.metrics = [m for m in self.metrics if m["name"] != name]


### PR DESCRIPTION
## Summary
- decouple ExerciseLibrary screen from backend and add test mode with stub provider
- move populate and delete logic into reusable helpers
- add stub data provider for previewing the exercise library screen

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ac7190ec8332a12832f6d918fc58