### PR TITLE
Add workout history screen listing past sessions

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -341,17 +341,16 @@ RootUI:
             text: "Back to Home"
             on_release: app.root.current = "home"
 
-<WorkoutHistoryScreen@MDScreen>:
+<WorkoutHistoryScreen>:
     md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
-        MDLabel:
-            text: "Workout History - review past workouts"
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
+        ScrollView:
+            do_scroll_x: False
+            MDList:
+                id: history_list
         MDRaisedButton:
             text: "Back to Home"
             on_release: app.root.current = "home"

--- a/main.py
+++ b/main.py
@@ -62,6 +62,7 @@ from ui.screens.edit_exercise_screen import EditExerciseScreen
 
 from ui.screens.rest_screen import RestScreen
 from ui.screens.previous_workouts_screen import PreviousWorkoutsScreen
+from ui.screens.workout_history_screen import WorkoutHistoryScreen
 
 
 

--- a/ui/screens/__init__.py
+++ b/ui/screens/__init__.py
@@ -11,6 +11,7 @@ from .rest_screen import RestScreen
 from .workout_active_screen import WorkoutActiveScreen
 from .workout_summary_screen import WorkoutSummaryScreen
 from .previous_workouts_screen import PreviousWorkoutsScreen
+from .workout_history_screen import WorkoutHistoryScreen
 
 
 __all__ = [
@@ -25,5 +26,6 @@ __all__ = [
     "WorkoutActiveScreen",
     "WorkoutSummaryScreen",
     "PreviousWorkoutsScreen",
+    "WorkoutHistoryScreen",
 
 ]

--- a/ui/screens/workout_history_screen.py
+++ b/ui/screens/workout_history_screen.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from kivymd.uix.screen import MDScreen
+from kivymd.uix.list import TwoLineListItem
+
+from backend.sessions import get_session_history
+
+
+class WorkoutHistoryScreen(MDScreen):
+    """Screen displaying a list of past workouts."""
+
+    def on_pre_enter(self, *args):
+        self.populate()
+        return super().on_pre_enter(*args)
+
+    def populate(self) -> None:
+        history = get_session_history()
+        lst = self.ids.get("history_list")
+        if not lst:
+            return
+        lst.clear_widgets()
+        for entry in history:
+            dt = datetime.fromtimestamp(entry["started_at"])
+            item = TwoLineListItem(
+                text=entry["preset_name"],
+                secondary_text=dt.strftime("%H:%M %d/%m/%y"),
+            )
+            lst.add_widget(item)


### PR DESCRIPTION
## Summary
- add backend helper to fetch past workout sessions
- implement `WorkoutHistoryScreen` to display preset name with start time
- wire history screen into main app and layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de997dd6c83329c10b8ce84d6d53e