### PR TITLE
Move session helpers to backend module

### DIFF
--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -1,3 +1,205 @@
-# Functions from core.py:
-# - validate_workout_session
-# - save_completed_session
+"""Session-related helpers extracted from :mod:`core`.
+
+This module provides utilities for validating and persisting a completed
+workout session.  It was migrated from the monolithic ``core`` module to
+keep responsibilities separated and the code base easier to maintain.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from backend.utils import _to_db_timing
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from backend.workout_session import WorkoutSession
+
+
+def validate_workout_session(session: "WorkoutSession") -> list[str]:
+    """Return a list of validation errors for ``session``.
+
+    A session is considered valid when it has an ``end_time`` and each
+    exercise contains results for the expected number of sets.  The function
+    returns a list of human-readable error messages.  An empty list means the
+    session passed validation.
+    """
+
+    errors: list[str] = []
+    if session.end_time is None:
+        errors.append("Session has not been completed")
+    for ex in session.exercises:
+        expected = ex.get("sets", 0)
+        actual = len(ex.get("results", []))
+        if actual != expected:
+            errors.append(
+                f"Exercise '{ex.get('name')}' has {actual} recorded sets but expected {expected}"
+            )
+    return errors
+
+
+def save_completed_session(session: "WorkoutSession", db_path: Path | None = None) -> None:
+    """Persist a finished ``session`` to the database.
+
+    The provided ``session`` must already be validated.  When ``db_path`` is
+    omitted the path associated with the session object is used.
+    """
+
+    path = Path(db_path or session.db_path)
+    errors = validate_workout_session(session)
+    if errors:
+        raise ValueError("; ".join(errors))
+
+    with sqlite3.connect(str(path)) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO session_sessions (preset_id, preset_name, started_at, ended_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                session.preset_id,
+                session.preset_name,
+                session.start_time,
+                session.end_time or time.time(),
+            ),
+        )
+        session_id = cursor.lastrowid
+
+        cursor.execute(
+            """
+            INSERT INTO session_session_sections (session_id, name, position)
+            VALUES (?, ?, 1)
+            """,
+            (session_id, session.preset_name),
+        )
+        section_id = cursor.lastrowid
+
+        if session.session_metrics:
+            metric_map = {m["name"]: m for m in session.session_metric_defs}
+            for pos, (name, value) in enumerate(
+                session.session_metrics.items(), 1
+            ):
+                mdef = metric_map.get(name, {})
+                cursor.execute(
+                    """
+                    INSERT INTO session_session_metrics
+                        (session_id, library_metric_type_id, preset_preset_metric_id, metric_name,
+                         metric_description, type, input_timing, scope, is_required,
+                         enum_values_json, value, position)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        session_id,
+                        mdef.get("library_metric_type_id"),
+                        mdef.get("preset_metric_id"),
+                        name,
+                        mdef.get("description"),
+                        mdef.get("type", "str"),
+                        _to_db_timing(mdef.get("input_timing")),
+                        mdef.get("scope", "session"),
+                        int(mdef.get("is_required", False)),
+                        json.dumps(mdef.get("values"))
+                        if mdef.get("type") == "enum"
+                        else None,
+                        str(value),
+                        pos,
+                    ),
+                )
+
+        for ex_pos, ex in enumerate(session.exercises, 1):
+            cursor.execute(
+                """
+                INSERT INTO session_section_exercises
+                    (section_id, library_exercise_id, preset_section_exercise_id,
+                     exercise_name, exercise_description, number_of_sets, rest_time, position)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    section_id,
+                    ex.get("library_exercise_id"),
+                    ex.get("preset_section_exercise_id"),
+                    ex.get("name"),
+                    ex.get("exercise_description"),
+                    ex.get("sets", 0),
+                    ex.get("rest", session.rest_duration),
+                    ex_pos,
+                ),
+            )
+            session_ex_id = cursor.lastrowid
+            metric_defs = ex.get("metric_defs", [])
+            metric_ids: dict[str, int] = {}
+            for m_pos, m in enumerate(metric_defs, 1):
+                cursor.execute(
+                    """
+                    INSERT INTO session_exercise_metrics
+                        (session_exercise_id, library_metric_type_id, preset_exercise_metric_id,
+                         metric_name, metric_description, type, input_timing, scope,
+                         is_required, enum_values_json, position)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        session_ex_id,
+                        m.get("library_metric_type_id"),
+                        m.get("preset_exercise_metric_id"),
+                        m["name"],
+                        m.get("description"),
+                        m.get("type", "str"),
+                        _to_db_timing(m.get("input_timing")),
+                        m.get("scope", "set"),
+                        int(m.get("is_required", False)),
+                        json.dumps(m.get("values"))
+                        if m.get("type") == "enum"
+                        else None,
+                        m_pos,
+                    ),
+                )
+                metric_ids[m["name"]] = cursor.lastrowid
+
+            for set_idx, result in enumerate(ex.get("results", []), 1):
+                cursor.execute(
+                    """
+                    INSERT INTO session_exercise_sets (section_exercise_id, set_number, started_at, ended_at, notes)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        session_ex_id,
+                        set_idx,
+                        result.get("started_at"),
+                        result.get("ended_at"),
+                        result.get("notes"),
+                    ),
+                )
+                set_id = cursor.lastrowid
+                metrics = result.get("metrics", {})
+                for name, value in metrics.items():
+                    metric_id = metric_ids.get(name)
+                    if metric_id is None:
+                        cursor.execute(
+                            """
+                            INSERT INTO session_exercise_metrics
+                                (session_exercise_id, metric_name, type, input_timing, scope, position)
+                            VALUES (?, ?, ?, ?, ?, ?)
+                            """,
+                            (
+                                session_ex_id,
+                                name,
+                                "str",
+                                _to_db_timing("post_set"),
+                                "set",
+                                len(metric_ids) + 1,
+                            ),
+                        )
+                        metric_id = cursor.lastrowid
+                        metric_ids[name] = metric_id
+                    cursor.execute(
+                        """
+                        INSERT INTO session_set_metrics (exercise_set_id, exercise_metric_id, value)
+                        VALUES (?, ?, ?)
+                        """,
+                        (set_id, metric_id, str(value)),
+                    )
+

--- a/tests/test_session_save.py
+++ b/tests/test_session_save.py
@@ -1,6 +1,7 @@
 import sqlite3
 import pytest
-import core
+
+from backend.sessions import save_completed_session
 from backend.workout_session import WorkoutSession
 
 
@@ -38,7 +39,7 @@ def _complete_session(db_path):
 
 def test_save_completed_session(sample_db):
     session = _complete_session(sample_db)
-    core.save_completed_session(session, db_path=sample_db)
+    save_completed_session(session, db_path=sample_db)
     conn = sqlite3.connect(sample_db)
     cur = conn.cursor()
     cur.execute("SELECT preset_id FROM session_sessions")
@@ -63,4 +64,4 @@ def test_save_completed_session(sample_db):
 def test_save_session_validation(sample_db):
     session = WorkoutSession("Push Day", db_path=sample_db)
     with pytest.raises(ValueError):
-        core.save_completed_session(session, db_path=sample_db)
+        save_completed_session(session, db_path=sample_db)

--- a/ui/screens/workout_summary_screen.py
+++ b/ui/screens/workout_summary_screen.py
@@ -4,7 +4,8 @@ from kivymd.uix.list import OneLineListItem
 from kivy.properties import ObjectProperty
 from kivymd.uix.dialog import MDDialog
 from kivymd.uix.button import MDRaisedButton
-import core
+
+from backend.sessions import save_completed_session, validate_workout_session
 
 
 class WorkoutSummaryScreen(MDScreen):
@@ -17,12 +18,12 @@ class WorkoutSummaryScreen(MDScreen):
         app = MDApp.get_running_app()
         session = app.workout_session if app else None
         if session and not getattr(session, "saved", False):
-            errors = core.validate_workout_session(session)
+            errors = validate_workout_session(session)
             if errors:
                 self._show_error("\n".join(errors))
             else:
                 try:
-                    core.save_completed_session(session, db_path=session.db_path)
+                    save_completed_session(session, db_path=session.db_path)
                 except Exception as exc:
                     self._show_error(str(exc))
         return super().on_pre_enter(*args)


### PR DESCRIPTION
## Summary
- add validation and save logic to backend.sessions module
- adjust workout summary screen to use new session helpers
- update session saving tests for new import path

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c63c15cac8332a18ebb9a487a47b8