### PR TITLE
Add screen for viewing past workout details

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -17,6 +17,8 @@ RootUI:
         name: "progress"
     WorkoutHistoryScreen:
         name: "workout_history"
+    ViewPreviousWorkoutScreen:
+        name: "view_previous_workout"
     SettingsScreen:
         name: "settings"
     RestScreen:
@@ -354,6 +356,20 @@ RootUI:
         MDRaisedButton:
             text: "Back to Home"
             on_release: app.root.current = "home"
+
+<ViewPreviousWorkoutScreen>:
+    md_bg_color: PINK_BG
+    BoxLayout:
+        orientation: "vertical"
+        spacing: "10dp"
+        padding: "20dp"
+        ScrollView:
+            do_scroll_x: False
+            MDList:
+                id: details_list
+        MDRaisedButton:
+            text: "Back"
+            on_release: app.root.current = "workout_history"
 
 <SettingsScreen@MDScreen>:
     md_bg_color: PINK_BG

--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ from ui.screens.edit_exercise_screen import EditExerciseScreen
 from ui.screens.rest_screen import RestScreen
 from ui.screens.previous_workouts_screen import PreviousWorkoutsScreen
 from ui.screens.workout_history_screen import WorkoutHistoryScreen
+from ui.screens.view_previous_workout_screen import ViewPreviousWorkoutScreen
 
 
 

--- a/tests/test_session_details.py
+++ b/tests/test_session_details.py
@@ -1,0 +1,57 @@
+import sqlite3
+
+from backend.sessions import save_completed_session, get_session_details
+from backend.workout_session import WorkoutSession
+
+
+def _prepare_session(db_path: str) -> WorkoutSession:
+    conn = sqlite3.connect(db_path)
+    preset_id = conn.execute(
+        "SELECT id FROM preset_presets WHERE name='Push Day'"
+    ).fetchone()[0]
+    metric_type_id = conn.execute(
+        "SELECT id FROM library_metric_types WHERE name='Reps'"
+    ).fetchone()[0]
+    conn.execute(
+        """
+        INSERT INTO preset_preset_metrics
+            (preset_id, library_metric_type_id, metric_name, metric_description,
+             type, input_timing, scope, is_required, position)
+        VALUES (?, ?, 'Session Reps', 'Total session reps', 'int', 'pre_workout', 'session', 1, 0)
+        """,
+        (preset_id, metric_type_id),
+    )
+    conn.commit()
+    conn.close()
+
+    session = WorkoutSession("Push Day", db_path=db_path, rest_duration=1)
+    session.set_session_metrics({"Session Reps": 28})
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 10})
+    session.mark_set_completed()
+    session.record_metrics(session.current_exercise, session.current_set, {"Reps": 8})
+    session.mark_set_completed()
+    session.record_metrics(
+        session.current_exercise,
+        session.current_set,
+        {"Reps": 5, "Weight": 100, "Machine": "A"},
+    )
+    session.mark_set_completed()
+    session.record_metrics(
+        session.current_exercise,
+        session.current_set,
+        {"Reps": 5, "Weight": 100, "Machine": "A"},
+    )
+    return session
+
+
+def test_get_session_details(sample_db):
+    session = _prepare_session(sample_db)
+    save_completed_session(session, db_path=sample_db)
+    details = get_session_details(session.start_time, db_path=sample_db)
+    assert details["preset_name"] == "Push Day"
+    assert any(m["name"] == "Session Reps" for m in details["metrics"])
+    assert details["exercises"]
+    first_ex = details["exercises"][0]
+    assert first_ex["sets"]
+    first_set = first_ex["sets"][0]
+    assert any(m["name"] == "Reps" for m in first_set["metrics"])

--- a/ui/screens/__init__.py
+++ b/ui/screens/__init__.py
@@ -12,6 +12,7 @@ from .workout_active_screen import WorkoutActiveScreen
 from .workout_summary_screen import WorkoutSummaryScreen
 from .previous_workouts_screen import PreviousWorkoutsScreen
 from .workout_history_screen import WorkoutHistoryScreen
+from .view_previous_workout_screen import ViewPreviousWorkoutScreen
 
 
 __all__ = [
@@ -27,5 +28,6 @@ __all__ = [
     "WorkoutSummaryScreen",
     "PreviousWorkoutsScreen",
     "WorkoutHistoryScreen",
+    "ViewPreviousWorkoutScreen",
 
 ]

--- a/ui/screens/view_previous_workout_screen.py
+++ b/ui/screens/view_previous_workout_screen.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from kivymd.uix.screen import MDScreen
+from kivymd.uix.list import MDList, OneLineListItem, TwoLineListItem
+from kivy.app import App
+
+from backend.sessions import get_session_details
+
+
+class ViewPreviousWorkoutScreen(MDScreen):
+    """Display details for a past workout session."""
+
+    session_start: float | None = None
+
+    def on_pre_enter(self, *args):
+        if self.session_start is not None:
+            self.populate()
+        return super().on_pre_enter(*args)
+
+    def show_session(self, started_at: float) -> None:
+        """Load data for ``started_at`` and switch to this screen."""
+        self.session_start = started_at
+        app = App.get_running_app()
+        app.root.current = "view_previous_workout"
+
+    def populate(self) -> None:
+        details = get_session_details(self.session_start)
+        lst: MDList = self.ids.get("details_list")  # type: ignore[arg-type]
+        if not lst:
+            return
+        lst.clear_widgets()
+        if not details:
+            lst.add_widget(OneLineListItem(text="No details found"))
+            return
+        lst.add_widget(OneLineListItem(text=f"Preset: {details['preset_name']}"))
+        if details.get("metrics"):
+            lst.add_widget(OneLineListItem(text="Session metrics:"))
+            for m in details["metrics"]:
+                lst.add_widget(OneLineListItem(text=f"{m['name']}: {m['value']}"))
+        for ex in details.get("exercises", []):
+            lst.add_widget(OneLineListItem(text=f"Exercise: {ex['name']}"))
+            for s in ex.get("sets", []):
+                metrics = ", ".join(f"{md['name']}: {md['value']}" for md in s["metrics"])
+                extra = []
+                if s.get("rest") is not None:
+                    extra.append(f"rest {int(s['rest'])}s")
+                if s.get("duration") is not None:
+                    extra.append(f"time {int(s['duration'])}s")
+                desc = ", ".join(extra)
+                item = TwoLineListItem(
+                    text=f"Set {s['number']}" + (f" ({desc})" if desc else ""),
+                    secondary_text=metrics or "",
+                )
+                lst.add_widget(item)

--- a/ui/screens/workout_history_screen.py
+++ b/ui/screens/workout_history_screen.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.list import TwoLineListItem
+from kivy.app import App
 
 from backend.sessions import get_session_history
 
@@ -24,5 +25,11 @@ class WorkoutHistoryScreen(MDScreen):
             item = TwoLineListItem(
                 text=entry["preset_name"],
                 secondary_text=dt.strftime("%H:%M %a %d/%m/%Y"),
+                on_release=lambda _, ts=entry["started_at"]: self.open_session(ts),
             )
             lst.add_widget(item)
+
+    def open_session(self, started_at: float) -> None:
+        app = App.get_running_app()
+        screen = app.root.get_screen("view_previous_workout")
+        screen.show_session(started_at)


### PR DESCRIPTION
## Summary
- enable viewing detailed information for a session from workout history
- implement backend helper to load session metrics, exercises, and set timing
- add tests covering session detail retrieval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f160352608332bb80f111d2e1688b