### PR TITLE
Reset rest timer when app loses focus

### DIFF
--- a/main.py
+++ b/main.py
@@ -435,6 +435,20 @@ class WorkoutApp(MDApp):
             return True
         return False
 
+    def on_pause(self):
+        """Ensure rest timer isn't marked ready when app is backgrounded."""
+        if self.root and self.root.current == "rest":
+            try:
+                rest_screen = self.root.get_screen("rest")
+            except Exception:
+                rest_screen = None
+            if rest_screen and getattr(rest_screen, "is_ready", False):
+                if hasattr(rest_screen, "unready"):
+                    rest_screen.unready()
+                else:
+                    rest_screen.is_ready = False
+        return True
+
     def init_preset_editor(self, force_reload: bool = False):
         """Create or reload the ``PresetEditor`` for the selected preset."""
 

--- a/ui/screens/rest_screen.py
+++ b/ui/screens/rest_screen.py
@@ -133,6 +133,12 @@ class RestScreen(MDScreen):
             if self.manager:
                 self.manager.current = "workout_active"
 
+    def unready(self):
+        """Reset the ready state without toggling."""
+        if self.is_ready:
+            self.is_ready = False
+            self.timer_color = (1, 0, 0, 1)
+
     def update_record_button_color(self):
         app = MDApp.get_running_app()
         session = app.workout_session if app else None


### PR DESCRIPTION
## Summary
- add `unready` helper on `RestScreen` to clear ready state
- reset rest timer readiness when app is paused/backgrounded

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb5f8912083328e0e3cef021cc7b1