### PR TITLE
Sync tempo sounds with stopwatch

### DIFF
--- a/ui/screens/session/workout_active_screen.py
+++ b/ui/screens/session/workout_active_screen.py
@@ -39,12 +39,12 @@ class WorkoutActiveScreen(MDScreen):
         if session and session.current_exercise < len(session.exercises):
             self.exercise_name = session.next_exercise_display()
             tempo = session.tempo_for_set(session.current_exercise, session.current_set)
+        self.start_timer()
         if app and hasattr(app, "sound"):
             if tempo:
-                app.sound.start_tempo(tempo, skip_start=True)
+                app.sound.start_tempo(tempo, skip_start=True, start_time=self.start_time)
             else:
                 app.sound.start_ticks()
-        self.start_timer()
         return super().on_pre_enter(*args)
 
     def stop_timer(self, *args):


### PR DESCRIPTION
## Summary
- synchronize tempo playback with workout stopwatch using saved epoch start time
- start workout timer before audio and supply epoch start to tempo sound scheduling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e304a728833288ddbf7ca5325171