### PR TITLE
Fix touch scaling in Android half-screen mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -86,7 +86,8 @@ from ui.screens.edit_preset_screen import (
 from ui.screens.workout_summary_screen import WorkoutSummaryScreen
 from ui.popups import AddMetricPopup, EditMetricPopup, METRIC_FIELD_ORDER
 
-
+HALF_SCREEN_X_SCALE = 1.0
+HALF_SCREEN_Y_SCALE = 1.0
 if os.name == "nt" or sys.platform.startswith("win"):
     base_width, base_height = 140, 140 * (20 / 9)
     if HALF_SCREEN:
@@ -97,8 +98,21 @@ elif platform == "android":
     full_width, full_height = Window.system_size
     if HALF_SCREEN:
         Window.size = (full_width / 2, full_height / 2)
+        HALF_SCREEN_X_SCALE = Window.width / full_width
+        HALF_SCREEN_Y_SCALE = Window.height / full_height
     else:
         Window.size = (full_width, full_height)
+
+
+def _adjust_touch(window, touch):
+    if HALF_SCREEN and platform == "android":
+        touch.x *= HALF_SCREEN_X_SCALE
+        touch.ox *= HALF_SCREEN_X_SCALE
+        touch.sx = touch.x / Window.width
+        touch.y *= HALF_SCREEN_Y_SCALE
+        touch.oy *= HALF_SCREEN_Y_SCALE
+        touch.sy = touch.y / Window.height
+    return False
 
 if not TESTING:
     try:
@@ -427,6 +441,11 @@ class WorkoutApp(MDApp):
     def build(self):
         root = Builder.load_file(str(Path(__file__).with_name("main.kv")))
         Window.bind(on_keyboard=self._on_keyboard)
+        Window.bind(
+            on_touch_down=_adjust_touch,
+            on_touch_move=_adjust_touch,
+            on_touch_up=_adjust_touch,
+        )
 
         return root
 


### PR DESCRIPTION
## Summary
- scale Android half-screen touch coordinates so hitboxes match the reduced window

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb40f228c8332b366f4ba5d4652fe