### PR TITLE
Load kv snippet for ExerciseLibraryScreen previews

### DIFF
--- a/ui/screens/exercise_library.py
+++ b/ui/screens/exercise_library.py
@@ -380,11 +380,18 @@ if __name__ == "__main__":  # pragma: no cover - manual visual test
         run("exercise_library")
     else:
         from kivymd.app import MDApp
+        from kivy.lang import Builder
+        from pathlib import Path
         from ui.routers import SingleRouter
         from ui.stubs.library_data import LibraryStubDataProvider
 
         class _TestApp(MDApp):
             def build(self):
+                kv_path = Path(__file__).resolve().parents[2] / "main.kv"
+                kv_text = kv_path.read_text(encoding="utf-8")
+                start = kv_text.index("<ExerciseRow@")
+                end = kv_text.index("<ProgressScreen@")
+                Builder.load_string(kv_text[start:end])
                 provider = LibraryStubDataProvider()
                 return ExerciseLibraryScreen(
                     data_provider=provider, router=SingleRouter(), test_mode=True


### PR DESCRIPTION
## Summary
- Load ExerciseLibraryScreen kv rules from main.kv when running the screen directly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898bf4d7dcc8332a212705efdbcfc54