### PR TITLE
Fix touch offset in half-screen Android mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,6 +87,7 @@ from ui.screens.workout_summary_screen import WorkoutSummaryScreen
 from ui.popups import AddMetricPopup, EditMetricPopup, METRIC_FIELD_ORDER
 
 
+HALF_SCREEN_Y_OFFSET = 0
 if os.name == "nt" or sys.platform.startswith("win"):
     base_width, base_height = 140, 140 * (20 / 9)
     if HALF_SCREEN:
@@ -97,8 +98,17 @@ elif platform == "android":
     full_width, full_height = Window.system_size
     if HALF_SCREEN:
         Window.size = (full_width / 2, full_height / 2)
+        HALF_SCREEN_Y_OFFSET = full_height - Window.height
     else:
         Window.size = (full_width, full_height)
+
+
+def _adjust_touch(window, touch):
+    if HALF_SCREEN and platform == "android" and HALF_SCREEN_Y_OFFSET:
+        touch.y += HALF_SCREEN_Y_OFFSET
+        touch.oy += HALF_SCREEN_Y_OFFSET
+        touch.sy = touch.y / Window.height
+    return False
 
 if not TESTING:
     try:
@@ -427,6 +437,11 @@ class WorkoutApp(MDApp):
     def build(self):
         root = Builder.load_file(str(Path(__file__).with_name("main.kv")))
         Window.bind(on_keyboard=self._on_keyboard)
+        Window.bind(
+            on_touch_down=_adjust_touch,
+            on_touch_move=_adjust_touch,
+            on_touch_up=_adjust_touch,
+        )
 
         return root
 


### PR DESCRIPTION
## Summary
- adjust Android half-screen mode so touch events align with scaled window

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb40f228c8332b366f4ba5d4652fe