### PR TITLE
Move metric helpers to dedicated backend module

### DIFF
--- a/backend/exercise.py
+++ b/backend/exercise.py
@@ -1,5 +1,6 @@
 from pathlib import Path
-from core import DEFAULT_DB_PATH, get_exercise_details, get_metrics_for_exercise
+from core import DEFAULT_DB_PATH, get_exercise_details
+from backend.metrics import get_metrics_for_exercise
 
 
 class Exercise:

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -1,15 +1,866 @@
-# Functions from core.py:
-# - get_metrics_for_exercise
-# - get_metrics_for_preset
-# - get_all_metric_types
-# - get_metric_type_schema
-# - is_metric_type_user_created
-# - add_metric_type
-# - add_metric_to_exercise
-# - remove_metric_from_exercise
-# - update_metric_type
-# - set_section_exercise_metric_override
-# - set_exercise_metric_override
-# - delete_metric_type
-# - uses_default_metric
-# - find_exercises_using_metric_type
+from __future__ import annotations
+
+import sqlite3
+import json
+import re
+from pathlib import Path
+
+from core import DEFAULT_DB_PATH, _from_db_timing
+
+
+def get_metrics_for_exercise(
+    exercise_name: str,
+    db_path: Path = DEFAULT_DB_PATH,
+    preset_name: str | None = None,
+    is_user_created: bool | None = None,
+) -> list:
+    """Return metric definitions for ``exercise_name``.
+
+    Each item in the returned list is a dictionary with ``name`` and ``type``
+    keys. ``values`` will contain any allowed values for ``enum`` metrics.
+    """
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+
+        if is_user_created is None:
+            cursor.execute(
+                "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0 ORDER BY is_user_created DESC LIMIT 1",
+                (exercise_name,),
+            )
+        else:
+            cursor.execute(
+                "SELECT id FROM library_exercises WHERE name = ? AND is_user_created = ? AND deleted = 0",
+                (exercise_name, int(is_user_created)),
+            )
+        row = cursor.fetchone()
+        if not row:
+            return []
+        exercise_id = row[0]
+
+        cursor.execute(
+            """
+        SELECT mt.id,
+               mt.name,
+               COALESCE(em.type, mt.type),
+               COALESCE(em.input_timing, mt.input_timing),
+               COALESCE(em.is_required, mt.is_required),
+               COALESCE(em.scope, mt.scope),
+               COALESCE(em.enum_values_json, mt.enum_values_json),
+               mt.description
+        FROM library_exercise_metrics em
+        JOIN library_metric_types mt ON mt.id = em.metric_type_id
+        WHERE em.exercise_id = ? AND em.deleted = 0 AND mt.deleted = 0
+        ORDER BY em.id
+        """,
+            (exercise_id,),
+        )
+
+        metrics = []
+        for (
+            metric_type_id,
+            name,
+            mtype,
+            input_timing,
+            is_required,
+            scope,
+            enum_json,
+            description,
+        ) in cursor.fetchall():
+            values = []
+            if mtype == "enum" and enum_json:
+                try:
+                    values = json.loads(enum_json)
+                except Exception:
+                    values = []
+            metrics.append(
+                {
+                    "name": name,
+                    "type": mtype,
+                    "input_timing": input_timing,
+                    "is_required": bool(is_required),
+                    "scope": scope,
+                    "description": description,
+                    "values": values,
+                    "library_metric_type_id": metric_type_id,
+                    "preset_exercise_metric_id": None,
+                }
+            )
+
+        # Apply overrides for a specific preset if requested
+        if preset_name:
+            cursor.execute(
+                """
+            SELECT sem.id,
+                   sem.metric_name,
+                   COALESCE(sem.type, mt.type),
+                   COALESCE(sem.input_timing, mt.input_timing),
+                   COALESCE(sem.is_required, mt.is_required),
+                   COALESCE(sem.scope, mt.scope),
+                   COALESCE(sem.enum_values_json, mt.enum_values_json),
+                   COALESCE(sem.metric_description, mt.description),
+                   COALESCE(sem.library_metric_type_id, mt.id)
+            FROM preset_exercise_metrics sem
+            JOIN preset_section_exercises se ON sem.section_exercise_id = se.id
+            JOIN preset_preset_sections s ON se.section_id = s.id
+            JOIN preset_presets p ON s.preset_id = p.id
+            LEFT JOIN library_metric_types mt ON sem.library_metric_type_id = mt.id
+            WHERE p.name = ? AND se.exercise_name = ?
+              AND sem.deleted = 0 AND se.deleted = 0 AND s.deleted = 0 AND p.deleted = 0
+            ORDER BY sem.position
+            """,
+                (preset_name, exercise_name),
+            )
+            overrides: dict[str, dict] = {}
+            for (
+                sem_id,
+                name,
+                mtype,
+                input_timing,
+                is_required,
+                scope,
+                enum_json,
+                description,
+                lib_type_id,
+            ) in cursor.fetchall():
+                values = []
+                if mtype == "enum" and enum_json:
+                    try:
+                        values = json.loads(enum_json)
+                    except Exception:
+                        values = []
+                overrides[name] = {
+                    "type": mtype,
+                    "input_timing": input_timing,
+                    "is_required": bool(is_required),
+                    "scope": scope,
+                    "description": description,
+                    "values": values,
+                    "library_metric_type_id": lib_type_id,
+                    "preset_exercise_metric_id": sem_id,
+                }
+
+            for metric in metrics:
+                name = metric["name"]
+                if name in overrides:
+                    data = overrides[name]
+                    for k, v in data.items():
+                        if k == "library_metric_type_id" and v is None:
+                            # Keep the default library_metric_type_id
+                            continue
+                        metric[k] = v
+            for name, data in overrides.items():
+                if not any(m["name"] == name for m in metrics):
+                    metrics.append({"name": name, **data})
+
+        return metrics
+
+
+def get_metrics_for_preset(
+    preset_name: str, db_path: Path = DEFAULT_DB_PATH
+) -> list:
+    """Return preset-level metric definitions for ``preset_name``."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id FROM preset_presets WHERE name = ? AND deleted = 0",
+            (preset_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return []
+        preset_id = row[0]
+        cursor.execute(
+            """
+            SELECT pm.id,
+                   COALESCE(pm.library_metric_type_id, mt.id),
+                   pm.metric_name,
+                   COALESCE(pm.metric_description, mt.description),
+                   COALESCE(pm.type, mt.type),
+                   COALESCE(pm.input_timing, mt.input_timing),
+                   COALESCE(pm.is_required, mt.is_required),
+                   COALESCE(pm.scope, mt.scope),
+                   COALESCE(pm.enum_values_json, mt.enum_values_json)
+              FROM preset_preset_metrics pm
+              LEFT JOIN library_metric_types mt ON pm.library_metric_type_id = mt.id
+             WHERE pm.preset_id = ? AND pm.deleted = 0
+             ORDER BY pm.position
+            """,
+            (preset_id,),
+        )
+        metrics = []
+        for (
+            pm_id,
+            lib_type_id,
+            name,
+            description,
+            mtype,
+            timing,
+            is_required,
+            scope,
+            enum_json,
+        ) in cursor.fetchall():
+            values = []
+            if mtype == "enum" and enum_json:
+                try:
+                    values = json.loads(enum_json)
+                except Exception:
+                    values = []
+            metrics.append(
+                {
+                    "name": name,
+                    "type": mtype,
+                    "input_timing": _from_db_timing(timing),
+                    "is_required": bool(is_required),
+                    "scope": scope,
+                    "values": values,
+                    "description": description,
+                    "library_metric_type_id": lib_type_id,
+                    "preset_metric_id": pm_id,
+                }
+            )
+    return metrics
+
+
+def get_all_metric_types(
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    include_user_created: bool = False,
+) -> list:
+    """Return all metric type definitions from the database.
+
+    If ``include_user_created`` is ``True`` the returned dictionaries include an
+    ``is_user_created`` flag.
+    """
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        if include_user_created:
+            cursor.execute(
+                """
+                SELECT name, type, input_timing,
+                       is_required, scope, description, is_user_created,
+                       enum_values_json
+                FROM library_metric_types
+                WHERE deleted = 0
+                ORDER BY id
+                """,
+            )
+            metric_types = [
+                {
+                    "name": name,
+                    "type": mtype,
+                    "input_timing": input_timing,
+                    "is_required": bool(is_required),
+                    "scope": scope,
+                    "description": description,
+                    "is_user_created": bool(flag),
+                    "enum_values_json": enum_json,
+                }
+                for (
+                    name,
+                    mtype,
+                    input_timing,
+                    is_required,
+                    scope,
+                    description,
+                    flag,
+                    enum_json,
+                ) in cursor.fetchall()
+            ]
+        else:
+            cursor.execute(
+                """
+                SELECT name, type, input_timing,
+                       is_required, scope, description, enum_values_json
+                FROM library_metric_types
+                WHERE deleted = 0
+                ORDER BY id
+                """,
+            )
+            metric_types = [
+                {
+                    "name": name,
+                    "type": mtype,
+                    "input_timing": input_timing,
+                    "is_required": bool(is_required),
+                    "scope": scope,
+                    "description": description,
+                    "enum_values_json": enum_json,
+                }
+                for (
+                    name,
+                    mtype,
+                    input_timing,
+                    is_required,
+                    scope,
+                    description,
+                    enum_json,
+                ) in cursor.fetchall()
+            ]
+        return metric_types
+
+
+def get_metric_type_schema(
+    db_path: Path = DEFAULT_DB_PATH,
+) -> list:
+    """Return column definitions for the ``library_metric_types`` table.
+
+    Each item is a dictionary with ``name`` and optional ``options`` keys. The
+    ``options`` list will contain allowed values if the column has a CHECK
+    constraint enumerating them.
+    """
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='library_metric_types'",
+        )
+        row = cursor.fetchone()
+        if not row:
+            return []
+
+        create_sql = row[0]
+        fields = []
+        for line in create_sql.splitlines():
+            line = line.strip().lstrip(",").rstrip(",").strip()
+            if (
+                not line
+                or line.startswith("CREATE TABLE")
+                or line.startswith("PRIMARY KEY")
+                or line.startswith("'")
+            ):
+                continue
+            m = re.match(r'"?(\w+)"?', line)
+            if not m:
+                continue
+            col = m.group(1)
+            field = {"name": col}
+            if col in {"id", "deleted", "is_user_created"}:
+                continue
+            chk = re.search(r"CHECK\(\"?\w+\"?\s+IN\s*\(([^)]+)\)\)", line, re.IGNORECASE)
+            if chk:
+                opts = [opt.strip().strip("'\"") for opt in chk.group(1).split(",")]
+                field["options"] = opts
+            fields.append(field)
+        return fields
+
+
+def is_metric_type_user_created(
+    metric_type_name: str,
+    *,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> bool:
+    """Return ``True`` if ``metric_type_name`` is marked as user created."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT is_user_created FROM library_metric_types WHERE name = ?",
+            (metric_type_name,),
+        )
+        row = cursor.fetchone()
+        return bool(row[0]) if row else False
+
+
+def add_metric_type(
+    name: str,
+    mtype: str,
+    input_timing: str,
+    scope: str,
+    description: str = "",
+    is_required: bool = False,
+    enum_values: list[str] | None = None,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> int:
+    """Insert a new metric type and return its ID."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id FROM library_metric_types WHERE name = ? AND deleted = 0",
+            (name,),
+        )
+        if cursor.fetchone():
+            raise ValueError(f"Metric type '{name}' already exists")
+        cursor.execute(
+            """
+            INSERT INTO library_metric_types
+                (name, type, input_timing,
+                 is_required, scope, description, is_user_created,
+                 enum_values_json)
+            VALUES (?, ?, ?, ?, ?, ?, 1, ?)
+            """,
+            (
+                name,
+                mtype,
+                input_timing,
+                int(is_required),
+                scope,
+                description,
+                json.dumps(enum_values) if enum_values is not None else None,
+            ),
+        )
+        metric_id = cursor.lastrowid
+        conn.commit()
+        return metric_id
+
+
+def add_metric_to_exercise(
+    exercise_name: str,
+    metric_type_name: str,
+    *,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> None:
+    """Associate ``metric_type_name`` with ``exercise_name``."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0",
+            (exercise_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Exercise '{exercise_name}' not found")
+        exercise_id = row[0]
+
+        cursor.execute(
+            "SELECT id FROM library_metric_types WHERE name = ? AND deleted = 0",
+            (metric_type_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Metric type '{metric_type_name}' not found")
+        metric_id = row[0]
+
+        cursor.execute(
+            "SELECT 1 FROM library_exercise_metrics WHERE exercise_id = ? AND metric_type_id = ? AND deleted = 0",
+            (exercise_id, metric_id),
+        )
+        if cursor.fetchone():
+            raise ValueError("Metric already associated with exercise")
+        cursor.execute(
+            "INSERT INTO library_exercise_metrics (exercise_id, metric_type_id) VALUES (?, ?)",
+            (exercise_id, metric_id),
+        )
+        conn.commit()
+
+
+def remove_metric_from_exercise(
+    exercise_name: str,
+    metric_type_name: str,
+    *,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> None:
+    """Remove association of ``metric_type_name`` from ``exercise_name``."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0",
+            (exercise_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Exercise '{exercise_name}' not found")
+        exercise_id = row[0]
+
+        cursor.execute(
+            "SELECT id FROM library_metric_types WHERE name = ? AND deleted = 0",
+            (metric_type_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Metric type '{metric_type_name}' not found")
+        metric_id = row[0]
+
+        cursor.execute(
+            "UPDATE library_exercise_metrics SET deleted = 1 WHERE exercise_id = ? AND metric_type_id = ?",
+            (exercise_id, metric_id),
+        )
+        conn.commit()
+
+
+def update_metric_type(
+    metric_type_name: str,
+    *,
+    new_name: str | None = None,
+    mtype: str | None = None,
+    input_timing: str | None = None,
+    is_required: bool | None = None,
+    scope: str | None = None,
+    description: str | None = None,
+    enum_values: list[str] | None = None,
+    db_path: Path = DEFAULT_DB_PATH,
+    is_user_created: bool | None = None,
+) -> None:
+    """Update fields of a metric type identified by ``metric_type_name``."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        if is_user_created is None:
+            cursor.execute(
+                "SELECT id FROM library_metric_types WHERE name = ? AND deleted = 0 ORDER BY is_user_created DESC LIMIT 1",
+                (metric_type_name,),
+            )
+        else:
+            cursor.execute(
+                "SELECT id FROM library_metric_types WHERE name = ? AND is_user_created = ? AND deleted = 0",
+                (metric_type_name, int(is_user_created)),
+            )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Metric type '{metric_type_name}' not found")
+        metric_id = row[0]
+
+        updates = []
+        params: list = []
+        if new_name is not None:
+            updates.append("name = ?")
+            params.append(new_name)
+        if mtype is not None:
+            updates.append("type = ?")
+            params.append(mtype)
+        if input_timing is not None:
+            updates.append("input_timing = ?")
+            params.append(input_timing)
+        if is_required is not None:
+            updates.append("is_required = ?")
+            params.append(int(is_required))
+        if scope is not None:
+            updates.append("scope = ?")
+            params.append(scope)
+        if description is not None:
+            updates.append("description = ?")
+            params.append(description)
+        if enum_values is not None:
+            updates.append("enum_values_json = ?")
+            params.append(json.dumps(enum_values))
+
+        if not updates:
+            return
+        params.append(metric_id)
+        cursor.execute(
+            f"UPDATE library_metric_types SET {', '.join(updates)} WHERE id = ?",
+            params,
+        )
+        conn.commit()
+
+
+def set_section_exercise_metric_override(
+    preset_name: str,
+    section_index: int,
+    exercise_name: str,
+    metric_type_name: str,
+    *,
+    input_timing: str,
+    is_required: bool = False,
+    scope: str = "set",
+    enum_values: list[str] | None = None,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> None:
+    """Apply an override for ``metric_type_name`` for a specific exercise in a preset."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+
+        cursor.execute(
+            "SELECT id FROM preset_presets WHERE name = ? AND deleted = 0",
+            (preset_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Preset '{preset_name}' not found")
+        preset_id = row[0]
+
+        cursor.execute(
+            "SELECT id FROM preset_preset_sections WHERE preset_id = ? AND deleted = 0 ORDER BY position",
+            (preset_id,),
+        )
+        sections = cursor.fetchall()
+        if section_index < 0 or section_index >= len(sections):
+            raise IndexError("Section index out of range")
+        section_id = sections[section_index][0]
+
+        cursor.execute(
+            "SELECT id, type, description FROM library_metric_types WHERE name = ? AND deleted = 0",
+            (metric_type_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Metric '{metric_type_name}' not found")
+        metric_type_id, def_type, metric_desc = row
+
+        cursor.execute(
+            "SELECT id FROM preset_section_exercises WHERE section_id = ? AND exercise_name = ? AND deleted = 0",
+            (section_id, exercise_name),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError("Exercise not found in section")
+        se_id = row[0]
+
+        cursor.execute(
+            "SELECT id FROM preset_exercise_metrics WHERE section_exercise_id = ? AND metric_name = ? AND deleted = 0",
+            (se_id, metric_type_name),
+        )
+        row = cursor.fetchone()
+        if row:
+            cursor.execute(
+                """
+                UPDATE preset_exercise_metrics
+                   SET type = ?,
+                       input_timing = ?,
+                       is_required = ?,
+                       scope = ?,
+                       enum_values_json = ?,
+                       library_metric_type_id = ?
+                 WHERE id = ?
+                """,
+                (
+                    mtype if (mtype := def_type) is not None else def_type,
+                    input_timing,
+                    int(is_required),
+                    scope,
+                    json.dumps(enum_values) if enum_values is not None else None,
+                    metric_type_id,
+                    row[0],
+                ),
+            )
+        else:
+            cursor.execute(
+                """
+                INSERT INTO preset_exercise_metrics
+                    (section_exercise_id, metric_name, metric_description, type, input_timing,
+                     is_required, scope, enum_values_json, library_metric_type_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    se_id,
+                    metric_type_name,
+                    metric_desc,
+                    def_type,
+                    input_timing,
+                    int(is_required),
+                    scope,
+                    json.dumps(enum_values) if enum_values is not None else None,
+                    metric_type_id,
+                ),
+            )
+        conn.commit()
+
+
+def set_exercise_metric_override(
+    exercise_name: str,
+    metric_type_name: str,
+    *,
+    is_user_created: bool | None = None,
+    mtype: str | None = None,
+    input_timing: str | None = None,
+    is_required: bool | None = None,
+    scope: str | None = None,
+    enum_values: list[str] | None = None,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> None:
+    """Apply an override for ``metric_type_name`` for a specific exercise.
+
+    ``is_user_created`` selects between predefined and user-created copies of
+    the exercise.  If ``None`` (the default), the user-created variant will be
+    chosen when it exists.
+    """
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+
+        if is_user_created is None:
+            cursor.execute(
+                "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0 ORDER BY is_user_created DESC LIMIT 1",
+                (exercise_name,),
+            )
+        else:
+            cursor.execute(
+                "SELECT id FROM library_exercises WHERE name = ? AND is_user_created = ? AND deleted = 0",
+                (exercise_name, int(is_user_created)),
+            )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Exercise '{exercise_name}' not found")
+        exercise_id = row[0]
+
+        cursor.execute(
+            "SELECT id FROM library_metric_types WHERE name = ? AND deleted = 0",
+            (metric_type_name,),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError(f"Metric '{metric_type_name}' not found")
+        metric_type_id = row[0]
+
+        cursor.execute(
+            "SELECT id FROM library_exercise_metrics WHERE exercise_id = ? AND metric_type_id = ? AND deleted = 0",
+            (exercise_id, metric_type_id),
+        )
+        row = cursor.fetchone()
+        if not row:
+            raise ValueError("Exercise is not associated with the metric")
+        em_id = row[0]
+
+        updates = []
+        params: list = []
+        if mtype is not None:
+            updates.append("type = ?")
+            params.append(mtype)
+        if input_timing is not None:
+            updates.append("input_timing = ?")
+            params.append(input_timing)
+        if is_required is not None:
+            updates.append("is_required = ?")
+            params.append(int(is_required))
+        if scope is not None:
+            updates.append("scope = ?")
+            params.append(scope)
+        if enum_values is not None:
+            updates.append("enum_values_json = ?")
+            params.append(json.dumps(enum_values))
+
+        if not updates:
+            cursor.execute(
+                """
+                UPDATE library_exercise_metrics
+                   SET type = NULL,
+                       input_timing = NULL,
+                       is_required = NULL,
+                       scope = NULL,
+                       enum_values_json = NULL
+                 WHERE id = ?
+                """,
+                (em_id,),
+            )
+        else:
+            params.append(em_id)
+            cursor.execute(
+                f"UPDATE library_exercise_metrics SET {', '.join(updates)} WHERE id = ?",
+                params,
+            )
+        conn.commit()
+
+
+def delete_metric_type(
+    name: str,
+    db_path: Path = DEFAULT_DB_PATH,
+    *,
+    is_user_created: bool = True,
+) -> bool:
+    """Delete ``name`` from the metric types table."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id FROM library_metric_types WHERE name = ? AND is_user_created = ? AND deleted = 0",
+            (name, int(is_user_created)),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return False
+
+        mt_id = row[0]
+
+        cursor.execute(
+            "SELECT 1 FROM library_exercise_metrics WHERE metric_type_id = ? AND deleted = 0 LIMIT 1",
+            (mt_id,),
+        )
+        if cursor.fetchone():
+            raise ValueError("Metric type is in use and cannot be deleted")
+
+        cursor.execute(
+            "SELECT 1 FROM preset_preset_metrics WHERE library_metric_type_id = ? AND deleted = 0 LIMIT 1",
+            (mt_id,),
+        )
+        if cursor.fetchone():
+            raise ValueError("Metric type is in use and cannot be deleted")
+
+        cursor.execute(
+            "SELECT 1 FROM preset_exercise_metrics WHERE library_metric_type_id = ? AND deleted = 0 LIMIT 1",
+            (mt_id,),
+        )
+        if cursor.fetchone():
+            raise ValueError("Metric type is in use and cannot be deleted")
+
+        cursor.execute(
+            "UPDATE library_metric_types SET deleted = 1 WHERE id = ?",
+            (mt_id,),
+        )
+        conn.commit()
+        return True
+
+
+def uses_default_metric(
+    exercise_name: str,
+    metric_type_name: str,
+    *,
+    is_user_created: bool | None = None,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> bool:
+    """Return ``True`` if ``exercise_name`` uses ``metric_type_name`` defaults."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+        if is_user_created is None:
+            cursor.execute(
+                "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0 ORDER BY is_user_created DESC LIMIT 1",
+                (exercise_name,),
+            )
+        else:
+            cursor.execute(
+                "SELECT id FROM library_exercises WHERE name = ? AND is_user_created = ? AND deleted = 0",
+                (exercise_name, int(is_user_created)),
+            )
+        row = cursor.fetchone()
+        if not row:
+            return False
+        ex_id = row[0]
+        cursor.execute(
+            """
+            SELECT em.type, em.input_timing, em.is_required, em.scope, em.enum_values_json
+              FROM library_exercise_metrics em
+              JOIN library_metric_types mt ON em.metric_type_id = mt.id
+             WHERE em.exercise_id = ? AND mt.name = ? AND em.deleted = 0 AND mt.deleted = 0
+            """,
+            (ex_id, metric_type_name),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return False
+        return all(val is None for val in row)
+
+
+def find_exercises_using_metric_type(
+    metric_name: str,
+    *,
+    db_path: Path = DEFAULT_DB_PATH,
+) -> list[str]:
+    """Return exercise names that include ``metric_name``."""
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT id FROM library_metric_types WHERE name = ? AND deleted = 0",
+            (metric_name,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return []
+        mt_id = row[0]
+        cur.execute(
+            """
+            SELECT e.name
+              FROM library_exercise_metrics em
+              JOIN library_exercises e ON em.exercise_id = e.id
+             WHERE em.metric_type_id = ? AND em.deleted = 0 AND e.deleted = 0
+            """,
+            (mt_id,),
+        )
+        return [r[0] for r in cur.fetchall()]
+

--- a/backend/workout_session.py
+++ b/backend/workout_session.py
@@ -3,12 +3,11 @@ import time
 from pathlib import Path
 
 from core import (
-    get_metrics_for_exercise,
-    get_metrics_for_preset,
     DEFAULT_SETS_PER_EXERCISE,
     DEFAULT_REST_DURATION,
     DEFAULT_DB_PATH,
 )
+from backend.metrics import get_metrics_for_exercise, get_metrics_for_preset
 
 
 class WorkoutSession:

--- a/main.py
+++ b/main.py
@@ -48,10 +48,16 @@ import core
 from backend.workout_session import WorkoutSession
 from core import (
     load_workout_presets,
-    get_metrics_for_exercise,
     DEFAULT_SETS_PER_EXERCISE,
     DEFAULT_REST_DURATION,
     DEFAULT_DB_PATH,
+)
+from backend.metrics import (
+    get_metrics_for_exercise,
+    get_metric_type_schema,
+    add_metric_type,
+    update_metric_type,
+    find_exercises_using_metric_type,
 )
 from backend.preset_editor import PresetEditor
 from ui.screens.metric_input_screen import MetricInputScreen
@@ -157,7 +163,7 @@ class EditMetricTypePopup(MDDialog):
     def _build_widgets(self):
         default_height = dp(48)
         self.input_widgets = {}
-        schema = core.get_metric_type_schema()
+        schema = get_metric_type_schema()
         if not schema:
             schema = [
                 {"name": "name"},
@@ -318,7 +324,7 @@ class EditMetricTypePopup(MDDialog):
             info_widgets.append(MDLabel(text=msg, halign="center"))
 
         if self.metric:
-            affected = core.find_exercises_using_metric_type(self.metric_name)
+            affected = find_exercises_using_metric_type(self.metric_name)
             if affected:
                 label = MDLabel(
                     text=f"Affects {len(affected)} exercises", halign="center"
@@ -358,7 +364,7 @@ class EditMetricTypePopup(MDDialog):
 
         db_path = DEFAULT_DB_PATH
         if self.metric and self.is_user_created:
-            core.update_metric_type(
+            update_metric_type(
                 self.metric_name,
                 mtype=data.get("type"),
                 input_timing=data.get("input_timing"),
@@ -371,7 +377,7 @@ class EditMetricTypePopup(MDDialog):
             )
         else:
             try:
-                core.add_metric_type(
+                add_metric_type(
                     data.get("name"),
                     data.get("type"),
                     data.get("input_timing"),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,6 +5,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import core
+from backend import metrics as metrics_module
 from backend.exercise import Exercise
 from backend.workout_session import WorkoutSession
 
@@ -91,7 +92,7 @@ def test_get_all_exercises(sample_db):
 
 def test_get_metrics_with_override(sample_db):
     # apply override before fetching
-    core.set_section_exercise_metric_override(
+    metrics_module.set_section_exercise_metric_override(
         "Push Day",
         0,
         "Bench Press",
@@ -101,7 +102,7 @@ def test_get_metrics_with_override(sample_db):
         scope="set",
         db_path=sample_db,
     )
-    metrics = core.get_metrics_for_exercise(
+    metrics = metrics_module.get_metrics_for_exercise(
         "Bench Press", db_path=sample_db, preset_name="Push Day"
     )
     override = next(m for m in metrics if m["name"] == "Weight")
@@ -110,7 +111,7 @@ def test_get_metrics_with_override(sample_db):
 
 
 def test_add_and_remove_metric(sample_db):
-    metric_id = core.add_metric_type(
+    metric_id = metrics_module.add_metric_type(
         name="Tempo",
         mtype="int",
         input_timing="post_set",
@@ -118,14 +119,14 @@ def test_add_and_remove_metric(sample_db):
         db_path=sample_db,
     )
     assert isinstance(metric_id, int)
-    core.add_metric_to_exercise("Push Up", "Tempo", db_path=sample_db)
+    metrics_module.add_metric_to_exercise("Push Up", "Tempo", db_path=sample_db)
     metrics = [
-        m["name"] for m in core.get_metrics_for_exercise("Push Up", db_path=sample_db)
+        m["name"] for m in metrics_module.get_metrics_for_exercise("Push Up", db_path=sample_db)
     ]
     assert "Tempo" in metrics
-    core.remove_metric_from_exercise("Push Up", "Tempo", db_path=sample_db)
+    metrics_module.remove_metric_from_exercise("Push Up", "Tempo", db_path=sample_db)
     metrics = [
-        m["name"] for m in core.get_metrics_for_exercise("Push Up", db_path=sample_db)
+        m["name"] for m in metrics_module.get_metrics_for_exercise("Push Up", db_path=sample_db)
     ]
     assert "Tempo" not in metrics
 
@@ -152,7 +153,7 @@ def test_workout_session_progress(sample_db, monkeypatch):
 
 
 def test_exercise_metric_override_table(sample_db):
-    core.set_exercise_metric_override(
+    metrics_module.set_exercise_metric_override(
         "Bench Press",
         "Weight",
         input_timing="pre_session",
@@ -160,32 +161,32 @@ def test_exercise_metric_override_table(sample_db):
         scope="exercise",
         db_path=sample_db,
     )
-    metrics = core.get_metrics_for_exercise("Bench Press", db_path=sample_db)
+    metrics = metrics_module.get_metrics_for_exercise("Bench Press", db_path=sample_db)
     override = next(m for m in metrics if m["name"] == "Weight")
     assert override["input_timing"] == "pre_session"
     assert override["is_required"] is True
 
-    core.set_exercise_metric_override("Bench Press", "Weight", db_path=sample_db)
-    metrics = core.get_metrics_for_exercise("Bench Press", db_path=sample_db)
+    metrics_module.set_exercise_metric_override("Bench Press", "Weight", db_path=sample_db)
+    metrics = metrics_module.get_metrics_for_exercise("Bench Press", db_path=sample_db)
     default = next(m for m in metrics if m["name"] == "Weight")
     assert default["input_timing"] == "post_set"
     assert default["is_required"] is False
 
 
 def test_global_update_removes_override(sample_db):
-    core.set_exercise_metric_override(
+    metrics_module.set_exercise_metric_override(
         "Bench Press",
         "Weight",
         input_timing="pre_session",
         db_path=sample_db,
     )
-    core.update_metric_type("Weight", input_timing="post_session", db_path=sample_db)
-    metrics = core.get_metrics_for_exercise("Bench Press", db_path=sample_db)
+    metrics_module.update_metric_type("Weight", input_timing="post_session", db_path=sample_db)
+    metrics = metrics_module.get_metrics_for_exercise("Bench Press", db_path=sample_db)
     override = next(m for m in metrics if m["name"] == "Weight")
     assert override["input_timing"] == "pre_session"
 
-    core.set_exercise_metric_override("Bench Press", "Weight", db_path=sample_db)
-    metrics = core.get_metrics_for_exercise("Bench Press", db_path=sample_db)
+    metrics_module.set_exercise_metric_override("Bench Press", "Weight", db_path=sample_db)
+    metrics = metrics_module.get_metrics_for_exercise("Bench Press", db_path=sample_db)
     updated = next(m for m in metrics if m["name"] == "Weight")
     assert updated["input_timing"] == "post_session"
 
@@ -208,7 +209,7 @@ def test_override_with_user_flag(sample_db):
     conn.commit()
     conn.close()
 
-    core.set_exercise_metric_override(
+    metrics_module.set_exercise_metric_override(
         "Bench Press",
         "Weight",
         input_timing="pre_session",
@@ -216,13 +217,13 @@ def test_override_with_user_flag(sample_db):
         db_path=sample_db,
     )
 
-    metrics_user = core.get_metrics_for_exercise(
+    metrics_user = metrics_module.get_metrics_for_exercise(
         "Bench Press", db_path=sample_db, is_user_created=True
     )
     user_override = next(m for m in metrics_user if m["name"] == "Weight")
     assert user_override["input_timing"] == "pre_session"
 
-    metrics_default = core.get_metrics_for_exercise(
+    metrics_default = metrics_module.get_metrics_for_exercise(
         "Bench Press", db_path=sample_db, is_user_created=False
     )
     default_metric = next(m for m in metrics_default if m["name"] == "Weight")
@@ -230,7 +231,7 @@ def test_override_with_user_flag(sample_db):
 
 
 def test_delete_metric_type(sample_db):
-    metric_id = core.add_metric_type(
+    metric_id = metrics_module.add_metric_type(
         name="Tempo",
         mtype="int",
         input_timing="post_set",
@@ -238,17 +239,17 @@ def test_delete_metric_type(sample_db):
         db_path=sample_db,
     )
     assert isinstance(metric_id, int)
-    assert core.delete_metric_type("Tempo", db_path=sample_db, is_user_created=True)
-    metrics = core.get_all_metric_types(sample_db, include_user_created=True)
+    assert metrics_module.delete_metric_type("Tempo", db_path=sample_db, is_user_created=True)
+    metrics = metrics_module.get_all_metric_types(sample_db, include_user_created=True)
     assert all(m["name"] != "Tempo" for m in metrics)
     assert (
-        core.delete_metric_type("Tempo", db_path=sample_db, is_user_created=True)
+        metrics_module.delete_metric_type("Tempo", db_path=sample_db, is_user_created=True)
         is False
     )
 
 
 def test_delete_metric_type_in_use_by_preset_exercise(sample_db):
-    mt_id = core.add_metric_type(
+    mt_id = metrics_module.add_metric_type(
         name="Velocity",
         mtype="float",
         input_timing="post_set",
@@ -273,7 +274,7 @@ def test_delete_metric_type_in_use_by_preset_exercise(sample_db):
     conn.close()
 
     with pytest.raises(ValueError):
-        core.delete_metric_type("Velocity", db_path=sample_db, is_user_created=True)
+        metrics_module.delete_metric_type("Velocity", db_path=sample_db, is_user_created=True)
 
 
 def test_find_presets_and_apply_changes(sample_db):
@@ -290,7 +291,7 @@ def test_find_presets_and_apply_changes(sample_db):
             "scope": "set",
         }
     )
-    core.add_metric_to_exercise("Push Up", "Weight", db_path=sample_db)
+    metrics_module.add_metric_to_exercise("Push Up", "Weight", db_path=sample_db)
 
     conn = sqlite3.connect(sample_db)
     before = {

--- a/tests/test_database_helpers.py
+++ b/tests/test_database_helpers.py
@@ -1,4 +1,5 @@
 import core
+from backend import metrics
 from backend.exercise import Exercise
 
 
@@ -23,15 +24,15 @@ def test_get_all_exercises(sample_db):
 
 
 def test_get_metrics_for_exercise(sample_db):
-    default = core.get_metrics_for_exercise("Bench Press", db_path=sample_db)
-    override = core.get_metrics_for_exercise("Bench Press", preset_name="Push Day", db_path=sample_db)
+    default = metrics.get_metrics_for_exercise("Bench Press", db_path=sample_db)
+    override = metrics.get_metrics_for_exercise("Bench Press", preset_name="Push Day", db_path=sample_db)
 
     def get_timing(metrics, name):
         return next(m for m in metrics if m["name"] == name)["input_timing"]
 
     assert get_timing(default, "Reps") == "post_set"
     assert get_timing(override, "Reps") == "pre_set"
-    assert core.get_metrics_for_exercise("Unknown", db_path=sample_db) == []
+    assert metrics.get_metrics_for_exercise("Unknown", db_path=sample_db) == []
 
 
 def test_load_workout_presets(sample_db):

--- a/tests/test_enum_values.py
+++ b/tests/test_enum_values.py
@@ -1,6 +1,7 @@
 import sqlite3
 from pathlib import Path
 import core
+from backend import metrics
 from backend.exercise import Exercise
 
 
@@ -13,13 +14,13 @@ def test_enum_values_default_and_override(sample_db: Path) -> None:
     conn.close()
 
     # Add Machine metric to an exercise without override
-    core.add_metric_to_exercise("Push-up", "Machine", db_path=sample_db)
+    metrics.add_metric_to_exercise("Push-up", "Machine", db_path=sample_db)
 
-    metrics_push = core.get_metrics_for_exercise("Push-up", db_path=sample_db)
+    metrics_push = metrics.get_metrics_for_exercise("Push-up", db_path=sample_db)
     vals_push = next(m["values"] for m in metrics_push if m["name"] == "Machine")
     assert vals_push == ["A", "B", "C"]
 
-    metrics_bench = core.get_metrics_for_exercise("Bench Press", db_path=sample_db)
+    metrics_bench = metrics.get_metrics_for_exercise("Bench Press", db_path=sample_db)
     vals_bench = next(m["values"] for m in metrics_bench if m["name"] == "Machine")
     assert vals_bench == ["A", "B"]
 
@@ -28,6 +29,6 @@ def test_enum_values_default_and_override(sample_db: Path) -> None:
     ex.update_metric("Machine", values=["A"])
     core.save_exercise(ex)
 
-    metrics_bench2 = core.get_metrics_for_exercise("Bench Press", db_path=sample_db)
+    metrics_bench2 = metrics.get_metrics_for_exercise("Bench Press", db_path=sample_db)
     vals_bench2 = next(m["values"] for m in metrics_bench2 if m["name"] == "Machine")
     assert vals_bench2 == ["A"]

--- a/tests/test_preset_metrics.py
+++ b/tests/test_preset_metrics.py
@@ -1,5 +1,6 @@
 import sqlite3
 import core
+from backend import metrics as bm
 
 def test_get_metrics_for_preset_pre_session(sample_db):
     conn = sqlite3.connect(sample_db)
@@ -18,7 +19,7 @@ def test_get_metrics_for_preset_pre_session(sample_db):
     conn.commit()
     conn.close()
 
-    metrics = core.get_metrics_for_preset('Push Day', db_path=sample_db)
-    duration = next(m for m in metrics if m["name"] == "Duration")
+    mdefs = bm.get_metrics_for_preset('Push Day', db_path=sample_db)
+    duration = next(m for m in mdefs if m["name"] == "Duration")
     assert duration["input_timing"] == "pre_session"
     assert duration["type"] == "int"

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -17,6 +17,7 @@ if kivy_available:
     from kivy.app import App
     from kivy.properties import ObjectProperty
     import core
+    from backend import metrics as metrics_module
     from backend.preset_editor import PresetEditor
     from backend.exercise import Exercise
     from backend.workout_session import WorkoutSession
@@ -625,7 +626,7 @@ def test_add_metric_popup_filters_scope(monkeypatch):
         {"name": "Set", "scope": "set"},
     ]
 
-    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: metrics)
+    monkeypatch.setattr(metrics_module, "get_all_metric_types", lambda *a, **k: metrics)
 
     popup = AddMetricPopup(DummyScreen(), popup_mode="select")
     list_view = popup.content_cls.children[0]
@@ -656,7 +657,7 @@ def test_add_preset_metric_popup_filters_scope(monkeypatch):
         {"name": "Session", "scope": "session"},
     ]
 
-    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: metrics)
+    monkeypatch.setattr(metrics_module, "get_all_metric_types", lambda *a, **k: metrics)
     screen = EditPresetScreen()
     popup = AddPresetMetricPopup(screen)
     list_view = popup.content_cls.children[0]
@@ -687,7 +688,7 @@ def test_add_session_metric_popup_filters_scope(monkeypatch):
         {"name": "Focus", "scope": "preset"},
     ]
 
-    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: metrics)
+    monkeypatch.setattr(metrics_module, "get_all_metric_types", lambda *a, **k: metrics)
     screen = EditPresetScreen()
     popup = AddSessionMetricPopup(screen)
     list_view = popup.content_cls.children[0]
@@ -1081,7 +1082,7 @@ def test_edit_metric_duplicate_name(monkeypatch):
     metric = DummyScreen.exercise_obj.metrics[0]
     popup = EditMetricPopup(DummyScreen(), metric)
     popup.input_widgets["name"].text = "Weight"
-    monkeypatch.setattr(core, "is_metric_type_user_created", lambda *a, **k: False)
+    monkeypatch.setattr(metrics_module, "is_metric_type_user_created", lambda *a, **k: False)
     popup.save_metric()
 
     assert not DummyScreen.exercise_obj.updated
@@ -1256,7 +1257,7 @@ def test_edit_preset_populate_details(monkeypatch):
         },
     ]
 
-    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: metrics)
+    monkeypatch.setattr(metrics_module, "get_all_metric_types", lambda *a, **k: metrics)
 
     app = _DummyApp()
     app.preset_editor = type(
@@ -1288,7 +1289,7 @@ def test_preset_name_row_preserved(monkeypatch):
 
     Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
 
-    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: [])
+    monkeypatch.setattr(metrics_module, "get_all_metric_types", lambda *a, **k: [])
 
     app = _DummyApp()
     app.preset_editor = type(
@@ -1317,7 +1318,7 @@ def test_details_has_add_button(monkeypatch):
 
     Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
 
-    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: [])
+    monkeypatch.setattr(metrics_module, "get_all_metric_types", lambda *a, **k: [])
 
     app = _DummyApp()
     app.preset_editor = type(
@@ -1345,7 +1346,7 @@ def test_metrics_has_add_button(monkeypatch):
 
     Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
 
-    monkeypatch.setattr(core, "get_all_metric_types", lambda *a, **k: [])
+    monkeypatch.setattr(metrics_module, "get_all_metric_types", lambda *a, **k: [])
 
     app = _DummyApp()
     app.preset_editor = type(
@@ -1373,7 +1374,7 @@ def test_fallback_input_timing_options(monkeypatch):
     class DummyScreen:
         exercise_obj = type("obj", (), {"metrics": []})()
 
-    monkeypatch.setattr(core, "get_metric_type_schema", lambda *a, **k: [])
+    monkeypatch.setattr(metrics_module, "get_metric_type_schema", lambda *a, **k: [])
     popup = AddMetricPopup(DummyScreen(), popup_mode="new")
     opts = list(popup.input_widgets["input_timing"].values)
     assert opts == [

--- a/tests/test_workout_db.py
+++ b/tests/test_workout_db.py
@@ -5,6 +5,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import core
+from backend import metrics
 
 
 def create_empty_db(path: Path) -> None:
@@ -87,7 +88,7 @@ def sample_db(tmp_db: Path) -> Path:
 
 
 def test_get_metric_type_schema(tmp_db: Path):
-    fields = core.get_metric_type_schema(db_path=tmp_db)
+    fields = metrics.get_metric_type_schema(db_path=tmp_db)
     names = {f["name"] for f in fields}
     assert names == {"name", "type", "input_timing", "is_required", "scope", "description", "enum_values_json"}
     type_opts = next(f["options"] for f in fields if f["name"] == "type")
@@ -122,7 +123,7 @@ def test_load_workout_presets(sample_db: Path):
 
 
 def test_add_and_remove_metric_from_exercise(sample_db: Path):
-    core.add_metric_to_exercise("Bench Press", "Reps", db_path=sample_db)
+    metrics.add_metric_to_exercise("Bench Press", "Reps", db_path=sample_db)
     conn = sqlite3.connect(sample_db)
     cur = conn.cursor()
     cur.execute(
@@ -130,7 +131,7 @@ def test_add_and_remove_metric_from_exercise(sample_db: Path):
     )
     count = cur.fetchone()[0]
     assert count == 1
-    core.remove_metric_from_exercise("Bench Press", "Reps", db_path=sample_db)
+    metrics.remove_metric_from_exercise("Bench Press", "Reps", db_path=sample_db)
     cur.execute(
         """SELECT COUNT(*) FROM library_exercise_metrics em JOIN library_exercises e ON em.exercise_id = e.id JOIN library_metric_types mt ON em.metric_type_id = mt.id WHERE e.name='Bench Press' AND mt.name='Reps' AND em.deleted = 0 AND e.deleted = 0 AND mt.deleted = 0"""
     )

--- a/ui/popups.py
+++ b/ui/popups.py
@@ -21,6 +21,7 @@ import sqlite3
 
 import core
 from core import DEFAULT_DB_PATH
+from backend import metrics as bm
 
 # Order of fields for metric editing popups
 METRIC_FIELD_ORDER = [
@@ -75,7 +76,7 @@ class AddMetricPopup(MDDialog):
     # Building widgets for both modes
     # ------------------------------------------------------------------
     def _build_select_widgets(self):
-        metrics = core.get_all_metric_types()
+        metrics = bm.get_all_metric_types()
         existing = {m.get("name") for m in self.screen.exercise_obj.metrics}
         metrics = [
             m
@@ -102,7 +103,7 @@ class AddMetricPopup(MDDialog):
         default_height = dp(48)
         self.input_widgets = {}
 
-        schema = core.get_metric_type_schema()
+        schema = bm.get_metric_type_schema()
         if not schema:
             schema = [
                 {"name": "name"},
@@ -248,7 +249,7 @@ class AddMetricPopup(MDDialog):
         popup.open()
 
     def add_metric(self, name, *args):
-        metric_defs = core.get_all_metric_types()
+        metric_defs = bm.get_all_metric_types()
         for m in metric_defs:
             if m["name"] == name:
                 self.screen.exercise_obj.add_metric(m)
@@ -307,7 +308,7 @@ class AddMetricPopup(MDDialog):
 
         db_path = DEFAULT_DB_PATH
         try:
-            core.add_metric_type(
+            bm.add_metric_type(
                 metric["name"],
                 metric["type"],
                 metric["input_timing"],
@@ -366,7 +367,7 @@ class EditMetricPopup(MDDialog):
         default_height = dp(48)
         self.input_widgets = {}
 
-        schema = core.get_metric_type_schema()
+        schema = bm.get_metric_type_schema()
         if not schema:
             schema = [
                 {"name": "name"},
@@ -608,7 +609,7 @@ class EditMetricPopup(MDDialog):
             def on_save(*a):
                 metric_saved = self.screen.exercise_obj.had_metric(self.metric["name"])
                 if cb_type.active:
-                    core.update_metric_type(
+                    bm.update_metric_type(
                         self.metric["name"],
                         mtype=updates.get("type"),
                         input_timing=updates.get("input_timing"),
@@ -619,7 +620,7 @@ class EditMetricPopup(MDDialog):
                         db_path=db_path,
                     )
                     if metric_saved:
-                        core.set_exercise_metric_override(
+                        bm.set_exercise_metric_override(
                             self.screen.exercise_obj.name,
                             self.metric["name"],
                             is_user_created=self.screen.exercise_obj.is_user_created,
@@ -627,7 +628,7 @@ class EditMetricPopup(MDDialog):
                         )
                 elif cb_ex.active:
                     if metric_saved:
-                        core.set_exercise_metric_override(
+                        bm.set_exercise_metric_override(
                             self.screen.exercise_obj.name,
                             self.metric["name"],
                             mtype=updates.get("type"),
@@ -640,7 +641,7 @@ class EditMetricPopup(MDDialog):
                         )
                 else:
                     preset_name = app.preset_editor.preset_name if app else ""
-                    core.set_section_exercise_metric_override(
+                    bm.set_section_exercise_metric_override(
                         preset_name,
                         self.screen.section_index,
                         self.screen.exercise_obj.name,
@@ -681,9 +682,9 @@ class EditMetricPopup(MDDialog):
 
             rows = []
             cb_default = None
-            if core.is_metric_type_user_created(
+            if bm.is_metric_type_user_created(
                 self.metric["name"], db_path=db_path
-            ) and core.uses_default_metric(
+            ) and bm.uses_default_metric(
                 self.screen.exercise_obj.name,
                 self.metric["name"],
                 is_user_created=self.screen.exercise_obj.is_user_created,
@@ -742,7 +743,7 @@ class EditMetricPopup(MDDialog):
                         self.metric["name"]
                     )
                     if cb_default and cb_default.active:
-                        core.update_metric_type(
+                        bm.update_metric_type(
                             self.metric["name"],
                             mtype=updates.get("type"),
                             input_timing=updates.get("input_timing"),
@@ -753,7 +754,7 @@ class EditMetricPopup(MDDialog):
                             db_path=db_path,
                         )
                         if metric_saved:
-                            core.set_exercise_metric_override(
+                            bm.set_exercise_metric_override(
                                 self.screen.exercise_obj.name,
                                 self.metric["name"],
                                 is_user_created=self.screen.exercise_obj.is_user_created,
@@ -761,7 +762,7 @@ class EditMetricPopup(MDDialog):
                             )
                     else:
                         if metric_saved:
-                            core.set_exercise_metric_override(
+                            bm.set_exercise_metric_override(
                                 self.screen.exercise_obj.name,
                                 self.metric["name"],
                                 mtype=updates.get("type"),
@@ -802,7 +803,7 @@ class EditMetricPopup(MDDialog):
             else:
                 apply_updates()
 
-        elif core.is_metric_type_user_created(self.metric["name"], db_path=db_path):
+        elif bm.is_metric_type_user_created(self.metric["name"], db_path=db_path):
             dialog = None
 
             def cancel_action(*a):
@@ -822,7 +823,7 @@ class EditMetricPopup(MDDialog):
             def on_save(*a):
                 metric_saved = self.screen.exercise_obj.had_metric(self.metric["name"])
                 if checkbox.active:
-                    core.update_metric_type(
+                    bm.update_metric_type(
                         self.metric["name"],
                         mtype=updates.get("type"),
                         input_timing=updates.get("input_timing"),
@@ -833,7 +834,7 @@ class EditMetricPopup(MDDialog):
                         db_path=db_path,
                     )
                     if metric_saved:
-                        core.set_exercise_metric_override(
+                        bm.set_exercise_metric_override(
                             self.screen.exercise_obj.name,
                             self.metric["name"],
                             is_user_created=self.screen.exercise_obj.is_user_created,
@@ -841,7 +842,7 @@ class EditMetricPopup(MDDialog):
                         )
                 else:
                     if metric_saved:
-                        core.set_exercise_metric_override(
+                        bm.set_exercise_metric_override(
                             self.screen.exercise_obj.name,
                             self.metric["name"],
                             mtype=updates.get("type"),

--- a/ui/screens/edit_exercise_screen.py
+++ b/ui/screens/edit_exercise_screen.py
@@ -35,6 +35,7 @@ from core import (
     DEFAULT_REST_DURATION,
     DEFAULT_DB_PATH,
 )
+from backend import metrics as bm
 from backend.exercise import Exercise
 
 from .metric_input_screen import MetricInputScreen
@@ -416,7 +417,7 @@ class EditExerciseScreen(MDScreen):
                             metric.get(field) != old.get(field)
                             for field in ("input_timing", "is_required", "scope")
                         ):
-                            core.set_section_exercise_metric_override(
+                            bm.set_section_exercise_metric_override(
                                 preset_name,
                                 self.section_index,
                                 self.exercise_obj.name,

--- a/ui/screens/edit_preset_screen.py
+++ b/ui/screens/edit_preset_screen.py
@@ -28,6 +28,7 @@ import sqlite3
 
 import core
 from core import DEFAULT_DB_PATH
+from backend.metrics import get_metrics_for_exercise, get_all_metric_types
 
 
 class SectionWidget(MDBoxLayout):
@@ -326,7 +327,7 @@ class EditPresetScreen(MDScreen):
                 else:
                     results = []
                     description = ""
-                    metric_defs = core.get_metrics_for_exercise(
+                    metric_defs = get_metrics_for_exercise(
                         ex["name"],
                         db_path=session.db_path,
                         preset_name=session.preset_name,
@@ -561,7 +562,7 @@ class EditPresetScreen(MDScreen):
 
         all_defs = {
             m["name"]: m
-            for m in core.get_all_metric_types(include_user_created=True)
+            for m in get_all_metric_types(include_user_created=True)
         }
 
         rv.data = [
@@ -912,7 +913,7 @@ class AddPresetMetricPopup(MDDialog):
             }
         metrics = [
             m
-            for m in core.get_all_metric_types()
+            for m in get_all_metric_types()
             if m.get("scope") == "preset" and (
                 m.get("name") not in existing and m.get("metric_name") not in existing
             )
@@ -964,7 +965,7 @@ class AddSessionMetricPopup(MDDialog):
             }
         metrics = [
             m
-            for m in core.get_all_metric_types()
+            for m in get_all_metric_types()
             if m.get("scope") == "session" and (
                 m.get("name") not in existing and m.get("metric_name") not in existing
             )

--- a/ui/screens/exercise_library.py
+++ b/ui/screens/exercise_library.py
@@ -20,6 +20,7 @@ from kivymd.uix.button import MDRaisedButton
 import os
 import core
 from core import DEFAULT_DB_PATH
+from backend import metrics as bm
 
 
 class ExerciseLibraryScreen(MDScreen):
@@ -65,7 +66,7 @@ class ExerciseLibraryScreen(MDScreen):
             and self.metric_cache_version != getattr(app, "metric_library_version", 0)
         ):
             db_path = DEFAULT_DB_PATH
-            self.all_metrics = core.get_all_metric_types(
+            self.all_metrics = bm.get_all_metric_types(
                 db_path, include_user_created=True
             )
             if app:
@@ -148,7 +149,7 @@ class ExerciseLibraryScreen(MDScreen):
             and self.metric_cache_version != getattr(app, "metric_library_version", 0)
         ):
             db_path = DEFAULT_DB_PATH
-            self.all_metrics = core.get_all_metric_types(
+            self.all_metrics = bm.get_all_metric_types(
                 db_path, include_user_created=True
             )
             if app:
@@ -284,7 +285,7 @@ class ExerciseLibraryScreen(MDScreen):
         def do_delete(*args):
             db_path = DEFAULT_DB_PATH
             try:
-                core.delete_metric_type(
+                bm.delete_metric_type(
                     metric_name, db_path=db_path, is_user_created=True
                 )
                 app = MDApp.get_running_app()

--- a/ui/screens/preset_overview_screen.py
+++ b/ui/screens/preset_overview_screen.py
@@ -2,6 +2,7 @@ from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
 from kivy.properties import ObjectProperty
 import core
+from backend.metrics import get_metrics_for_exercise, get_metrics_for_preset
 from ui.expandable_list_item import ExpandableListItem, ExerciseSummaryItem
 from ui.popups import PreSessionMetricPopup
 
@@ -69,7 +70,7 @@ class PresetOverviewScreen(MDScreen):
                 desc = desc_info.get("description", "") if desc_info else ""
                 sets = ex.get("sets", 0) or 0
                 rest = ex.get("rest", 0) or 0
-                metrics = core.get_metrics_for_exercise(
+                metrics = get_metrics_for_exercise(
                     ex["name"], preset_name=preset_name
                 )
                 metric_names = ", ".join(m["name"] for m in metrics)
@@ -94,7 +95,7 @@ class PresetOverviewScreen(MDScreen):
             return
         app = MDApp.get_running_app()
         preset_name = app.selected_preset
-        metrics = core.get_metrics_for_preset(preset_name)
+        metrics = get_metrics_for_preset(preset_name)
         pre_metrics = [m for m in metrics if m.get("input_timing") == "pre_session"]
         if pre_metrics:
             popup = PreSessionMetricPopup(


### PR DESCRIPTION
## Summary
- centralize metric database helpers in `backend/metrics.py`
- update imports and calls to use new metrics module
- keep metric type schema detection consistent with database

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c591721a48332bab9e67d9cc72a28