### PR TITLE
Preload workout exercises for faster metric entry

### DIFF
--- a/tests/test_workout_session.py
+++ b/tests/test_workout_session.py
@@ -33,6 +33,14 @@ def test_workout_session_flow(sample_db):
     assert "Bench Press" in summary
 
 
+def test_exercises_preloaded(sample_db):
+    session = WorkoutSession("Push Day", db_path=sample_db)
+    first = session.exercises
+    second = session.exercises
+    assert first is second
+    assert all(data["exercise_info"] is not None for data in session.session_data)
+
+
 def test_pre_set_metrics_flow(sample_db):
     session = WorkoutSession("Push Day", db_path=sample_db, rest_duration=1)
 


### PR DESCRIPTION
## Summary
- preload workout exercises and cache their metric results to avoid rebuilding data when switching exercises
- refresh cached exercises after preset edits or recovery loading
- test that exercise info is fully cached up front

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d24a4e088332b43b2bef8590a846