### PR TITLE
Use icon buttons on preset detail screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -114,15 +114,20 @@ RootUI:
         ScrollView:
             MDList:
                 id: summary_list
-        MDRaisedButton:
-            text: "Edit Preset"
-            on_release: app.root.current = "edit_preset"
-        MDRaisedButton:
-            text: "Go to Preset Overview"
-            on_release: app.root.current = "preset_overview"
-        MDRaisedButton:
-            text: "Back to Presets"
-            on_release: app.root.current = "presets"
+        BoxLayout:
+            orientation: "horizontal"
+            size_hint_y: None
+            height: "48dp"
+            spacing: "10dp"
+            MDIconButton:
+                icon: "arrow-left"
+                on_release: app.root.current = "presets"
+            MDIconButton:
+                icon: "pencil"
+                on_release: app.root.current = "edit_preset"
+            MDIconButton:
+                icon: "arrow-right"
+                on_release: app.root.current = "preset_overview"
 
 <ExerciseRow@MDBoxLayout>:
     name: ""


### PR DESCRIPTION
## Summary
- Replace PresetDetailScreen text buttons with icon buttons in a single row
- Align action layout with other screens for smaller displays

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a444dacb58833295e863f6dddebc5e