### PR TITLE
Gracefully handle missing RobotoMono font for workout timer

### DIFF
--- a/ui/screens/session/workout_active_screen.py
+++ b/ui/screens/session/workout_active_screen.py
@@ -6,9 +6,16 @@ from kivymd.uix.dialog import MDDialog
 from kivymd.uix.button import MDFlatButton
 from kivy.core.text import LabelBase
 from kivymd.font_definitions import fonts_path
+from pathlib import Path
 import time
 
-LabelBase.register(name="RobotoMonoDigital", fn_regular=f"{fonts_path}/RobotoMono-Regular.ttf")
+# Only register the custom font if it exists to avoid unnecessary errors and memory usage
+DIGITAL_FONT = "RobotoMonoDigital"
+_font_path = Path(fonts_path) / "RobotoMono-Regular.ttf"
+if _font_path.exists():
+    LabelBase.register(name=DIGITAL_FONT, fn_regular=str(_font_path))
+else:
+    DIGITAL_FONT = "Roboto"
 
 
 class WorkoutActiveScreen(MDScreen):
@@ -18,7 +25,7 @@ class WorkoutActiveScreen(MDScreen):
     start_time = NumericProperty(0.0)
     formatted_time = StringProperty("00:00")
     exercise_name = StringProperty("")
-    digital_font = StringProperty("RobotoMonoDigital")
+    digital_font = StringProperty(DIGITAL_FONT)
     _event = None
 
     def start_timer(self, *args):


### PR DESCRIPTION
## Summary
- avoid crashing when RobotoMono font is absent by checking existence before registration
- fall back to system font for stopwatch display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a56ec0f5f48332ae25a1bd9779c096