### PR TITLE
Fix half-screen mode to resize window

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,6 @@ from kivymd.uix.card import MDSeparator
 from kivymd.uix.dialog import MDDialog
 from kivymd.uix.floatlayout import MDFloatLayout
 from kivymd.uix.tab import MDTabsBase
-from kivy.uix.scatter import Scatter
 
 try:
     from kivymd.uix.spinner import MDSpinner
@@ -89,10 +88,17 @@ from ui.popups import AddMetricPopup, EditMetricPopup, METRIC_FIELD_ORDER
 
 
 if os.name == "nt" or sys.platform.startswith("win"):
-    Window.size = (140, 140 * (20 / 9))
+    base_width, base_height = 140, 140 * (20 / 9)
+    if HALF_SCREEN:
+        Window.size = (base_width / 2, base_height / 2)
+    else:
+        Window.size = (base_width, base_height)
 elif platform == "android":
     full_width, full_height = Window.system_size
-    Window.size = (full_width, full_height)
+    if HALF_SCREEN:
+        Window.size = (full_width / 2, full_height / 2)
+    else:
+        Window.size = (full_width, full_height)
 
 if not TESTING:
     try:
@@ -421,18 +427,6 @@ class WorkoutApp(MDApp):
     def build(self):
         root = Builder.load_file(str(Path(__file__).with_name("main.kv")))
         Window.bind(on_keyboard=self._on_keyboard)
-
-        if HALF_SCREEN:
-            container = Scatter(
-                scale=0.5,
-                do_rotation=False,
-                do_translation=False,
-                size=Window.size,
-                size_hint=(None, None),
-                pos=(0, 0),
-            )
-            container.add_widget(root)
-            return container
 
         return root
 


### PR DESCRIPTION
## Summary
- Adjust window resizing logic to halve screen dimensions when HALF_SCREEN is enabled
- Simplify build process by removing scatter scaling wrapper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cafd5b8148332a6326f3b60048a0a