### PR TITLE
Add Skip Exercise feature with undo support

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -453,7 +453,7 @@ RootUI:
             size_hint_y: None
             height: "20dp"
         MDGridLayout:
-            cols: 6
+            cols: 7
             spacing: "10dp"
             size_hint_y: None
             height: self.minimum_height
@@ -462,6 +462,10 @@ RootUI:
                 text: "Undo"
                 disabled: root.undo_disabled
                 on_release: root.show_undo_confirmation()
+            IconTextButton:
+                icon: "skip-next"
+                text: "skip"
+                on_release: root.show_skip_confirmation()
             IconTextButton:
                 id: record_btn
                 icon: "clipboard"
@@ -511,6 +515,9 @@ RootUI:
             MDRaisedButton:
                 text: "Undo"
                 on_release: root.show_undo_confirmation()
+            MDRaisedButton:
+                text: "Skip"
+                on_release: root.show_skip_confirmation()
             MDRaisedButton:
                 text: "Finish"
                 on_release:

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -209,3 +209,25 @@ def test_apply_edited_preset_preserves_metrics(sample_db):
     assert session.exercises[0]["name"] == "Bench Press"
     metric_names = [m["name"] for m in session.exercises[0]["metric_defs"]]
     assert "Reps" in metric_names
+
+
+def test_skip_exercise_and_undo(sample_db):
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    # complete first set of first exercise
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
+    session.mark_set_completed()
+    assert session.current_exercise == 0 and session.current_set == 1
+
+    # skip remaining sets of current exercise
+    assert session.skip_exercise()
+    assert session.current_exercise == 1 and session.current_set == 0
+
+    # undo the skip
+    assert session.undo_last_set()
+    assert session.current_exercise == 0 and session.current_set == 1
+
+
+def test_skip_last_exercise_noop(sample_db):
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    assert session.skip_exercise()
+    assert not session.skip_exercise()

--- a/ui/screens/workout_active_screen.py
+++ b/ui/screens/workout_active_screen.py
@@ -4,6 +4,7 @@ from kivy.clock import Clock
 from kivymd.app import MDApp
 from kivymd.uix.dialog import MDDialog
 from kivymd.uix.button import MDFlatButton
+from kivymd.toast import toast
 import time
 
 
@@ -65,7 +66,37 @@ class WorkoutActiveScreen(MDScreen):
         app = MDApp.get_running_app()
         session = app.workout_session if app else None
         if session:
-            session.undo_set_start()
+            if session.last_action_was_skip():
+                session.undo_last_set()
+            else:
+                session.undo_set_start()
         self.stop_timer()
         if self.manager:
             self.manager.current = "rest"
+
+    def show_skip_confirmation(self):
+        app = MDApp.get_running_app()
+        session = app.workout_session if app else None
+        if session and session.current_exercise >= len(session.preset_snapshot) - 1:
+            toast("No next exercise")
+            return
+        if not hasattr(self, "_skip_dialog") or not self._skip_dialog:
+            self._skip_dialog = MDDialog(
+                text="Skip this exercise and move to the next?",
+                buttons=[
+                    MDFlatButton(text="Cancel", on_release=lambda *_: self._skip_dialog.dismiss()),
+                    MDFlatButton(text="Confirm", on_release=self._perform_skip),
+                ],
+            )
+        self._skip_dialog.open()
+
+    def _perform_skip(self, *args):
+        if hasattr(self, "_skip_dialog") and self._skip_dialog:
+            self._skip_dialog.dismiss()
+        app = MDApp.get_running_app()
+        session = app.workout_session if app else None
+        if session and session.skip_exercise():
+            self.exercise_name = session.next_exercise_display()
+            self.start_timer()
+        else:
+            toast("No next exercise")


### PR DESCRIPTION
## Summary
- Add skip_exercise logic to WorkoutSession with undo support
- Introduce Skip buttons on rest and active screens with confirmation dialogs
- Enable undo after skip and prevent skipping final exercise
- Add tests covering skip workflow and last exercise edge case

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689df7f3501483329283700151dfdbc5