### PR TITLE
Integrate tempo visualizer into workout screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -2,6 +2,7 @@
 #:import ButtonBehavior kivy.uix.behaviors.button.ButtonBehavior
 #:import PINK_BG ui.colors.PINK_BG
 #:import PURPLE_BG ui.colors.PURPLE_BG
+#:import TempoVisualizer ui.tempo_visualizer.TempoVisualizer
 RootUI:
     WelcomeScreen:
         name: "welcome"
@@ -529,6 +530,7 @@ RootUI:
                     on_release: root.confirm_finish()
 
 <WorkoutActiveScreen>:
+    tempo_bar: tempo_bar
     on_leave: root.stop_timer()
     md_bg_color: PURPLE_BG
     BoxLayout:
@@ -545,6 +547,11 @@ RootUI:
         MDLabel:
             text: root.exercise_name
             halign: "center"
+        TempoVisualizer:
+            id: tempo_bar
+            size_hint_y: None
+            height: dp(8)
+            opacity: 0
         MDBoxLayout:
             orientation: "horizontal"
             spacing: "10dp"

--- a/tests/test_tempo_visualizer.py
+++ b/tests/test_tempo_visualizer.py
@@ -1,4 +1,13 @@
 from tempo import TempoCycle
+import pytest
+import time
+
+try:  # pragma: no cover - optional Kivy dependency
+    from ui.tempo_visualizer import TempoVisualizer
+    kivy_available = True
+except Exception:  # pragma: no cover - Kivy not installed
+    TempoVisualizer = None
+    kivy_available = False
 
 
 def test_phase_progress_and_order():
@@ -17,3 +26,16 @@ def test_wraps_after_total():
     idx, frac, _ = cycle.phase_at(10.5)
     assert idx == 0  # new rep, concentric
     assert round(frac, 2) == 0.5
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_visualizer_uses_start_time(monkeypatch):
+    viz = TempoVisualizer(tempo="1111")
+    monkeypatch.setattr(time, "time", lambda: 105.0)
+    monkeypatch.setattr(time, "perf_counter", lambda: 200.0)
+    viz.start(start_time=100.0)
+    assert viz._start == 195.0
+    monkeypatch.setattr(time, "perf_counter", lambda: 197.0)
+    viz._update(0)
+    assert [s.progress for s in viz._segments[:2]] == [1, 1]
+    assert viz._segments[2].progress == 0

--- a/ui/tempo_visualizer.py
+++ b/ui/tempo_visualizer.py
@@ -74,8 +74,22 @@ class TempoVisualizer(BoxLayout):
             self._segments.append(seg)
             self.add_widget(seg)
 
-    def start(self):
-        self._start = time.perf_counter()
+    def start(self, start_time: float | None = None) -> None:
+        """Begin visual playback of the tempo cycle.
+
+        ``start_time`` can optionally be provided to align the visualisation
+        with an external clock (e.g. the sound system). If omitted, the
+        animation starts from the current moment.
+        """
+
+        now = time.perf_counter()
+        if start_time is None:
+            self._start = now
+        else:
+            # ``start_time`` is based on ``time.time()`` so convert it to the
+            # ``perf_counter`` reference to keep progress in sync.
+            self._start = now - (time.time() - start_time)
+
         if self._event:
             self._event.cancel()
         self._event = Clock.schedule_interval(self._update, 1 / 30)


### PR DESCRIPTION
## Summary
- Sync tempo bar with audio by allowing a start time offset
- Display tempo progress on the active workout screen
- Test the tempo visualizer timing alignment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d29d29d083329ce4578843cfb77f