### PR TITLE
Allow editing previous section until next starts

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1501,6 +1501,22 @@ def test_session_edit_locking(monkeypatch, sample_db):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_previous_section_unlocked_until_next_started(monkeypatch, sample_db):
+    session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
+    app = _DummyApp()
+    app.workout_session = session
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+    screen = EditPresetScreen(mode="session")
+    next_start = session.section_starts[1]
+    session.current_exercise = next_start
+    session.current_set = 0
+    assert not screen._is_section_locked(0)
+    assert screen._is_exercise_locked(0, 0)
+    session.current_set = 1
+    assert screen._is_section_locked(0)
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_reordering_current_exercise_updates_index(monkeypatch, sample_db):
     editor = PresetEditor("Push Day", db_path=sample_db)
     session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)

--- a/ui/screens/general/edit_preset_screen.py
+++ b/ui/screens/general/edit_preset_screen.py
@@ -266,13 +266,17 @@ class EditPresetScreen(MDScreen):
         if section_index >= len(session.section_starts):
             return False
         start = session.section_starts[section_index]
+        has_next = section_index + 1 < len(session.section_starts)
         end = (
             session.section_starts[section_index + 1]
-            if section_index + 1 < len(session.section_starts)
+            if has_next
             else len(session.exercises)
         )
-        if session.current_exercise >= end:
+        if session.current_exercise > end:
             return True
+        if session.current_exercise == end:
+            if not has_next or session.current_set > 0:
+                return True
         if start <= session.current_exercise < end and session.current_set > 0:
             return True
         return False


### PR DESCRIPTION
## Summary
- tweak section locking so previous sections remain editable until the next section's first set begins
- add regression test to ensure earlier sections stay unlocked until the next section starts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a31c36b0a8833280b2a0724251791c