### PR TITLE
Unify settings screen across app

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -29,8 +29,6 @@ RootUI:
         name: "metric_input"
     WorkoutEditScreen:
         name: "workout_edit"
-    WorkoutSettingsScreen:
-        name: "workout_settings"
     WorkoutSummaryScreen:
         name: "workout_summary"
     EditExerciseScreen:
@@ -68,7 +66,7 @@ RootUI:
                 on_release: app.root.current = "progress"
             MDRaisedButton:
                 text: "Settings"
-                on_release: app.root.current = "settings"
+                on_release: app.open_settings('home')
             MDRaisedButton:
                 text: "History"
                 on_release: app.root.current = "workout_history"
@@ -335,8 +333,8 @@ RootUI:
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1
         MDRaisedButton:
-            text: "Back to Home"
-            on_release: app.root.current = "home"
+            text: "Back"
+            on_release: app.root.current = root.return_to
 
 <WorkoutHistoryScreen>:
     md_bg_color: PINK_BG
@@ -349,8 +347,8 @@ RootUI:
             MDList:
                 id: history_list
         MDRaisedButton:
-            text: "Back to Home"
-            on_release: app.root.current = "home"
+            text: "Back"
+            on_release: app.root.current = root.return_to
 
 <ViewPreviousWorkoutScreen>:
     md_bg_color: PINK_BG
@@ -402,8 +400,8 @@ RootUI:
                 value: 1
                 on_value: root.on_sound_level(self, self.value)
         MDRaisedButton:
-            text: "Back to Home"
-            on_release: app.root.current = "home"
+            text: "Back"
+            on_release: app.root.current = root.return_to
 
 <IconTextButton@MDCard>:
     on_press: print("IconTextButton pressed:", root.icon)
@@ -522,7 +520,7 @@ RootUI:
                     on_release: app.edit_active_preset()
                 IconTextButton:
                     icon: "cog"
-                    on_release: app.root.current = "workout_settings"
+                    on_release: app.open_settings('rest')
                 IconTextButton:
                     icon: "book"
                     on_release: app.root.current = "previous_workouts"
@@ -717,21 +715,6 @@ RootUI:
         padding: "20dp"
         MDLabel:
             text: "Workout Edit - tweak exercises in this session"
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
-        MDRaisedButton:
-            text: "Back to Rest"
-            on_release: app.root.current = "rest"
-
-<WorkoutSettingsScreen@MDScreen>:
-    md_bg_color: PINK_BG
-    BoxLayout:
-        orientation: "vertical"
-        spacing: "10dp"
-        padding: "20dp"
-        MDLabel:
-            text: "Workout Settings - adjust options for this workout"
             halign: "center"
             theme_text_color: "Custom"
             text_color: 0.2, 0.6, 0.86, 1

--- a/main.py
+++ b/main.py
@@ -566,6 +566,7 @@ class WorkoutApp(MDApp):
         self.sound.set_volume(app_settings.get_value("sound_level") or 1.0)
         sound_on = app_settings.get_value("sound_on")
         self.sound.set_enabled(True if sound_on is None else sound_on)
+        self._settings_origin = ""
 
     def build(self):
         root = Builder.load_file(str(Path(__file__).with_name("main.kv")))
@@ -587,12 +588,30 @@ class WorkoutApp(MDApp):
                 rest_screen = self.root.get_screen("rest")
             except Exception:
                 rest_screen = None
-            if rest_screen and getattr(rest_screen, "is_ready", False):
-                if hasattr(rest_screen, "unready"):
-                    rest_screen.unready()
-                else:
-                    rest_screen.is_ready = False
+        if rest_screen and getattr(rest_screen, "is_ready", False):
+            if hasattr(rest_screen, "unready"):
+                rest_screen.unready()
+            else:
+                rest_screen.is_ready = False
         return True
+
+    def open_settings(self, return_to: str) -> None:
+        """Show the settings screen and remember where to return.
+
+        Parameters
+        ----------
+        return_to:
+            Name of the screen to resume when settings closes.
+        """
+        if not self.root:
+            return
+        try:
+            settings = self.root.get_screen("settings")
+        except Exception:
+            return
+        settings.return_to = return_to
+        self._settings_origin = return_to
+        self.root.current = "settings"
 
     def init_preset_editor(self, force_reload: bool = False):
         """Create or reload the ``PresetEditor`` for the selected preset."""

--- a/ui/screens/general/settings_screen.py
+++ b/ui/screens/general/settings_screen.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from kivymd.uix.screen import MDScreen
 from kivymd.app import MDApp
+from kivy.properties import StringProperty
 from backend import settings as app_settings
 
 
 class SettingsScreen(MDScreen):
     """Display and persist user-configurable settings."""
+
+    return_to = StringProperty("home")
+    """Name of the screen to return to when leaving settings."""
 
     def on_pre_enter(self, *args) -> None:
         """Populate controls from stored settings."""

--- a/ui/screens/session/workout_active_screen.py
+++ b/ui/screens/session/workout_active_screen.py
@@ -45,18 +45,20 @@ class WorkoutActiveScreen(MDScreen):
         self._update_elapsed(0)
 
     def on_pre_enter(self, *args):
+        """Prepare the workout display when entering the screen."""
         app = MDApp.get_running_app()
         session = app.workout_session if app else None
         tempo = None
         if session and session.current_exercise < len(session.exercises):
             self.exercise_name = session.next_exercise_display()
             tempo = session.tempo_for_set(session.current_exercise, session.current_set)
-        self.start_timer()
-        if app and hasattr(app, "sound"):
-            if tempo:
-                app.sound.start_tempo(tempo, skip_start=True, start_time=self.start_time)
-            else:
-                app.sound.start_ticks()
+        if not self._event:
+            self.start_timer()
+            if app and hasattr(app, "sound"):
+                if tempo:
+                    app.sound.start_tempo(tempo, skip_start=True, start_time=self.start_time)
+                else:
+                    app.sound.start_ticks()
         return super().on_pre_enter(*args)
 
     def stop_timer(self, *args):
@@ -66,10 +68,13 @@ class WorkoutActiveScreen(MDScreen):
             self._event = None
 
     def on_leave(self, *args):
-        app = MDApp.get_running_app()
-        if app and hasattr(app, "sound"):
-            app.sound.stop()
-        self.stop_timer()
+        """Stop timers only when exiting to a non-settings screen."""
+        next_screen = self.manager.current if self.manager else None
+        if next_screen != "settings":
+            app = MDApp.get_running_app()
+            if app and hasattr(app, "sound"):
+                app.sound.stop()
+            self.stop_timer()
         return super().on_leave(*args)
 
     def _update_elapsed(self, dt):


### PR DESCRIPTION
## Summary
- Replace separate workout settings with shared app settings screen
- Track originating screen and return appropriately when closing settings
- Prevent workouts and rest timers from pausing when opening settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5b6b5279483329845f062dfcfb34a