### PR TITLE
Add version label to Welcome screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -655,6 +655,13 @@ ScreenManager:
         spacing: "10dp"
         padding: "20dp"
         MDLabel:
+            text: app.app_version
+            halign: "center"
+            theme_text_color: "Custom"
+            text_color: 0.5, 0.5, 0.5, 1
+            font_style: "Caption"
+            adaptive_height: True
+        MDLabel:
             text: "Welcome - start your fitness journey"
             halign: "center"
             theme_text_color: "Custom"

--- a/main.py
+++ b/main.py
@@ -406,6 +406,8 @@ class WorkoutApp(MDApp):
     exercise_library_version: int = 0
     # Incremented when a metric type is added or edited
     metric_library_version: int = 0
+    # Displayed application version on the welcome screen
+    app_version = StringProperty("1.0.0")
 
     def build(self):
         root = Builder.load_file(str(Path(__file__).with_name("main.kv")))


### PR DESCRIPTION
## Summary
- Display app version on the Welcome screen via a small grey label
- Expose `app_version` StringProperty for easy version text updates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c7c5334a8833288a27b36cd9884c6