### PR TITLE
Adjust skip logic to rest screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -516,9 +516,6 @@ RootUI:
                 text: "Undo"
                 on_release: root.show_undo_confirmation()
             MDRaisedButton:
-                text: "Skip"
-                on_release: root.show_skip_confirmation()
-            MDRaisedButton:
                 text: "Finish"
                 on_release:
                     app.record_new_set = True

--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -213,18 +213,18 @@ def test_apply_edited_preset_preserves_metrics(sample_db):
 
 def test_skip_exercise_and_undo(sample_db):
     session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
-    # complete first set of first exercise
+    original_sets = session.preset_snapshot[0]["sets"]
     session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
     session.mark_set_completed()
     assert session.current_exercise == 0 and session.current_set == 1
-
-    # skip remaining sets of current exercise
     assert session.skip_exercise()
     assert session.current_exercise == 1 and session.current_set == 0
-
-    # undo the skip
+    assert session.preset_snapshot[0]["sets"] == 1
+    assert session.session_data[0]["skipped_sets"] == original_sets - 1
     assert session.undo_last_set()
     assert session.current_exercise == 0 and session.current_set == 1
+    assert session.preset_snapshot[0]["sets"] == original_sets
+    assert "skipped_sets" not in session.session_data[0]
 
 
 def test_skip_last_exercise_noop(sample_db):

--- a/ui/screens/rest_screen.py
+++ b/ui/screens/rest_screen.py
@@ -213,8 +213,24 @@ class RestScreen(MDScreen):
         app = MDApp.get_running_app()
         session = app.workout_session if app else None
         if session and session.skip_exercise():
-            if self.manager:
-                self.manager.current = "workout_active"
+            self.next_exercise_name = session.next_exercise_name()
+            self.next_set_info = (
+                f"set {session.current_set + 1} of {session.exercises[session.current_exercise]['sets']}"
+                if session.current_exercise < len(session.exercises)
+                else ""
+            )
+            self.rest_time_info = f"{session.rest_duration} seconds rest time"
+            details = get_exercise_details(
+                self.next_exercise_name, db_path=session.db_path
+            )
+            self.next_exercise_desc = details.get("description", "") if details else ""
+            self.target_time = session.rest_target_time
+            self.undo_disabled = (
+                session.current_exercise == 0
+                and session.current_set == 0
+                and not session.exercises[0]["results"]
+            )
+            self.update_timer(0)
         else:
             toast("No next exercise")
                 

--- a/ui/screens/workout_active_screen.py
+++ b/ui/screens/workout_active_screen.py
@@ -4,7 +4,6 @@ from kivy.clock import Clock
 from kivymd.app import MDApp
 from kivymd.uix.dialog import MDDialog
 from kivymd.uix.button import MDFlatButton
-from kivymd.toast import toast
 import time
 
 
@@ -73,30 +72,3 @@ class WorkoutActiveScreen(MDScreen):
         self.stop_timer()
         if self.manager:
             self.manager.current = "rest"
-
-    def show_skip_confirmation(self):
-        app = MDApp.get_running_app()
-        session = app.workout_session if app else None
-        if session and session.current_exercise >= len(session.preset_snapshot) - 1:
-            toast("No next exercise")
-            return
-        if not hasattr(self, "_skip_dialog") or not self._skip_dialog:
-            self._skip_dialog = MDDialog(
-                text="Skip this exercise and move to the next?",
-                buttons=[
-                    MDFlatButton(text="Cancel", on_release=lambda *_: self._skip_dialog.dismiss()),
-                    MDFlatButton(text="Confirm", on_release=self._perform_skip),
-                ],
-            )
-        self._skip_dialog.open()
-
-    def _perform_skip(self, *args):
-        if hasattr(self, "_skip_dialog") and self._skip_dialog:
-            self._skip_dialog.dismiss()
-        app = MDApp.get_running_app()
-        session = app.workout_session if app else None
-        if session and session.skip_exercise():
-            self.exercise_name = session.next_exercise_display()
-            self.start_timer()
-        else:
-            toast("No next exercise")


### PR DESCRIPTION
## Summary
- remove skip controls from active workout screen
- keep skip on rest screen with confirmation without changing screens
- track skipped sets so they aren't saved with the session

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f13bb136483328ba0531e618b7419