### PR TITLE
Streamline preset overview controls

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -1018,18 +1018,11 @@ RootUI:
 <PresetOverviewScreen>:
     details_list: details_tab.ids.details_list
     workout_list: workout_tab.ids.workout_list
-    preset_label: preset_label
     md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
         spacing: "10dp"
         padding: "20dp"
-        MDLabel:
-            id: preset_label
-            text: ""
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
         MDTabs:
             id: tabs
             DetailsTab:
@@ -1038,12 +1031,19 @@ RootUI:
             WorkoutTab:
                 id: workout_tab
                 title: "Workout"
-        MDRaisedButton:
-            text: "Back to Detail"
-            on_release: app.root.current = "preset_detail"
-        MDRaisedButton:
-            text: "Start Workout"
-            on_release: root.start_workout()
+        MDBoxLayout:
+            size_hint_y: None
+            height: "40dp"
+            spacing: "10dp"
+            MDIconButton:
+                icon: "chevron-left"
+                on_release: app.root.current = "preset_detail"
+            MDIconButton:
+                icon: "clipboard"
+                on_release: root.open_metric_popup()
+            MDIconButton:
+                icon: "play"
+                on_release: root.start_workout()
 
 <EditExerciseScreen>:
     metrics_list: metrics_list

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1018,7 +1018,6 @@ def test_preset_overview_screen_populate(monkeypatch):
     screen = PresetOverviewScreen()
     screen.details_list = DummyList()
     screen.workout_list = DummyList()
-    screen.preset_label = type("L", (), {"text": ""})()
 
     class DummyApp:
         selected_preset = "Test"
@@ -1082,7 +1081,6 @@ def test_pre_session_metrics_prompt_before_start(monkeypatch):
     screen = PresetOverviewScreen()
     screen.details_list = DummyList()
     screen.workout_list = DummyList()
-    screen.preset_label = type("L", (), {"text": ""})()
     screen.manager = type("M", (), {"current": ""})()
 
     class DummyApp:

--- a/ui/screens/general/preset_overview_screen.py
+++ b/ui/screens/general/preset_overview_screen.py
@@ -12,7 +12,6 @@ class PresetOverviewScreen(MDScreen):
 
     details_list = ObjectProperty(None)
     workout_list = ObjectProperty(None)
-    preset_label = ObjectProperty(None)
     _pre_session_metric_data = None
 
     def on_pre_enter(self, *args):
@@ -22,7 +21,7 @@ class PresetOverviewScreen(MDScreen):
         return super().on_pre_enter(*args)
 
     def populate(self):
-        if not self.details_list or not self.workout_list or not self.preset_label:
+        if not self.details_list or not self.workout_list:
             return
 
         self.details_list.clear_widgets()
@@ -31,11 +30,6 @@ class PresetOverviewScreen(MDScreen):
         app = MDApp.get_running_app()
         app.init_preset_editor()
         preset_name = app.selected_preset
-        self.preset_label.text = (
-            preset_name
-            if preset_name
-            else "Preset Overview - summary of the chosen preset"
-        )
 
         editor = app.preset_editor
         if not editor:
@@ -89,8 +83,11 @@ class PresetOverviewScreen(MDScreen):
         if self.manager:
             self.manager.current = "rest"
 
-    def _prompt_pre_session_metrics(self):
-        if self._pre_session_metric_data is not None:
+    def open_metric_popup(self):
+        self._prompt_pre_session_metrics(force=True)
+
+    def _prompt_pre_session_metrics(self, force: bool = False):
+        if self._pre_session_metric_data is not None and not force:
             return
         app = MDApp.get_running_app()
         preset_name = app.selected_preset


### PR DESCRIPTION
## Summary
- compact preset overview by removing header label and using icon-only controls
- allow metric popup to be reopened via clipboard icon
- adjust tests for updated screen layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4470045b88332bea5878814899ed8