### PR TITLE
Use tempo metric for workout sounds

### DIFF
--- a/backend/workout_session.py
+++ b/backend/workout_session.py
@@ -377,6 +377,30 @@ class WorkoutSession:
         store = self.metric_store.get((self.current_exercise, self.current_set), {})
         return all(store.get(name) not in (None, "") for name in required)
 
+    def tempo_for_set(self, exercise_index: int, set_index: int) -> str | None:
+        """Return a 4-digit tempo string for the specified set, if present."""
+
+        if exercise_index >= len(self.preset_snapshot):
+            return None
+        metric_defs = self.preset_snapshot[exercise_index].get("metric_defs", [])
+        tempo_name = next(
+            (
+                m["name"]
+                for m in metric_defs
+                if m.get("library_metric_type_id") == 3
+            ),
+            None,
+        )
+        if not tempo_name:
+            return None
+        value = self.metric_store.get((exercise_index, set_index), {}).get(tempo_name)
+        if value is None:
+            return None
+        tempo = str(value)
+        if tempo.isdigit() and len(tempo) == 4:
+            return tempo
+        return None
+
     # --------------------------------------------------------------
     # Post-set metric helpers
     # --------------------------------------------------------------

--- a/ui/screens/session/workout_active_screen.py
+++ b/ui/screens/session/workout_active_screen.py
@@ -35,13 +35,15 @@ class WorkoutActiveScreen(MDScreen):
     def on_pre_enter(self, *args):
         app = MDApp.get_running_app()
         session = app.workout_session if app else None
+        tempo = None
         if session and session.current_exercise < len(session.exercises):
             self.exercise_name = session.next_exercise_display()
-            tempo = session.exercises[session.current_exercise].get("tempo")
-        else:
-            tempo = None
+            tempo = session.tempo_for_set(session.current_exercise, session.current_set)
         if app and hasattr(app, "sound"):
-            app.sound.start_tempo(tempo, skip_start=True)
+            if tempo:
+                app.sound.start_tempo(tempo, skip_start=True)
+            else:
+                app.sound.start_ticks()
         self.start_timer()
         return super().on_pre_enter(*args)
 


### PR DESCRIPTION
## Summary
- derive tempo from set metrics (library metric type 3) in `WorkoutSession`
- trigger tempo or tick sounds in `WorkoutActiveScreen` depending on metric validity

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4d0cc402483329d896bbf84abb94e