### PR TITLE
Fix RestScreen layout and handle missing notes

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -404,12 +404,16 @@ ScreenManager:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
-        AnchorLayout:
+        BoxLayout:
             size_hint_y: None
             height: self.minimum_height
             MDLabel:
                 text: root.session_time_label
-                size_hint_x: .33
+                size_hint_x: None
+                width: self.texture_size[0]
+                size_hint_y: None
+                height: self.texture_size[1]
+                pos_hint: {"center_x": .5}
                 halign: "center"
                 theme_text_color: "Custom"
                 text_color: 0.2, 0.6, 0.86, 1

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -271,7 +271,9 @@ class MetricInputScreen(MDScreen):
         if duration is not None:
             self.metrics_list.add_widget(self._create_time_row(duration))
 
-        notes_text = self.session.get_set_notes(self.exercise_idx, self.set_idx)
+        notes_text = ""
+        if hasattr(self.session, "get_set_notes"):
+            notes_text = self.session.get_set_notes(self.exercise_idx, self.set_idx)
         notes_row = self._create_notes_row(notes_text)
         self.metrics_list.add_widget(notes_row)
         self._notes_widget = notes_row.input_widget


### PR DESCRIPTION
## Summary
- replace AnchorLayout with adaptive BoxLayout to avoid missing `minimum_height`
- guard metric input screen against sessions lacking `get_set_notes`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ca6ddf6f08332b2c18b0a032fc7aa