### PR TITLE
Fix metric override indentation

### DIFF
--- a/ui/popups.py
+++ b/ui/popups.py
@@ -660,14 +660,15 @@ class EditMetricPopup(MDDialog):
                         enum_values=updates.get("values"),
                         db_path=db_path,
                     )
-                        if metric_saved:
-                            metrics.set_exercise_metric_override(
-                                self.screen.exercise_obj.name,
-                                self.metric["name"],
-                                is_user_created=self.screen.exercise_obj.is_user_created,
-                                value=updates.get("value"),
-                                db_path=db_path,
-                            )
+                    # Ensure overrides are updated if the metric already existed
+                    if metric_saved:
+                        metrics.set_exercise_metric_override(
+                            self.screen.exercise_obj.name,
+                            self.metric["name"],
+                            is_user_created=self.screen.exercise_obj.is_user_created,
+                            value=updates.get("value"),
+                            db_path=db_path,
+                        )
                 elif cb_ex.active:
                     if metric_saved:
                         metrics.set_exercise_metric_override(


### PR DESCRIPTION
## Summary
- fix unexpected indent in metric update popup
- document metric override handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5cb3383d0833297910dc3dec6599e