### PR TITLE
Fix rest screen session timer alignment

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -415,12 +415,10 @@ ScreenManager:
             height: self.minimum_height
             MDLabel:
                 text: root.session_time_label
-                size_hint_x: None
-                width: self.texture_size[0]
                 size_hint_y: None
                 height: self.texture_size[1]
-                pos_hint: {"center_x": .5}
-                halign: "center"
+                halign: "left"
+                multiline: False
                 theme_text_color: "Custom"
                 text_color: 0.2, 0.6, 0.86, 1
         BoxLayout:


### PR DESCRIPTION
## Summary
- Ensure rest screen session timer displays text horizontally and aligns left

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb5a5ed208332b478f3a6784379ad