### PR TITLE
Add session stopwatch to RestScreen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -404,11 +404,15 @@ ScreenManager:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
-        MDLabel:
-            text: "Rest – The main screen shown between exercises. Displays a countdown timer while the user rests before the next exercise begins."
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
+        AnchorLayout:
+            size_hint_y: None
+            height: self.minimum_height
+            MDLabel:
+                text: root.session_time_label
+                size_hint_x: .33
+                halign: "center"
+                theme_text_color: "Custom"
+                text_color: 0.2, 0.6, 0.86, 1
         BoxLayout:
             orientation: "horizontal"
             size_hint_y: None

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 import pytest
+import time
 
 os.environ["KIVY_WINDOW"] = "mock"
 # Skip tests entirely if Kivy (and KivyMD) are not installed
@@ -359,6 +360,16 @@ def test_rest_screen_toggle_ready_changes_state():
     screen.toggle_ready()
     assert screen.is_ready is True
     assert screen.timer_color == (0, 1, 0, 1)
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_rest_screen_session_time_updates(monkeypatch):
+    screen = RestScreen()
+    screen.target_time = 200.0
+    screen.session_start_time = 100.0
+    monkeypatch.setattr(time, "time", lambda: 160.0)
+    screen.update_timer(0)
+    assert screen.session_time_label == "01:00"
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")

--- a/ui/screens/rest_screen.py
+++ b/ui/screens/rest_screen.py
@@ -62,7 +62,9 @@ class RestScreen(MDScreen):
     """Screen shown between exercises with a rest timer."""
 
     timer_label = StringProperty("00:20")
+    session_time_label = StringProperty("00:00")
     target_time = NumericProperty(0)
+    session_start_time = NumericProperty(0)
     next_exercise_name = StringProperty("")
     next_exercise_desc = StringProperty("")
     next_set_info = StringProperty("")
@@ -90,13 +92,16 @@ class RestScreen(MDScreen):
                 and session.current_set == 0
                 and not session.exercises[0]["results"]
             )
+            self.session_start_time = session.start_time
         else:
-            self.target_time = time.time() + DEFAULT_REST_DURATION
+            now = time.time()
+            self.target_time = now + DEFAULT_REST_DURATION
             self.next_exercise_name = ""
             self.next_set_info = ""
             self.rest_time_info = ""
             self.next_exercise_desc = ""
             self.undo_disabled = True
+            self.session_start_time = now
         self.is_ready = False
         self.timer_color = (1, 0, 0, 1)
         self.update_timer(0)
@@ -215,6 +220,10 @@ class RestScreen(MDScreen):
             total_seconds = math.ceil(remaining)
             minutes, seconds = divmod(total_seconds, 60)
             self.timer_label = f"{minutes:02d}:{seconds:02d}"
+
+        elapsed = int(time.time() - (self.session_start_time or time.time()))
+        minutes, seconds = divmod(elapsed, 60)
+        self.session_time_label = f"{minutes:02d}:{seconds:02d}"
 
     def _adjust_step(self) -> int:
         """Return adjustment step based on remaining rest time."""


### PR DESCRIPTION
## Summary
- Show a session stopwatch on RestScreen using session start time
- Replace intro label with timer occupying one third of the top width
- Test session stopwatch updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c81a06f3c8332ad4b6c7fcb19c12b