### PR TITLE
Tighten Exercise & Metric library layouts for small screens

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -217,7 +217,7 @@ RootUI:
     FloatLayout:
         MDBoxLayout:
             orientation: "vertical"
-            spacing: "10dp"
+            spacing: "5dp"
             padding: "20dp"
             MDBoxLayout:
                 size_hint_y: None
@@ -240,8 +240,11 @@ RootUI:
                     name: "exercises"
                     BoxLayout:
                         orientation: "vertical"
-                        BoxLayout:
-                            orientation: "vertical"
+                        MDBoxLayout:
+                            orientation: "horizontal"
+                            size_hint_y: None
+                            height: "40dp"
+                            spacing: "5dp"
                             MDTextField:
                                 id: search_field
                                 hint_text: "Search exercises"
@@ -249,47 +252,42 @@ RootUI:
                                 on_text: root.update_search(self.text)
                                 size_hint_y: None
                                 height: "40dp"
-                            MDBoxLayout:
-                                orientation: "horizontal"
+                                size_hint_x: 1
+                            MDIconButton:
+                                icon: "filter-variant"
+                                on_release: root.open_filter_popup()
+                                size_hint: None, None
+                                size: "40dp", "40dp"
+                        MDRecycleView:
+                            id: exercise_list
+                            viewclass: "ExerciseRow"
+                            RecycleBoxLayout:
+                                default_size: None, dp(56)
+                                default_size_hint: 1, None
                                 size_hint_y: None
                                 height: self.minimum_height
-                                MDLabel:
-                                    text: "Exercise Library - browse all exercises"
-                                    halign: "center"
-                                    theme_text_color: "Custom"
-                                    text_color: 0.2, 0.6, 0.86, 1
-                                    size_hint_x: 0.9
-                                MDIconButton:
-                                    icon: "filter-variant"
-                                    on_release: root.open_filter_popup()
-                            MDRecycleView:
-                                id: exercise_list
-                                viewclass: "ExerciseRow"
-                                RecycleBoxLayout:
-                                    default_size: None, dp(56)
-                                    default_size_hint: 1, None
-                                    size_hint_y: None
-                                    height: self.minimum_height
-                                    orientation: "vertical"
+                                orientation: "vertical"
                         MDBoxLayout:
+                            orientation: "horizontal"
                             size_hint_y: None
-                            height: "56dp"
-                            padding: "10dp"
+                            height: "48dp"
                             spacing: "10dp"
-                            MDRaisedButton:
-                                text: "Back"
+                            MDIconButton:
+                                icon: "arrow-left"
                                 on_release: root.go_back()
                             Widget:
-                            MDFloatingActionButton:
+                            MDIconButton:
                                 icon: "plus"
-                                md_bg_color: app.theme_cls.primary_color
                                 on_release: root.new_exercise()
                 Screen:
                     name: "metrics"
                     BoxLayout:
                         orientation: "vertical"
-                        BoxLayout:
-                            orientation: "vertical"
+                        MDBoxLayout:
+                            orientation: "horizontal"
+                            size_hint_y: None
+                            height: "40dp"
+                            spacing: "5dp"
                             MDTextField:
                                 id: metric_search_field
                                 hint_text: "Search metrics"
@@ -297,40 +295,32 @@ RootUI:
                                 on_text: root.update_search(self.text)
                                 size_hint_y: None
                                 height: "40dp"
-                            MDBoxLayout:
-                                orientation: "horizontal"
+                                size_hint_x: 1
+                            MDIconButton:
+                                icon: "filter-variant"
+                                on_release: root.open_filter_popup()
+                                size_hint: None, None
+                                size: "40dp", "40dp"
+                        MDRecycleView:
+                            id: metric_list
+                            viewclass: "MetricRow"
+                            RecycleBoxLayout:
+                                default_size: None, dp(56)
+                                default_size_hint: 1, None
                                 size_hint_y: None
                                 height: self.minimum_height
-                                MDLabel:
-                                    text: "Metric Library - browse all metrics"
-                                    halign: "center"
-                                    theme_text_color: "Custom"
-                                    text_color: 0.2, 0.6, 0.86, 1
-                                    size_hint_x: 0.9
-                                MDIconButton:
-                                    icon: "filter-variant"
-                                    on_release: root.open_filter_popup()
-                            MDRecycleView:
-                                id: metric_list
-                                viewclass: "MetricRow"
-                                RecycleBoxLayout:
-                                    default_size: None, dp(56)
-                                    default_size_hint: 1, None
-                                    size_hint_y: None
-                                    height: self.minimum_height
-                                    orientation: "vertical"
+                                orientation: "vertical"
                         MDBoxLayout:
+                            orientation: "horizontal"
                             size_hint_y: None
-                            height: "56dp"
-                            padding: "10dp"
+                            height: "48dp"
                             spacing: "10dp"
-                            MDRaisedButton:
-                                text: "Back"
+                            MDIconButton:
+                                icon: "arrow-left"
                                 on_release: root.go_back()
                             Widget:
-                            MDFloatingActionButton:
+                            MDIconButton:
                                 icon: "plus"
-                                md_bg_color: app.theme_cls.primary_color
                                 on_release: root.new_metric()
 
 <ProgressScreen@MDScreen>:


### PR DESCRIPTION
## Summary
- Shrink spacing above library tabs for denser layout
- Inline search bars with filter icons in Exercise/Metric tabs
- Replace text buttons with compact back and add icons at bottom

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a44c7c4620833282cb8e28f1b8cecf