### PR TITLE
Add sound settings with volume and mute control

### DIFF
--- a/assets/sounds/__init__.py
+++ b/assets/sounds/__init__.py
@@ -22,6 +22,8 @@ class SoundSystem:
         self._durations: list[int] = []
         self._index = 0
         self._next_time = 0.0
+        self._volume = 1.0
+        self._enabled = True
         # Preload frequently used sounds to avoid first-play latency.
         for name in ("start", "tick"):
             self._load(name)
@@ -38,11 +40,22 @@ class SoundSystem:
         return snd
 
     def play(self, name: str) -> None:
-        """Play a named sound if available."""
+        """Play a named sound if available respecting volume and toggle."""
+        if not self._enabled:
+            return
         snd = self._load(name)
         if snd:
+            snd.volume = self._volume
             snd.stop()
             snd.play()
+
+    def set_volume(self, volume: float) -> None:
+        """Set playback volume for future sounds."""
+        self._volume = max(0.0, min(1.0, float(volume)))
+
+    def set_enabled(self, enabled: bool) -> None:
+        """Enable or disable sound playback."""
+        self._enabled = bool(enabled)
 
     # ------------------------------------------------------------------
     # Public API

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Utility functions for loading and saving user settings.
+
+The settings are stored as a list of dictionaries to preserve order.
+Each dictionary contains ``key``, ``value`` and ``type`` entries.
+"""
+
+from pathlib import Path
+import json
+from typing import Any, List, Dict
+
+# Path to the JSON file where settings are persisted.
+SETTINGS_PATH = Path(__file__).resolve().parents[1] / "data" / "settings.json"
+
+# Default settings to initialize the file on first run.
+DEFAULT_SETTINGS: List[Dict[str, Any]] = [
+    {"key": "sound_level", "value": 1.0, "type": "slider"},
+    {"key": "sound_on", "value": True, "type": "bool"},
+]
+
+# Internal cache so settings are only read from disk once.
+_settings_cache: List[Dict[str, Any]] | None = None
+
+
+def load_settings() -> List[Dict[str, Any]]:
+    """Load settings from :data:`SETTINGS_PATH` or create defaults."""
+    if SETTINGS_PATH.exists():
+        try:
+            with SETTINGS_PATH.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+                if isinstance(data, list):
+                    return data
+        except Exception:
+            pass
+    save_settings(DEFAULT_SETTINGS)
+    return DEFAULT_SETTINGS.copy()
+
+
+def save_settings(settings: List[Dict[str, Any]]) -> None:
+    """Persist ``settings`` to :data:`SETTINGS_PATH`."""
+    SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with SETTINGS_PATH.open("w", encoding="utf-8") as fh:
+        json.dump(settings, fh)
+
+
+def get_settings() -> List[Dict[str, Any]]:
+    """Return the cached settings list, loading from disk if needed."""
+    global _settings_cache
+    if _settings_cache is None:
+        _settings_cache = load_settings()
+    return _settings_cache
+
+
+def get_value(key: str) -> Any:
+    """Fetch the value associated with ``key``."""
+    for item in get_settings():
+        if item.get("key") == key:
+            return item.get("value")
+    return None
+
+
+def set_value(key: str, value: Any) -> None:
+    """Update ``key`` with ``value`` and persist the change."""
+    settings = get_settings()
+    for item in settings:
+        if item.get("key") == key:
+            item["value"] = value
+            break
+    else:
+        settings.append({"key": key, "value": value, "type": type(value).__name__})
+    save_settings(settings)

--- a/data/settings.json
+++ b/data/settings.json
@@ -1,0 +1,4 @@
+[
+    {"key": "sound_level", "value": 1.0, "type": "slider"},
+    {"key": "sound_on", "value": true, "type": "bool"}
+]

--- a/main.kv
+++ b/main.kv
@@ -366,7 +366,7 @@ RootUI:
             text: "Back"
             on_release: app.root.current = "workout_history"
 
-<SettingsScreen@MDScreen>:
+<SettingsScreen>:
     md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
@@ -377,6 +377,30 @@ RootUI:
             halign: "center"
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1
+        MDBoxLayout:
+            orientation: "horizontal"
+            size_hint_y: None
+            height: "40dp"
+            MDLabel:
+                text: "Sound"
+                valign: "center"
+            MDSwitch:
+                id: sound_toggle
+                pos_hint: {"center_y": 0.5}
+                on_active: root.on_sound_toggle(self, self.active)
+        MDBoxLayout:
+            orientation: "horizontal"
+            size_hint_y: None
+            height: "40dp"
+            MDLabel:
+                text: "Sound Level"
+                valign: "center"
+            MDSlider:
+                id: sound_level_slider
+                min: 0
+                max: 1
+                value: 1
+                on_value: root.on_sound_level(self, self.value)
         MDRaisedButton:
             text: "Back to Home"
             on_release: app.root.current = "home"

--- a/main.py
+++ b/main.py
@@ -70,6 +70,7 @@ from ui.screens.session.rest_screen import RestScreen
 from ui.screens.general.previous_workouts_screen import PreviousWorkoutsScreen
 from ui.screens.general.workout_history_screen import WorkoutHistoryScreen
 from ui.screens.general.view_previous_workout_screen import ViewPreviousWorkoutScreen
+from ui.screens.general.settings_screen import SettingsScreen
 
 
 
@@ -95,6 +96,7 @@ from ui.screens.general.edit_preset_screen import (
 from ui.screens.session.workout_summary_screen import WorkoutSummaryScreen
 from ui.popups import AddMetricPopup, EditMetricPopup, METRIC_FIELD_ORDER
 from assets.sounds import SoundSystem
+from backend import settings as app_settings
 
 # Set a consistent window size on desktop for predictable layout.
 if os.name == "nt":
@@ -560,6 +562,10 @@ class WorkoutApp(MDApp):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.sound = SoundSystem()
+        # Initialize sound system with persisted settings.
+        self.sound.set_volume(app_settings.get_value("sound_level") or 1.0)
+        sound_on = app_settings.get_value("sound_on")
+        self.sound.set_enabled(True if sound_on is None else sound_on)
 
     def build(self):
         root = Builder.load_file(str(Path(__file__).with_name("main.kv")))

--- a/ui/screens/general/__init__.py
+++ b/ui/screens/general/__init__.py
@@ -18,6 +18,7 @@ from .previous_workouts_screen import PreviousWorkoutsScreen
 from .workout_history_screen import WorkoutHistoryScreen
 from .view_previous_workout_screen import ViewPreviousWorkoutScreen
 from .welcome_screen import WelcomeScreen
+from .settings_screen import SettingsScreen
 
 __all__ = [
     "EditExerciseScreen",
@@ -36,4 +37,5 @@ __all__ = [
     "WorkoutHistoryScreen",
     "ViewPreviousWorkoutScreen",
     "WelcomeScreen",
+    "SettingsScreen",
 ]

--- a/ui/screens/general/settings_screen.py
+++ b/ui/screens/general/settings_screen.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""Screen for modifying app settings."""
+
+from kivymd.uix.screen import MDScreen
+from kivymd.app import MDApp
+from backend import settings as app_settings
+
+
+class SettingsScreen(MDScreen):
+    """Display and persist user-configurable settings."""
+
+    def on_pre_enter(self, *args) -> None:
+        """Populate controls from stored settings."""
+        self.ids.sound_level_slider.value = app_settings.get_value("sound_level") or 1.0
+        sound_on = app_settings.get_value("sound_on")
+        self.ids.sound_toggle.active = True if sound_on is None else bool(sound_on)
+
+    def on_sound_level(self, slider, value: float) -> None:
+        """Handle volume slider changes."""
+        app_settings.set_value("sound_level", value)
+        MDApp.get_running_app().sound.set_volume(value)
+
+    def on_sound_toggle(self, switch, value: bool) -> None:
+        """Handle sound enable/disable toggling."""
+        app_settings.set_value("sound_on", value)
+        MDApp.get_running_app().sound.set_enabled(value)


### PR DESCRIPTION
## Summary
- add persistent settings module storing ordered dictionaries in `data/settings.json`
- add settings screen with sound toggle and volume slider
- connect sound system to new settings for volume and enable/disable

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5b01e0ef88332b203fb22a45975cb