### PR TITLE
Fix metric screen preview and log issue

### DIFF
--- a/codex_mistakes.md
+++ b/codex_mistakes.md
@@ -36,3 +36,11 @@ Add new entries below as issues are encountered. Over time this becomes a refere
 - **Problem** – App crashed with `ModuleNotFoundError: No module named 'kivymd.uix.icon'`
 - **Fix** – Import `MDIcon` from `kivymd.uix.label`
 - **Lesson** – In KivyMD 1.x, use `kivymd.uix.label.MDIcon`; `kivymd.uix.icon` only exists in KivyMD 2.x
+
+### Loading full main.kv in screen preview
+
+- **Context** – `MetricInputScreen` preview block
+- **Mistake** – Loaded `main.kv`, which references many undeclared screen classes
+- **Problem** – Running `metric_input_screen.py` raised `FactoryException: Unknown class <PresetsScreen>`
+- **Fix** – Extracted only the `<MetricInputScreen>` rule from `main.kv` when previewing
+- **Lesson** – Previewing a single screen should load only its kv rules to avoid missing class errors

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -443,7 +443,13 @@ if __name__ == "__main__":  # pragma: no cover - manual visual test
         def build(self):
             kv_path = Path(__file__).resolve().parents[2] / "main.kv"
             if kv_path.exists():
-                Builder.load_file(str(kv_path))
+                kv_text = kv_path.read_text(encoding="utf-8")
+                start = kv_text.find("<MetricInputScreen>")
+                if start != -1:
+                    end = kv_text.find("\n<", start + 1)
+                    if end == -1:
+                        end = len(kv_text)
+                    Builder.load_string(kv_text[start:end])
             return MetricInputScreen(test_mode=True)
 
     _PreviewApp().run()


### PR DESCRIPTION
## Summary
- Fix MetricInputScreen preview by loading only its rule from main.kv
- Log missing-class crash in codex_mistakes.md for future reference

## Testing
- `pytest -q`
- (failed: `pip install kivymd==1.2.0`)


------
https://chatgpt.com/codex/tasks/task_e_6898ae593f5483329ae4933424140b4a