### PR TITLE
Add database import/export utilities in settings screen

### DIFF
--- a/backend/db_io.py
+++ b/backend/db_io.py
@@ -1,0 +1,132 @@
+"""Import and export helpers for the workout database."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import shutil
+import sqlite3
+import time
+import logging
+from typing import Any, Dict, List, Tuple
+
+# Path to the application's SQLite database.
+DB_PATH = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+# Directory where database backups are stored.
+BACKUP_DIR = Path(__file__).resolve().parents[1] / "backups"
+
+# Minimal set of tables expected to exist in any valid workout database.
+REQUIRED_TABLES = [
+    "library_exercises",
+    "library_metric_types",
+    "preset_presets",
+]
+
+
+def get_downloads_dir() -> Path:
+    """Return the system Downloads directory.
+
+    The path is derived from :class:`pathlib.Path.home` and is created if it
+    does not already exist.
+    """
+    downloads = Path.home() / "Downloads"
+    downloads.mkdir(parents=True, exist_ok=True)
+    return downloads
+
+
+def sqlite_to_json(db_path: Path) -> Dict[str, List[Dict[str, Any]]]:
+    """Return a JSON-serialisable representation of ``db_path``.
+
+    The function introspects the database to discover all user tables and
+    converts each row to a dictionary mapping column names to values. This
+    implementation is schema-agnostic so it can operate on future database
+    layouts without modification.
+    """
+    result: Dict[str, List[Dict[str, Any]]] = {}
+    with sqlite3.connect(str(db_path)) as conn:
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+        cur.execute("""SELECT name FROM sqlite_master \
+                       WHERE type='table' AND name NOT LIKE 'sqlite_%'""")
+        tables = [r[0] for r in cur.fetchall()]
+        for table in tables:
+            cur.execute(f"SELECT * FROM {table}")
+            rows = [dict(row) for row in cur.fetchall()]
+            result[table] = rows
+    return result
+
+
+def export_database(db_path: Path = DB_PATH, dest_dir: Path | None = None) -> Path:
+    """Export ``db_path`` to ``dest_dir`` as a ``.db`` file.
+
+    The destination file is named ``workout_<EPOCH>.db`` and stored in the
+    user's Downloads directory by default. A :class:`pathlib.Path` pointing to
+    the exported file is returned.
+    """
+    dest_dir = dest_dir or get_downloads_dir()
+    filename = f"workout_{int(time.time())}.db"
+    dest = dest_dir / filename
+    shutil.copy2(db_path, dest)
+    logging.info("Exported database to %s", dest)
+    return dest
+
+
+def export_database_json(db_path: Path = DB_PATH, dest_dir: Path | None = None) -> Path:
+    """Export ``db_path`` to ``dest_dir`` as a JSON file.
+
+    The JSON document captures the entire contents of the database without
+    relying on any hard-coded schema information. The destination file is named
+    ``workout_<EPOCH>.json``. A :class:`pathlib.Path` to the exported file is
+    returned.
+    """
+    dest_dir = dest_dir or get_downloads_dir()
+    data = sqlite_to_json(db_path)
+    filename = f"workout_{int(time.time())}.json"
+    dest = dest_dir / filename
+    with dest.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+    logging.info("Exported database JSON to %s", dest)
+    return dest
+
+
+def validate_database(db_path: Path) -> Tuple[bool, List[str]]:
+    """Run validation checks on ``db_path``.
+
+    Currently the function ensures all tables listed in
+    :data:`REQUIRED_TABLES` exist. The returned tuple contains a boolean
+    indicating success and a list of error messages. The design intentionally
+    makes it easy to add further validation rules in the future.
+    """
+    errors: List[str] = []
+    try:
+        with sqlite3.connect(str(db_path)) as conn:
+            cur = conn.cursor()
+            for table in REQUIRED_TABLES:
+                cur.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                    (table,),
+                )
+                if not cur.fetchone():
+                    errors.append(f"missing table: {table}")
+    except Exception as exc:  # pragma: no cover - defensive
+        errors.append(str(exc))
+    return (len(errors) == 0, errors)
+
+
+def import_database(src_path: Path, db_path: Path = DB_PATH, backup_dir: Path = BACKUP_DIR) -> bool:
+    """Validate and replace the current database with ``src_path``.
+
+    A backup of the existing database is created in ``backup_dir`` before the
+    replacement occurs. If validation fails the operation is aborted and the
+    current database is left untouched. ``True`` is returned on success.
+    """
+    valid, errors = validate_database(src_path)
+    if not valid:
+        logging.error("Import failed validation: %s", "; ".join(errors))
+        return False
+
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path = backup_dir / f"workout_{int(time.time())}.db.bak"
+    shutil.copy2(db_path, backup_path)
+    shutil.copy2(src_path, db_path)
+    logging.info("Replaced database with %s (backup: %s)", src_path, backup_path)
+    return True

--- a/main.kv
+++ b/main.kv
@@ -399,6 +399,26 @@ RootUI:
                 max: 1
                 value: 1
                 on_value: root.on_sound_level(self, self.value)
+        MDBoxLayout:
+            orientation: "vertical"
+            spacing: "10dp"
+            size_hint_y: None
+            height: self.minimum_height
+            MDRaisedButton:
+                text: "Export DB"
+                size_hint_y: None
+                height: "40dp"
+                on_release: root.export_db()
+            MDRaisedButton:
+                text: "Export JSON"
+                size_hint_y: None
+                height: "40dp"
+                on_release: root.export_json()
+            MDRaisedButton:
+                text: "Import DB"
+                size_hint_y: None
+                height: "40dp"
+                on_release: root.open_import_db()
         MDRaisedButton:
             text: "Back"
             on_release: app.root.current = root.return_to

--- a/ui/screens/general/settings_screen.py
+++ b/ui/screens/general/settings_screen.py
@@ -2,10 +2,36 @@ from __future__ import annotations
 
 """Screen for modifying app settings."""
 
-from kivymd.uix.screen import MDScreen
-from kivymd.app import MDApp
+try:
+    from kivymd.uix.screen import MDScreen
+    from kivymd.app import MDApp
+    from kivymd.uix.filemanager import MDFileManager
+    from kivymd.toast import toast
+except Exception:  # pragma: no cover - minimal stubs for testing
+    MDApp = object
+
+    class MDScreen:  # type: ignore[misc]
+        pass
+
+    class MDFileManager:  # type: ignore[misc]
+        def __init__(self, *_, **__):
+            pass
+
+        def show(self, *_, **__):
+            pass
+
+        def close(self, *_, **__):
+            pass
+
+    def toast(*_, **__):  # type: ignore[misc]
+        pass
+
 from kivy.properties import StringProperty
+from pathlib import Path
+import logging
+
 from backend import settings as app_settings
+from backend import db_io
 
 
 class SettingsScreen(MDScreen):
@@ -13,6 +39,7 @@ class SettingsScreen(MDScreen):
 
     return_to = StringProperty("home")
     """Name of the screen to return to when leaving settings."""
+    file_manager: MDFileManager | None = None
 
     def on_pre_enter(self, *args) -> None:
         """Populate controls from stored settings."""
@@ -29,3 +56,49 @@ class SettingsScreen(MDScreen):
         """Handle sound enable/disable toggling."""
         app_settings.set_value("sound_on", value)
         MDApp.get_running_app().sound.set_enabled(value)
+
+    # ------------------------------------------------------------------
+    # Database import/export helpers
+    # ------------------------------------------------------------------
+    def export_db(self) -> None:
+        """Export the SQLite database as a ``.db`` file."""
+        try:
+            path = db_io.export_database()
+            logging.info("Database exported to %s", path)
+            toast("Database exported")
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.error("Database export failed: %s", exc)
+            toast("Export failed")
+
+    def export_json(self) -> None:
+        """Export the SQLite database as a JSON file."""
+        try:
+            path = db_io.export_database_json()
+            logging.info("Database JSON exported to %s", path)
+            toast("JSON exported")
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.error("JSON export failed: %s", exc)
+            toast("Export failed")
+
+    def open_import_db(self) -> None:
+        """Open a file picker to select a database for import."""
+        if self.file_manager is None:
+            self.file_manager = MDFileManager(
+                exit_manager=self.close_file_manager,
+                select_path=self.select_import_file,
+                ext=[".db"],
+            )
+        self.file_manager.show(str(db_io.get_downloads_dir()))
+
+    def close_file_manager(self, *_) -> None:
+        """Close the file picker if it is open."""
+        if self.file_manager:
+            self.file_manager.close()
+
+    def select_import_file(self, path: str) -> None:
+        """Validate and import the selected database file."""
+        self.close_file_manager()
+        if db_io.import_database(Path(path)):
+            toast("Import successful")
+        else:
+            toast("Import failed")


### PR DESCRIPTION
## Summary
- add backend helpers to export/import workout.db, including generic SQLite-to-JSON converter and validation with backups
- expose export/import actions in settings screen with minimal UI buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d11f6cd883329f1c8f89e9594d83