### PR TITLE
Refine active workout UI

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -517,16 +517,12 @@ RootUI:
             id: stopwatch
             text: root.formatted_time
             halign: "center"
+            font_name: root.digital_font
             font_style: "H2"
             multiline: False
         MDLabel:
             text: root.exercise_name
             halign: "center"
-        MDLabel:
-            text: "Active Workout Screen – The primary screen shown while the user is performing an exercise. Displays the current exercise details, timer, and any relevant cues or instructions."
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
         MDBoxLayout:
             orientation: "horizontal"
             spacing: "10dp"

--- a/ui/screens/session/workout_active_screen.py
+++ b/ui/screens/session/workout_active_screen.py
@@ -4,7 +4,11 @@ from kivy.clock import Clock
 from kivymd.app import MDApp
 from kivymd.uix.dialog import MDDialog
 from kivymd.uix.button import MDFlatButton
+from kivy.core.text import LabelBase
+from kivymd.font_definitions import fonts_path
 import time
+
+LabelBase.register(name="RobotoMonoDigital", fn_regular=f"{fonts_path}/RobotoMono-Regular.ttf")
 
 
 class WorkoutActiveScreen(MDScreen):
@@ -14,6 +18,7 @@ class WorkoutActiveScreen(MDScreen):
     start_time = NumericProperty(0.0)
     formatted_time = StringProperty("00:00")
     exercise_name = StringProperty("")
+    digital_font = StringProperty("RobotoMonoDigital")
     _event = None
 
     def start_timer(self, *args):


### PR DESCRIPTION
## Summary
- Remove verbose description label from active workout screen
- Use monospaced digital font for stopwatch display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d16f97408332970b89c171f77b5e