### PR TITLE
fix NoTransition import for ExerciseLibrary screen test

### DIFF
--- a/ui/screens/exercise_library.py
+++ b/ui/screens/exercise_library.py
@@ -391,7 +391,10 @@ if __name__ == "__main__":  # pragma: no cover - manual visual test
                 kv_text = kv_path.read_text(encoding="utf-8")
                 start = kv_text.index("<ExerciseRow@")
                 end = kv_text.index("<ProgressScreen@")
-                Builder.load_string(kv_text[start:end])
+                Builder.load_string(
+                    "#:import NoTransition kivy.uix.screenmanager.NoTransition\n"
+                    + kv_text[start:end]
+                )
                 provider = LibraryStubDataProvider()
                 return ExerciseLibraryScreen(
                     data_provider=provider, router=SingleRouter(), test_mode=True


### PR DESCRIPTION
## Summary
- fix NameError in ExerciseLibrary screen preview by importing `NoTransition`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898c3ade540833295b07d96519ebf2e