### PR TITLE
Move session recovery popup to home screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -42,7 +42,7 @@ RootUI:
     PreviousWorkoutsScreen:
         name: "previous_workouts"
 
-<HomeScreen@MDScreen>:
+<HomeScreen>:
     md_bg_color: PINK_BG
     ScrollView:
         do_scroll_x: False

--- a/main.py
+++ b/main.py
@@ -45,6 +45,7 @@ from kivy.utils import platform
 from ui.screens.general.preset_detail_screen import PresetDetailScreen
 from ui.screens.general.preset_overview_screen import PresetOverviewScreen
 from ui.screens.general.welcome_screen import WelcomeScreen
+from ui.screens.general.home_screen import HomeScreen
 from pathlib import Path
 import os
 import re

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -63,8 +63,8 @@ def test_switch_tab_updates_current_tab():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
-def test_welcome_screen_triggers_recovery(monkeypatch):
-    from ui.screens.general.welcome_screen import WelcomeScreen
+def test_home_screen_triggers_recovery(monkeypatch):
+    from ui.screens.general.home_screen import HomeScreen
     from backend.workout_session import WorkoutSession
 
     dummy_session = object()
@@ -79,12 +79,36 @@ def test_welcome_screen_triggers_recovery(monkeypatch):
     def fake_dialog(self, session):
         called["session"] = session
 
-    monkeypatch.setattr(WelcomeScreen, "_show_recovery_dialog", fake_dialog)
+    monkeypatch.setattr(HomeScreen, "_show_recovery_dialog", fake_dialog)
 
-    screen = WelcomeScreen()
+    screen = HomeScreen()
     screen.on_enter()
 
     assert called.get("session") is dummy_session
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_home_screen_no_recovery_shows_info(monkeypatch):
+    from ui.screens.general.home_screen import HomeScreen
+    from backend.workout_session import WorkoutSession
+
+    monkeypatch.setattr(
+        WorkoutSession,
+        "load_from_recovery",
+        classmethod(lambda cls: None),
+    )
+
+    called = {}
+
+    def fake_dialog(self):
+        called["called"] = True
+
+    monkeypatch.setattr(HomeScreen, "_show_no_session_dialog", fake_dialog)
+
+    screen = HomeScreen()
+    screen.on_enter()
+
+    assert called.get("called") is True
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")

--- a/ui/screens/general/home_screen.py
+++ b/ui/screens/general/home_screen.py
@@ -1,0 +1,79 @@
+try:  # pragma: no cover - fallback for environments without Kivy
+    from kivymd.app import MDApp
+    from kivymd.uix.screen import MDScreen
+    from kivymd.uix.dialog import MDDialog
+    from kivymd.uix.button import MDFlatButton, MDRaisedButton
+except Exception:  # pragma: no cover - simple stubs
+    MDApp = object
+    MDScreen = object
+
+    class MDDialog:
+        def __init__(self, *a, **k):
+            pass
+
+        def open(self, *a, **k):
+            pass
+
+        def dismiss(self, *a, **k):
+            pass
+
+    class MDFlatButton:
+        def __init__(self, *a, **k):
+            pass
+
+    class MDRaisedButton(MDFlatButton):
+        pass
+
+from backend.workout_session import WorkoutSession
+
+
+class HomeScreen(MDScreen):
+    """Primary screen that always prompts about session recovery."""
+
+    def on_enter(self, *args):
+        session = WorkoutSession.load_from_recovery()
+        if session:
+            self._show_recovery_dialog(session)
+        else:
+            self._show_no_session_dialog()
+        return super().on_enter(*args)
+
+    def _show_recovery_dialog(self, session: WorkoutSession) -> None:
+        app = MDApp.get_running_app()
+
+        def recover(*_):
+            dialog.dismiss()
+            if app:
+                app.workout_session = session
+                if session.is_set_active():
+                    session.resume_from_last_start = True
+                    if app.root:
+                        app.root.current = "workout_active"
+                else:
+                    if app.root:
+                        app.root.current = "rest"
+
+        def discard(*_):
+            session.clear_recovery_files()
+            dialog.dismiss()
+
+        dialog = MDDialog(
+            text="Recover previous workout session?",
+            buttons=[
+                MDFlatButton(text="No", on_release=discard),
+                MDRaisedButton(text="Yes", on_release=recover),
+            ],
+        )
+        dialog.open()
+        self._recovery_dialog = dialog
+
+    def _show_no_session_dialog(self) -> None:
+        def close(*_):
+            dialog.dismiss()
+
+        dialog = MDDialog(
+            text="No recovered session found.",
+            buttons=[MDRaisedButton(text="Continue", on_release=close)],
+        )
+        dialog.open()
+        self._recovery_dialog = dialog

--- a/ui/screens/general/welcome_screen.py
+++ b/ui/screens/general/welcome_screen.py
@@ -1,69 +1,10 @@
 try:  # pragma: no cover - fallback for environments without Kivy
-    from kivymd.app import MDApp
     from kivymd.uix.screen import MDScreen
-    from kivymd.uix.dialog import MDDialog
-    from kivymd.uix.button import MDFlatButton, MDRaisedButton
 except Exception:  # pragma: no cover - simple stubs
-    MDApp = object
     MDScreen = object
-
-    class MDDialog:  # minimal placeholder
-        def __init__(self, *a, **k):
-            pass
-
-        def open(self, *a, **k):
-            pass
-
-        def dismiss(self, *a, **k):
-            pass
-
-    class MDFlatButton:  # minimal placeholder
-        def __init__(self, *a, **k):
-            pass
-
-    class MDRaisedButton(MDFlatButton):
-        pass
-
-from backend.workout_session import WorkoutSession
 
 
 class WelcomeScreen(MDScreen):
-    """Initial screen that checks for recoverable workout sessions."""
+    """Initial screen displayed when the app starts."""
 
-    def on_enter(self, *args):
-        if getattr(self, "_checked_recovery", False):
-            return super().on_enter(*args)
-        self._checked_recovery = True
-        session = WorkoutSession.load_from_recovery()
-        if session:
-            self._show_recovery_dialog(session)
-        return super().on_enter(*args)
-
-    def _show_recovery_dialog(self, session: WorkoutSession) -> None:
-        app = MDApp.get_running_app()
-
-        def recover(*_):
-            dialog.dismiss()
-            if app:
-                app.workout_session = session
-                if session.is_set_active():
-                    session.resume_from_last_start = True
-                    if app.root:
-                        app.root.current = "workout_active"
-                else:
-                    if app.root:
-                        app.root.current = "rest"
-
-        def discard(*_):
-            session.clear_recovery_files()
-            dialog.dismiss()
-
-        dialog = MDDialog(
-            text="Recover previous workout session?",
-            buttons=[
-                MDFlatButton(text="No", on_release=discard),
-                MDRaisedButton(text="Yes", on_release=recover),
-            ],
-        )
-        dialog.open()
-        self._recovery_dialog = dialog
+    pass


### PR DESCRIPTION
## Summary
- prompt for session recovery on home screen, offering recovery or continue
- simplify welcome screen with no recovery logic
- adjust tests for new recovery flow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a44e2d631083328db0ab1c624b2711