### PR TITLE
Fix stopwatch label layout during workouts

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -507,6 +507,7 @@ ScreenManager:
             text: root.formatted_time
             halign: "center"
             font_style: "H2"
+            multiline: False
         MDLabel:
             text: root.exercise_name
             halign: "center"


### PR DESCRIPTION
## Summary
- prevent active workout stopwatch text from wrapping vertically

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb1a603b4833285b29684f595e541