### PR TITLE
Fix crash when adding exercises to presets

### DIFF
--- a/ui/screens/general/edit_exercise_screen.py
+++ b/ui/screens/general/edit_exercise_screen.py
@@ -167,10 +167,10 @@ class EditExerciseScreen(MDScreen):
             if app.preset_editor and self.section_index < len(
                 app.preset_editor.sections
             ):
-                exercises = app.preset_editor.sections[self.section_index]["exercises"]
-                self.section_length = len(exercises)
-                if self.exercise_index < len(exercises):
-                    ex = exercises[self.exercise_index]
+                section_exercises = app.preset_editor.sections[self.section_index]["exercises"]
+                self.section_length = len(section_exercises)
+                if self.exercise_index < len(section_exercises):
+                    ex = section_exercises[self.exercise_index]
                     self.exercise_sets = ex.get("sets", DEFAULT_SETS_PER_EXERCISE)
                     self.exercise_rest = ex.get("rest", DEFAULT_REST_DURATION)
             else:

--- a/ui/screens/general/edit_preset_screen.py
+++ b/ui/screens/general/edit_preset_screen.py
@@ -757,16 +757,16 @@ class ExerciseSelectionPanel(MDBoxLayout):
             if app:
                 self.cache_version = app.exercise_library_version
 
-        exercises = self.all_exercises or []
+        exercise_rows = self.all_exercises or []
         if self.filter_mode == "user":
-            exercises = [ex for ex in exercises if ex[1]]
+            exercise_rows = [ex for ex in exercise_rows if ex[1]]
         elif self.filter_mode == "premade":
-            exercises = [ex for ex in exercises if not ex[1]]
+            exercise_rows = [ex for ex in exercise_rows if not ex[1]]
         if self.search_text:
             s = self.search_text.lower()
-            exercises = [ex for ex in exercises if s in ex[0].lower()]
+            exercise_rows = [ex for ex in exercise_rows if s in ex[0].lower()]
 
-        for name, is_user in exercises:
+        for name, is_user in exercise_rows:
             item = OneLineListItem(
                 text=name,
                 theme_text_color="Custom",

--- a/ui/screens/general/exercise_library.py
+++ b/ui/screens/general/exercise_library.py
@@ -109,18 +109,18 @@ class ExerciseLibraryScreen(MDScreen):
             )
             if app:
                 self.cache_version = app.exercise_library_version
-        exercises = self.all_exercises or []
+        exercise_rows = self.all_exercises or []
 
         mode = self.filter_mode
         if mode == "user":
-            exercises = [ex for ex in exercises if ex[1]]
+            exercise_rows = [ex for ex in exercise_rows if ex[1]]
         elif mode == "premade":
-            exercises = [ex for ex in exercises if not ex[1]]
+            exercise_rows = [ex for ex in exercise_rows if not ex[1]]
         if self.search_text:
             s = self.search_text.lower()
-            exercises = [ex for ex in exercises if s in ex[0].lower()]
+            exercise_rows = [ex for ex in exercise_rows if s in ex[0].lower()]
         data = []
-        for name, is_user in exercises:
+        for name, is_user in exercise_rows:
             data.append(
                 {
                     "name": name,


### PR DESCRIPTION
## Summary
- avoid local variable shadowing of `exercises` module in exercise selection panels
- prevent preset exercise editor from crashing when adding exercises
- clean up variable names in exercise editor for clarity

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a42549f868833295509dcd714e5095