### PR TITLE
Fix crash when opening MetricInputScreen with null metrics_list

### DIFF
--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -19,7 +19,7 @@ from kivymd.uix.selectioncontrol import MDCheckbox
 class MetricInputScreen(MDScreen):
     """Screen for entering workout metrics with navigation and filtering."""
 
-    metrics_list = ObjectProperty(None)
+    metrics_list = ObjectProperty(None, allownone=True)
     label_text = StringProperty("")
     can_nav_left = BooleanProperty(False)
     can_nav_right = BooleanProperty(False)


### PR DESCRIPTION
## Summary
- allow `MetricInputScreen.metrics_list` to accept `None` so the screen can be instantiated without assigned widgets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898bf74610c833281acb556cdb1d8f1