### PR TITLE
Add half-screen wrapper option

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -2,7 +2,7 @@
 #:import ButtonBehavior kivy.uix.behaviors.button.ButtonBehavior
 #:import PINK_BG ui.colors.PINK_BG
 #:import PURPLE_BG ui.colors.PURPLE_BG
-ScreenManager:
+RootUI:
     WelcomeScreen:
         name: "welcome"
     HomeScreen:


### PR DESCRIPTION
## Summary
- add `half_screen` feature flag
- wrap main UI in 2×2 `GridLayout` when flag enabled
- introduce `RootUI` class for ScreenManager root
- ensure navigation still works by keeping `RootUI` as app root when wrapped

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689de64e2db48332b72874dbe17a52e6