### PR TITLE
Ensure rest screen timers restart after navigation

### DIFF
--- a/ui/screens/session/rest_screen.py
+++ b/ui/screens/session/rest_screen.py
@@ -119,11 +119,12 @@ class RestScreen(MDScreen):
     def on_leave(self, *args):
         if hasattr(self, "_event") and self._event:
             self._event.cancel()
+            self._event = None
         return super().on_leave(*args)
 
     def _ensure_clock_event(self):
         """Ensure the timer update event is running."""
-        if not hasattr(self, "_event") or not self._event:
+        if not getattr(getattr(self, "_event", None), "is_triggered", False):
             self._event = Clock.schedule_interval(self.update_timer, 0.1)
 
     def toggle_ready(self):


### PR DESCRIPTION
## Summary
- reset and reschedule timer events so rest screen clocks keep updating after returning

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4700e219c83328d435ecb6bbcb6f4