### PR TITLE
feat: add test modes for preset detail screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -113,13 +113,13 @@ ScreenManager:
                 id: summary_list
         MDRaisedButton:
             text: "Edit Preset"
-            on_release: app.root.current = "edit_preset"
+            on_release: root.navigate("edit_preset")
         MDRaisedButton:
             text: "Go to Preset Overview"
-            on_release: app.root.current = "preset_overview"
+            on_release: root.navigate("preset_overview")
         MDRaisedButton:
             text: "Back to Presets"
-            on_release: app.root.current = "presets"
+            on_release: root.navigate("presets")
 
 <ExerciseRow@MDBoxLayout>:
     name: ""


### PR DESCRIPTION
## Summary
- allow PresetDetailScreen to accept a router and handle navigation via helper
- add interactive single or flow test modes when running preset_detail_screen directly
- switch PresetDetailScreen buttons in main.kv to use the new navigation helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898c3f476f88332b39de19d09d18ade