### PR TITLE
Ensure editable Time metric at top

### DIFF
--- a/backend/workout_session.py
+++ b/backend/workout_session.py
@@ -274,6 +274,7 @@ class WorkoutSession:
             and set_index == self.current_set
         ):
             self.last_set_time = self.current_set_start_time + duration
+            self.rest_target_time = self.last_set_time + self.rest_duration
             return
 
         self._ensure_session_entry(exercise_index)

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -111,6 +111,16 @@ def test_mark_set_completed_time_adjustment(sample_db, monkeypatch):
     assert session.rest_target_time == pytest.approx(190.0)
 
 
+def test_update_set_duration_updates_rest(sample_db, monkeypatch):
+    monkeypatch.setattr(core.time, "time", lambda: 100.0)
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=30)
+    start = session.current_set_start_time
+    session.mark_set_completed()
+    session.update_set_duration(session.current_exercise, session.current_set, 42.0)
+    assert session.last_set_time == pytest.approx(start + 42.0)
+    assert session.rest_target_time == pytest.approx(start + 42.0 + session.rest_duration)
+
+
 def test_undo_last_set_restores_metrics_and_timer(sample_db, monkeypatch):
     session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
     start = session.current_set_start_time

--- a/ui/screens/metric_input_screen.py
+++ b/ui/screens/metric_input_screen.py
@@ -251,7 +251,9 @@ class MetricInputScreen(MDScreen):
             return
         exercise = self.session.exercises[self.exercise_idx]
         metrics = [
-            m for m in exercise.get("metric_defs", []) if m.get("name") != "Notes"
+            m
+            for m in exercise.get("metric_defs", [])
+            if m.get("name") not in ("Notes", "Time")
         ]
         # Determine any previously recorded values for this set
         values = {}
@@ -262,14 +264,14 @@ class MetricInputScreen(MDScreen):
             values = self.session.pending_pre_set_metrics.get(
                 (self.exercise_idx, self.set_idx), {}
             )
+        duration = self.session.get_set_duration(self.exercise_idx, self.set_idx)
+        if duration is not None:
+            self.metrics_list.add_widget(self._create_time_row(duration))
         for metric in self._apply_filters(metrics):
             name = metric.get("name")
             self.metrics_list.add_widget(
                 self._create_row(metric, values.get(name))
             )
-        duration = self.session.get_set_duration(self.exercise_idx, self.set_idx)
-        if duration is not None:
-            self.metrics_list.add_widget(self._create_time_row(duration))
 
         notes_text = ""
         if hasattr(self.session, "get_set_notes"):
@@ -361,6 +363,7 @@ class MetricInputScreen(MDScreen):
         def _enable_edit(field, touch):
             if field.readonly and field.collide_point(*touch.pos):
                 field.readonly = False
+                field.focus = True
             return False
 
         if hasattr(widget, "bind"):


### PR DESCRIPTION
## Summary
- Always show the derived Time metric at the top of the metric list and allow editing
- Keep rest timer in sync when manually adjusting set duration
- Add regression test for updating rest timer after editing duration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb22e489c8332af6ea71c7f228757