### PR TITLE
Improve popup layouts for small screens

### DIFF
--- a/main.py
+++ b/main.py
@@ -289,6 +289,8 @@ class EditMetricTypePopup(MDDialog):
         self.metric_name = metric_name
         self.is_user_created = is_user_created
         self.metric = None
+        # Default to nearly full-screen to keep buttons visible on small devices
+        kwargs.setdefault("size_hint", (0.95, 0.95))
         if metric_name:
             for m in screen.all_metrics or []:
                 if (
@@ -444,7 +446,8 @@ class EditMetricTypePopup(MDDialog):
             update_enum_visibility()
             update_enum_filter()
 
-        layout = ScrollView(do_scroll_y=True, size_hint_y=None, height=dp(400))
+        # Fill the dialog space and allow scrolling for compact screens
+        layout = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         info_widgets = []
         if self.metric and not self.is_user_created:
             has_copy = False

--- a/ui/popups.py
+++ b/ui/popups.py
@@ -47,6 +47,8 @@ class AddMetricPopup(MDDialog):
         self.screen = screen
         self.mode = mode
         self.popup_mode = popup_mode
+        # Ensure dialog nearly fills the screen on small devices
+        kwargs.setdefault("size_hint", (0.95, 0.95))
         if self.mode == "session":
             content = MDBoxLayout()
             close_btn = MDRaisedButton(
@@ -88,8 +90,8 @@ class AddMetricPopup(MDDialog):
             item = OneLineListItem(text=m["name"])
             item.bind(on_release=lambda inst, name=m["name"]: self.add_metric(name))
             list_view.add_widget(item)
-
-        scroll = ScrollView(do_scroll_y=True, size_hint_y=None, height=dp(400))
+        # Use full available space and allow scrolling so buttons remain visible
+        scroll = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         scroll.add_widget(list_view)
 
         new_btn = MDRaisedButton(
@@ -224,7 +226,8 @@ class AddMetricPopup(MDDialog):
             update_enum_visibility()
             update_enum_filter()
 
-        layout = ScrollView(do_scroll_y=True, size_hint_y=None, height=dp(400))
+        # Fill dialog area and enable scrolling for small screens
+        layout = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         layout.add_widget(form)
 
         save_btn = MDRaisedButton(text="Save", on_release=self.save_metric)
@@ -354,6 +357,8 @@ class EditMetricPopup(MDDialog):
         self.screen = screen
         self.metric = metric
         self.mode = mode
+        # Ensure dialog uses most of the screen on small devices
+        kwargs.setdefault("size_hint", (0.95, 0.95))
         if self.mode == "session":
             content = MDBoxLayout()
             close_btn = MDRaisedButton(
@@ -531,7 +536,8 @@ class EditMetricPopup(MDDialog):
             )
             update_value_visibility()
 
-        layout = ScrollView(do_scroll_y=True, size_hint_y=None, height=dp(400))
+        # Allow the form to scroll within the dialog and prevent clipping
+        layout = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         layout.add_widget(form)
 
         save_btn = MDRaisedButton(text="Save", on_release=self.save_metric)

--- a/ui/screens/general/edit_preset_screen.py
+++ b/ui/screens/general/edit_preset_screen.py
@@ -840,6 +840,8 @@ class AddPresetMetricPopup(MDDialog):
     def __init__(self, screen: "EditPresetScreen", **kwargs):
         self.screen = screen
         content, buttons = self._build_widgets()
+        # Expand popup to cover most of the screen for better visibility on small devices
+        kwargs.setdefault("size_hint", (0.95, 0.95))
         super().__init__(
             title="Select Metric", type="custom", content_cls=content, buttons=buttons, **kwargs
         )
@@ -866,7 +868,8 @@ class AddPresetMetricPopup(MDDialog):
             item.bind(on_release=lambda inst, name=m["name"]: self.add_metric(name))
             list_view.add_widget(item)
 
-        scroll = ScrollView(do_scroll_y=True, size_hint_y=None, height=dp(400))
+        # Use available space and make list scrollable so action buttons remain on screen
+        scroll = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         scroll.add_widget(list_view)
 
         cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())
@@ -888,6 +891,8 @@ class AddSessionMetricPopup(MDDialog):
     def __init__(self, screen: "EditPresetScreen", **kwargs):
         self.screen = screen
         content, buttons = self._build_widgets()
+        # Ensure dialog is nearly full screen to avoid hidden buttons
+        kwargs.setdefault("size_hint", (0.95, 0.95))
         super().__init__(
             title="Select Metric",
             type="custom",
@@ -918,7 +923,8 @@ class AddSessionMetricPopup(MDDialog):
             item.bind(on_release=lambda inst, name=m["name"]: self.add_metric(name))
             list_view.add_widget(item)
 
-        scroll = ScrollView(do_scroll_y=True, size_hint_y=None, height=dp(400))
+        # Occupy available space and enable scrolling for small displays
+        scroll = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         scroll.add_widget(list_view)
 
         cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())


### PR DESCRIPTION
## Summary
- expand metric popups to nearly full-screen size
- make popup content scrollable so action buttons stay visible
- apply layout fixes across metric and preset popups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d65953b0833298cb0c257445e49e