### PR TITLE
Enable testing and half screen by default

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-TESTING = False
+TESTING = True
 HALF_SCREEN = True
 
 from kivymd.app import MDApp


### PR DESCRIPTION
## Summary
- Set TESTING flag to True by default
- Ensure HALF_SCREEN mode remains enabled by default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cb6958ab083329ff0706dc75832c3