### PR TITLE
Simplify presets screen UI with inline selection

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -74,32 +74,24 @@ ScreenManager:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
-        MDLabel:
-            text: "Presets – Select a workout from a list of predefined presets. Each preset represents a unique workout routine."
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
         ScrollView:
             MDList:
                 id: preset_list
-        MDLabel:
-            text: "Selected: " + root.selected_preset if root.selected_preset else "Select a preset"
-            halign: "center"
-        MDRaisedButton:
-            id: select_btn
-            text: root.selected_preset if root.selected_preset else "Select Preset"
-            disabled: not root.selected_preset
-            on_release: root.confirm_selection()
-        MDRaisedButton:
-            text: "Edit Preset"
-            disabled: not root.selected_preset
-            on_release: app.root.current = "edit_preset"
-        MDRaisedButton:
-            text: "New Preset"
-            on_release: app.start_new_preset(); app.root.current = "edit_preset"
-        MDRaisedButton:
-            text: "Back to Home"
-            on_release: app.root.current = "home"
+        BoxLayout:
+            orientation: "horizontal"
+            size_hint_y: None
+            height: "48dp"
+            spacing: "10dp"
+            MDIconButton:
+                icon: "arrow-left"
+                on_release: app.root.current = "home"
+            MDIconButton:
+                icon: "pencil"
+                disabled: not root.selected_preset
+                on_release: app.root.current = "edit_preset"
+            MDIconButton:
+                icon: "plus"
+                on_release: app.start_new_preset(); app.root.current = "edit_preset"
 
 <PresetDetailScreen>:
     summary_list: summary_list

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -807,8 +807,8 @@ def test_exercise_selection_panel_filters(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
-def test_preset_select_button_updates(monkeypatch):
-    """Selecting a preset updates the select button text."""
+def test_presets_screen_selects_preset(monkeypatch):
+    """Selecting a preset stores the chosen name."""
     from kivy.lang import Builder
     from pathlib import Path
 
@@ -821,10 +821,53 @@ def test_preset_select_button_updates(monkeypatch):
     )
 
     screen = PresetsScreen()
-    dummy = type("Obj", (), {"md_bg_color": (0, 0, 0, 0)})()
+    dummy = type(
+        "Obj",
+        (),
+        {
+            "md_bg_color": (0, 0, 0, 0),
+            "theme_text_color": "Primary",
+            "text_color": (0, 0, 0, 1),
+        },
+    )()
     screen.select_preset("Sample", dummy)
 
-    assert screen.ids.select_btn.text == "Sample"
+    assert screen.selected_preset == "Sample"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_presets_screen_second_tap_confirms(monkeypatch):
+    from kivy.lang import Builder
+    from pathlib import Path
+
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    monkeypatch.setattr(
+        presets, "WORKOUT_PRESETS", [{"name": "Sample", "exercises": []}]
+    )
+
+    screen = PresetsScreen()
+    dummy = type(
+        "Obj",
+        (),
+        {
+            "md_bg_color": (0, 0, 0, 0),
+            "theme_text_color": "Primary",
+            "text_color": (0, 0, 0, 1),
+        },
+    )()
+
+    called = {"v": False}
+
+    def fake_confirm():
+        called["v"] = True
+
+    screen.confirm_selection = fake_confirm
+
+    screen.select_preset("Sample", dummy)
+    assert not called["v"]
+    screen.select_preset("Sample", dummy)
+    assert called["v"]
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")

--- a/ui/screens/presets_screen.py
+++ b/ui/screens/presets_screen.py
@@ -1,6 +1,6 @@
 from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
-from kivy.properties import ObjectProperty, StringProperty, ListProperty
+from kivy.properties import ObjectProperty, StringProperty
 from kivymd.uix.list import OneLineListItem
 from backend import presets
 
@@ -14,12 +14,6 @@ class PresetsScreen(MDScreen):
 
     _selected_color = (0, 1, 0, 1)
     _selected_text_color = (0, 1, 0, 1)
-    _default_btn_color = ListProperty(None, allownone=True)
-
-    def on_kv_post(self, base_widget):
-        # Store the default color of the "Select" button so it can be restored
-        self._default_btn_color = self.ids.select_btn.md_bg_color
-        return super().on_kv_post(base_widget)
 
     def clear_selection(self, reset_app: bool = True):
         """Reset any selected preset and remove highlight.
@@ -39,8 +33,6 @@ class PresetsScreen(MDScreen):
             app = MDApp.get_running_app()
             if app:
                 app.selected_preset = ""
-        if self._default_btn_color is not None:
-            self.ids.select_btn.md_bg_color = self._default_btn_color
 
     def on_pre_enter(self, *args):
         self.clear_selection()
@@ -67,14 +59,9 @@ class PresetsScreen(MDScreen):
             self.preset_list.add_widget(item)
 
     def select_preset(self, name, item):
-        """Select a preset from WORKOUT_PRESETS and highlight item."""
+        """Highlight an item, confirm on second tap."""
         if self.selected_item is item:
-            # Toggle off selection if tapping the already selected item
-            item.md_bg_color = (0, 0, 0, 0)
-            item.theme_text_color = "Primary"
-            self.selected_item = None
-            self.selected_preset = ""
-            MDApp.get_running_app().selected_preset = ""
+            self.confirm_selection()
             return
 
         if self.selected_item:


### PR DESCRIPTION
## Summary
- Remove presets screen description and select button for a leaner layout
- Add icon-based back, edit, and new buttons beneath preset list
- Tap preset to highlight, tap again to open, with tests updated accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689caeeb6d8c833285a62188a526082c