### PR TITLE
Add per-set notes field to session and metric input UI

### DIFF
--- a/tests/test_metric_input_tabs.py
+++ b/tests/test_metric_input_tabs.py
@@ -219,6 +219,12 @@ def test_save_future_metrics_preserves_session_state():
             st = self.current_set if set_index is None else set_index
             self.pending_pre_set_metrics[(ex, st)] = metrics.copy()
 
+        def get_set_notes(self, ex_idx, set_idx):
+            return ""
+
+        def set_set_notes(self, ex_idx, set_idx, text):
+            pass
+
     dummy_session = DummySession()
     dummy_app = types.SimpleNamespace(workout_session=dummy_session)
     metric_module.MDApp.get_running_app = classmethod(lambda cls: dummy_app)
@@ -353,6 +359,12 @@ def test_save_future_metrics_returns_to_rest():
             st = self.current_set if set_index is None else set_index
             self.pending_pre_set_metrics[(ex, st)] = metrics.copy()
 
+        def get_set_notes(self, ex_idx, set_idx):
+            return ""
+
+        def set_set_notes(self, ex_idx, set_idx, text):
+            pass
+
     dummy_session = DummySession()
     dummy_app = types.SimpleNamespace(workout_session=dummy_session)
     metric_module.MDApp.get_running_app = classmethod(lambda cls: dummy_app)
@@ -415,6 +427,12 @@ def test_edit_previous_set_does_not_leak_future_pending():
             ex = self.current_exercise if exercise_index is None else exercise_index
             st = self.current_set if set_index is None else set_index
             self.pending_pre_set_metrics[(ex, st)] = metrics.copy()
+
+        def get_set_notes(self, ex_idx, set_idx):
+            return ""
+
+        def set_set_notes(self, ex_idx, set_idx, text):
+            pass
 
     dummy_session = DummySession()
     dummy_app = types.SimpleNamespace(workout_session=dummy_session)


### PR DESCRIPTION
## Summary
- Track per-set notes separately from other metrics in `WorkoutSession` via new `get_set_notes`/`set_set_notes` helpers
- Append a lightweight multiline Notes input at the end of each set's metric list
- Update tests to use the new notes API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c80c8e78c83328a9be723c69d5c96