### PR TITLE
Add tempo visualization widget

### DIFF
--- a/tempo.py
+++ b/tempo.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass
+class TempoPhase:
+    """Represents a single phase in the tempo cycle."""
+
+    name: str
+    duration: int
+
+
+class TempoCycle:
+    """Utility for computing tempo phase progression.
+
+    A tempo is a four digit string describing [eccentric, pause bottom,
+    concentric, pause top] durations. Execution always begins with the
+    concentric phase, i.e. the third digit.
+    """
+
+    ORDER_NAMES: List[str] = [
+        "concentric",
+        "pause_top",
+        "eccentric",
+        "pause_bottom",
+    ]
+
+    def __init__(self, tempo: str) -> None:
+        if len(tempo) != 4 or not tempo.isdigit():
+            raise ValueError("Tempo must be a four digit string")
+
+        digits = [int(ch) for ch in tempo]
+        order = [2, 3, 0, 1]  # start from concentric
+        self.phases: List[TempoPhase] = [
+            TempoPhase(self.ORDER_NAMES[i], digits[idx]) for i, idx in enumerate(order)
+        ]
+        self.total: int = sum(p.duration for p in self.phases)
+
+    def phase_at(self, elapsed: float) -> Tuple[int, float, float]:
+        """Return current phase index, fraction complete, and remaining time.
+
+        ``elapsed`` is seconds since cycle start. The cycle loops when
+        ``elapsed`` exceeds the total duration.
+        """
+
+        if self.total == 0:
+            return 0, 0.0, 0.0
+
+        t = elapsed % self.total
+        acc = 0
+        for index, phase in enumerate(self.phases):
+            next_acc = acc + phase.duration
+            if t < next_acc:
+                within = t - acc
+                fraction = within / phase.duration if phase.duration else 1.0
+                remaining = self.total - (acc + within)
+                return index, fraction, remaining
+            acc = next_acc
+
+        # Should not reach here, but return last phase complete
+        return len(self.phases) - 1, 1.0, 0.0

--- a/tests/test_tempo_visualizer.py
+++ b/tests/test_tempo_visualizer.py
@@ -1,0 +1,19 @@
+from tempo import TempoCycle
+
+
+def test_phase_progress_and_order():
+    cycle = TempoCycle("3412")
+    assert [p.duration for p in cycle.phases] == [1, 2, 3, 4]
+    assert cycle.total == 10
+
+    idx, frac, remaining = cycle.phase_at(3.4)
+    assert idx == 2  # eccentric phase
+    assert round(frac, 2) == round(0.4 / 3, 2)
+    assert round(remaining, 1) == round(10 - 3.4, 1)
+
+
+def test_wraps_after_total():
+    cycle = TempoCycle("3412")
+    idx, frac, _ = cycle.phase_at(10.5)
+    assert idx == 0  # new rep, concentric
+    assert round(frac, 2) == 0.5

--- a/ui/tempo_visualizer.py
+++ b/ui/tempo_visualizer.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import time
+
+from kivy.clock import Clock
+from kivy.graphics import Color, Rectangle
+from kivy.properties import ListProperty, NumericProperty, StringProperty
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.widget import Widget
+
+from tempo import TempoCycle
+
+
+class _TempoSegment(Widget):
+    """Single colored segment that fills left to right."""
+
+    color = ListProperty([1, 1, 1, 1])
+    progress = NumericProperty(0.0)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        with self.canvas:
+            self._bg_color = Color(rgba=(*self.color[:3], 0.3))
+            self._bg_rect = Rectangle(pos=self.pos, size=self.size)
+            self._fg_color = Color(rgba=self.color)
+            self._fg_rect = Rectangle(pos=self.pos, size=(0, self.height))
+        self.bind(
+            pos=self._update_graphics,
+            size=self._update_graphics,
+            progress=self._update_graphics,
+            color=self._recolor,
+        )
+
+    def _recolor(self, *args):
+        self._bg_color.rgba = (*self.color[:3], 0.3)
+        self._fg_color.rgba = self.color
+
+    def _update_graphics(self, *args):
+        self._bg_rect.pos = self.pos
+        self._bg_rect.size = self.size
+        self._fg_rect.pos = self.pos
+        self._fg_rect.size = (self.width * self.progress, self.height)
+
+
+class TempoVisualizer(BoxLayout):
+    """Displays a tempo as a horizontal progress bar."""
+
+    tempo = StringProperty("0000")
+    colors = ListProperty(
+        [
+            [0.2, 0.6, 1, 1],  # concentric
+            [0.2, 1, 0.6, 1],  # pause top
+            [1, 0.6, 0.2, 1],  # eccentric
+            [1, 0.2, 0.2, 1],  # pause bottom
+        ]
+    )
+
+    def __init__(self, **kwargs):
+        super().__init__(orientation="horizontal", **kwargs)
+        self._cycle: TempoCycle | None = None
+        self._segments: list[_TempoSegment] = []
+        self._event = None
+        self.bind(tempo=self._build)
+        if self.tempo:
+            self._build()
+
+    def _build(self, *args):
+        self.clear_widgets()
+        self._segments = []
+        self._cycle = TempoCycle(self.tempo)
+        total = self._cycle.total or 1
+        for i, phase in enumerate(self._cycle.phases):
+            seg = _TempoSegment(color=self.colors[i], size_hint_x=phase.duration / total)
+            self._segments.append(seg)
+            self.add_widget(seg)
+
+    def start(self):
+        self._start = time.perf_counter()
+        if self._event:
+            self._event.cancel()
+        self._event = Clock.schedule_interval(self._update, 1 / 30)
+
+    def stop(self):
+        if self._event:
+            self._event.cancel()
+            self._event = None
+
+    def _update(self, dt):
+        if not self._cycle:
+            return
+        elapsed = time.perf_counter() - self._start
+        idx, frac, _ = self._cycle.phase_at(elapsed)
+        for i, seg in enumerate(self._segments):
+            if i < idx:
+                seg.progress = 1
+            elif i == idx:
+                seg.progress = frac
+            else:
+                seg.progress = 0


### PR DESCRIPTION
## Summary
- add `TempoCycle` helper to compute current tempo phase and progress
- introduce `TempoVisualizer` Kivy widget showing a looping four-phase tempo bar
- test tempo logic for correct ordering and wraparound

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a72d0b0c8332b5a57f6af04619e7