### PR TITLE
Apply themed backgrounds to session and menu screens

### DIFF
--- a/devtool/color.py
+++ b/devtool/color.py
@@ -22,6 +22,7 @@ from kivy.utils import get_color_from_hex, get_hex_from_color
 import json
 import os
 import copy
+from ui.colors import PINK_BG
 
 
 def _rel_lum(c: float) -> float:
@@ -38,6 +39,7 @@ def _contrast_ratio(a, b) -> float:
 
 
 class EditColorsScreen(MDScreen):
+    md_bg_color = PINK_BG
     """Screen for editing colors."""
 
     active_target = StringProperty("text")
@@ -223,6 +225,7 @@ class EditColorsScreen(MDScreen):
 
 
 class PreviewScreen(MDScreen):
+    md_bg_color = PINK_BG
     """Base class for preview screens."""
 
     label_text = StringProperty("")
@@ -260,6 +263,7 @@ class PreviewScreen(MDScreen):
 
 
 class SnapshotScreen(MDScreen):
+    md_bg_color = PINK_BG
     """Full screen preview of all components."""
 
     def build(self):

--- a/main.kv
+++ b/main.kv
@@ -1,5 +1,7 @@
 #:import NoTransition kivy.uix.screenmanager.NoTransition
 #:import ButtonBehavior kivy.uix.behaviors.button.ButtonBehavior
+#:import PINK_BG ui.colors.PINK_BG
+#:import PURPLE_BG ui.colors.PURPLE_BG
 ScreenManager:
     WelcomeScreen:
         name: "welcome"
@@ -39,6 +41,7 @@ ScreenManager:
         name: "previous_workouts"
 
 <HomeScreen@MDScreen>:
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -66,6 +69,7 @@ ScreenManager:
 
 <PresetsScreen>:
     preset_list: preset_list
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -99,6 +103,7 @@ ScreenManager:
 
 <PresetDetailScreen>:
     summary_list: summary_list
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -205,6 +210,7 @@ ScreenManager:
     exercise_list: exercise_list
     metric_list: metric_list
     current_tab: "exercises"
+    md_bg_color: PINK_BG
     FloatLayout:
         MDBoxLayout:
             orientation: "vertical"
@@ -325,6 +331,7 @@ ScreenManager:
                                 on_release: root.new_metric()
 
 <ProgressScreen@MDScreen>:
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -339,6 +346,7 @@ ScreenManager:
             on_release: app.root.current = "home"
 
 <WorkoutHistoryScreen@MDScreen>:
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -353,6 +361,7 @@ ScreenManager:
             on_release: app.root.current = "home"
 
 <SettingsScreen@MDScreen>:
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -400,6 +409,7 @@ ScreenManager:
         text_color: root.text_color
 
 <RestScreen>:
+    md_bg_color: PURPLE_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -479,6 +489,7 @@ ScreenManager:
 
 <WorkoutActiveScreen>:
     on_leave: root.stop_timer()
+    md_bg_color: PURPLE_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -524,6 +535,7 @@ ScreenManager:
 <MetricInputScreen>:
     on_pre_enter: root.on_pre_enter()
     metrics_list: metrics_list
+    md_bg_color: PURPLE_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -608,6 +620,7 @@ ScreenManager:
             on_release: root.save_metrics()
 
 <WorkoutEditScreen@MDScreen>:
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -622,6 +635,7 @@ ScreenManager:
             on_release: app.root.current = "rest"
 
 <WorkoutSettingsScreen@MDScreen>:
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -637,6 +651,7 @@ ScreenManager:
 
 <WorkoutSummaryScreen>:
     summary_list: summary_list
+    md_bg_color: PURPLE_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -654,6 +669,7 @@ ScreenManager:
             on_release: app.root.current = "home"
 
 <WelcomeScreen@MDScreen>:
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -726,6 +742,7 @@ ScreenManager:
     metrics_box: metrics_box
     panel_visible: False
     on_current_tab: edit_tabs.current = self.current_tab
+    md_bg_color: PINK_BG
     FloatLayout:
         MDBoxLayout:
             id: main_content
@@ -984,6 +1001,7 @@ ScreenManager:
     details_list: details_tab.ids.details_list
     workout_list: workout_tab.ids.workout_list
     preset_label: preset_label
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
@@ -1014,6 +1032,7 @@ ScreenManager:
     name_field: name_field
     description_field: description_field
     current_tab: "metrics"
+    md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"

--- a/ui/colors.py
+++ b/ui/colors.py
@@ -1,0 +1,4 @@
+"""Common UI color constants used across screens."""
+
+PINK_BG = (1, 0.97, 0.97, 1)
+PURPLE_BG = (0.97, 0.95, 1, 1)

--- a/ui/screens/history_comparison_screen.py
+++ b/ui/screens/history_comparison_screen.py
@@ -1,12 +1,14 @@
-from kivy.uix.screenmanager import Screen
+from kivymd.uix.screen import MDScreen
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.gridlayout import GridLayout
 from kivy.uix.scrollview import ScrollView
 from kivy.uix.label import Label
+from ui.colors import PINK_BG
 
 
-class HistoryComparisonScreen(Screen):
+class HistoryComparisonScreen(MDScreen):
     """Screen displaying a 2D scrollable comparison of exercise sessions."""
+    md_bg_color = PINK_BG
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -271,7 +271,9 @@ class MetricInputScreen(MDScreen):
         if duration is not None:
             self.metrics_list.add_widget(self._create_time_row(duration))
 
-        notes_text = self.session.get_set_notes(self.exercise_idx, self.set_idx)
+        notes_text = ""
+        if hasattr(self.session, "get_set_notes"):
+            notes_text = self.session.get_set_notes(self.exercise_idx, self.set_idx)
         notes_row = self._create_notes_row(notes_text)
         self.metrics_list.add_widget(notes_row)
         self._notes_widget = notes_row.input_widget

--- a/ui/screens/previous_workouts_screen.py
+++ b/ui/screens/previous_workouts_screen.py
@@ -1,14 +1,16 @@
 from kivy.app import App
-from kivy.uix.screenmanager import Screen
+from kivymd.uix.screen import MDScreen
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.gridlayout import GridLayout
 from kivy.uix.scrollview import ScrollView
 from kivy.uix.label import Label
 from kivy.uix.button import Button
+from ui.colors import PINK_BG
 
 
-class PreviousWorkoutsScreen(Screen):
+class PreviousWorkoutsScreen(MDScreen):
     """Screen displaying a 2D scrollable comparison of exercise sessions."""
+    md_bg_color = PINK_BG
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
## Summary
- Add color constants for pink and purple background shades
- Apply pink background to non-session screens and purple to session-loop screens
- Guard MetricInputScreen notes handling when sessions lack `get_set_notes`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ca89bdde4833291199cc6b753a85c