### PR TITLE
Fix session recovery prompt on Welcome screen

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -63,6 +63,31 @@ def test_switch_tab_updates_current_tab():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_welcome_screen_triggers_recovery(monkeypatch):
+    from ui.screens.general.welcome_screen import WelcomeScreen
+    from backend.workout_session import WorkoutSession
+
+    dummy_session = object()
+    monkeypatch.setattr(
+        WorkoutSession,
+        "load_from_recovery",
+        classmethod(lambda cls: dummy_session),
+    )
+
+    called = {}
+
+    def fake_dialog(self, session):
+        called["session"] = session
+
+    monkeypatch.setattr(WelcomeScreen, "_show_recovery_dialog", fake_dialog)
+
+    screen = WelcomeScreen()
+    screen.on_enter()
+
+    assert called.get("session") is dummy_session
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_optional_metrics_populated():
     from kivy.lang import Builder
     from pathlib import Path

--- a/ui/screens/general/welcome_screen.py
+++ b/ui/screens/general/welcome_screen.py
@@ -30,14 +30,14 @@ from backend.workout_session import WorkoutSession
 class WelcomeScreen(MDScreen):
     """Initial screen that checks for recoverable workout sessions."""
 
-    def on_pre_enter(self, *args):
+    def on_enter(self, *args):
         if getattr(self, "_checked_recovery", False):
-            return super().on_pre_enter(*args)
+            return super().on_enter(*args)
         self._checked_recovery = True
         session = WorkoutSession.load_from_recovery()
         if session:
             self._show_recovery_dialog(session)
-        return super().on_pre_enter(*args)
+        return super().on_enter(*args)
 
     def _show_recovery_dialog(self, session: WorkoutSession) -> None:
         app = MDApp.get_running_app()


### PR DESCRIPTION
## Summary
- Ensure Welcome screen checks for saved workout sessions on enter and prompts to resume
- Add regression test for recovery dialog invocation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a449151a6083329a8d159a0b0a23c3