### PR TITLE
Initialize rest screen reference in on_pause to prevent crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -583,6 +583,9 @@ class WorkoutApp(MDApp):
 
     def on_pause(self):
         """Ensure rest timer isn't marked ready when app is backgrounded."""
+        # ``rest_screen`` must always be defined to avoid an ``UnboundLocalError``
+        # when the app is paused on screens other than ``rest``.
+        rest_screen = None
         if self.root and self.root.current == "rest":
             try:
                 rest_screen = self.root.get_screen("rest")


### PR DESCRIPTION
## Summary
- Prevent UnboundLocalError when the app is paused on non-rest screens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5d42824f8833295f2e62a69ee4e67