### PR TITLE
Add workout session recovery using dual JSON backups

### DIFF
--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -313,4 +313,5 @@ def save_completed_session(session: "WorkoutSession", db_path: Path | None = Non
                         (set_id, metric_id, str(value)),
                     )
     session.saved = True
+    session.clear_recovery_files()
 

--- a/main.kv
+++ b/main.kv
@@ -686,7 +686,7 @@ RootUI:
             text: "Back to Home"
             on_release: app.root.current = "home"
 
-<WelcomeScreen@MDScreen>:
+<WelcomeScreen>:
     md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"

--- a/main.py
+++ b/main.py
@@ -44,6 +44,7 @@ from kivy.graphics import Color, Rectangle
 from kivy.utils import platform
 from ui.screens.general.preset_detail_screen import PresetDetailScreen
 from ui.screens.general.preset_overview_screen import PresetOverviewScreen
+from ui.screens.general.welcome_screen import WelcomeScreen
 from pathlib import Path
 import os
 import re
@@ -615,6 +616,7 @@ class WorkoutApp(MDApp):
             self.workout_session = WorkoutSession(preset_name, db_path=DEFAULT_DB_PATH)
         else:
             self.workout_session = None
+            WorkoutSession.clear_recovery_files()
 
         # ensure metric input doesn't accidentally advance sets
         self.record_new_set = False

--- a/ui/screens/__init__.py
+++ b/ui/screens/__init__.py
@@ -7,6 +7,7 @@ from .session import (
     WorkoutSummaryScreen,
 )
 from .general import (
+    WelcomeScreen,
     EditExerciseScreen,
     EditPresetScreen,
     ExerciseLibraryScreen,
@@ -32,4 +33,5 @@ __all__ = [
     "PreviousWorkoutsScreen",
     "WorkoutHistoryScreen",
     "ViewPreviousWorkoutScreen",
+    "WelcomeScreen",
 ]

--- a/ui/screens/general/__init__.py
+++ b/ui/screens/general/__init__.py
@@ -17,6 +17,7 @@ from .presets_screen import PresetsScreen
 from .previous_workouts_screen import PreviousWorkoutsScreen
 from .workout_history_screen import WorkoutHistoryScreen
 from .view_previous_workout_screen import ViewPreviousWorkoutScreen
+from .welcome_screen import WelcomeScreen
 
 __all__ = [
     "EditExerciseScreen",
@@ -34,4 +35,5 @@ __all__ = [
     "PreviousWorkoutsScreen",
     "WorkoutHistoryScreen",
     "ViewPreviousWorkoutScreen",
+    "WelcomeScreen",
 ]

--- a/ui/screens/general/welcome_screen.py
+++ b/ui/screens/general/welcome_screen.py
@@ -1,0 +1,69 @@
+try:  # pragma: no cover - fallback for environments without Kivy
+    from kivymd.app import MDApp
+    from kivymd.uix.screen import MDScreen
+    from kivymd.uix.dialog import MDDialog
+    from kivymd.uix.button import MDFlatButton, MDRaisedButton
+except Exception:  # pragma: no cover - simple stubs
+    MDApp = object
+    MDScreen = object
+
+    class MDDialog:  # minimal placeholder
+        def __init__(self, *a, **k):
+            pass
+
+        def open(self, *a, **k):
+            pass
+
+        def dismiss(self, *a, **k):
+            pass
+
+    class MDFlatButton:  # minimal placeholder
+        def __init__(self, *a, **k):
+            pass
+
+    class MDRaisedButton(MDFlatButton):
+        pass
+
+from backend.workout_session import WorkoutSession
+
+
+class WelcomeScreen(MDScreen):
+    """Initial screen that checks for recoverable workout sessions."""
+
+    def on_pre_enter(self, *args):
+        if getattr(self, "_checked_recovery", False):
+            return super().on_pre_enter(*args)
+        self._checked_recovery = True
+        session = WorkoutSession.load_from_recovery()
+        if session:
+            self._show_recovery_dialog(session)
+        return super().on_pre_enter(*args)
+
+    def _show_recovery_dialog(self, session: WorkoutSession) -> None:
+        app = MDApp.get_running_app()
+
+        def recover(*_):
+            dialog.dismiss()
+            if app:
+                app.workout_session = session
+                if session.is_set_active():
+                    session.resume_from_last_start = True
+                    if app.root:
+                        app.root.current = "workout_active"
+                else:
+                    if app.root:
+                        app.root.current = "rest"
+
+        def discard(*_):
+            session.clear_recovery_files()
+            dialog.dismiss()
+
+        dialog = MDDialog(
+            text="Recover previous workout session?",
+            buttons=[
+                MDFlatButton(text="No", on_release=discard),
+                MDRaisedButton(text="Yes", on_release=recover),
+            ],
+        )
+        dialog.open()
+        self._recovery_dialog = dialog

--- a/ui/screens/session/workout_active_screen.py
+++ b/ui/screens/session/workout_active_screen.py
@@ -27,6 +27,8 @@ class WorkoutActiveScreen(MDScreen):
             self.start_time = time.time()
             if session:
                 session.current_set_start_time = self.start_time
+        if session:
+            session.save_recovery_state()
         self._event = Clock.schedule_interval(self._update_elapsed, 0.1)
         self._update_elapsed(0)
 


### PR DESCRIPTION
## Summary
- Persist workout session state to dual JSON backup files for crash recovery
- Restore sessions on startup via new welcome screen prompt
- Clear recovery data after saving completed workouts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a43a89cac0833292612479a28a840f