### PR TITLE
Expand metric popups to fill screen

### DIFF
--- a/main.py
+++ b/main.py
@@ -289,8 +289,11 @@ class EditMetricTypePopup(MDDialog):
         self.metric_name = metric_name
         self.is_user_created = is_user_created
         self.metric = None
-        # Default to nearly full-screen to keep buttons visible on small devices
-        kwargs.setdefault("size_hint", (0.95, 0.95))
+        # Default to nearly full-screen to keep buttons visible on small devices.
+        # ``MDDialog`` does not respect vertical ``size_hint`` values, so specify
+        # the height explicitly to occupy most of the window.
+        kwargs.setdefault("size_hint", (0.95, None))
+        kwargs.setdefault("height", Window.height * 0.9)
         if metric_name:
             for m in screen.all_metrics or []:
                 if (

--- a/ui/popups.py
+++ b/ui/popups.py
@@ -47,8 +47,11 @@ class AddMetricPopup(MDDialog):
         self.screen = screen
         self.mode = mode
         self.popup_mode = popup_mode
-        # Ensure dialog nearly fills the screen on small devices
-        kwargs.setdefault("size_hint", (0.95, 0.95))
+        # Ensure dialog nearly fills the screen on small devices. MDDialog
+        # ignores vertical ``size_hint`` values, so we explicitly set the
+        # height to occupy most of the available window.
+        kwargs.setdefault("size_hint", (0.95, None))
+        kwargs.setdefault("height", Window.height * 0.9)
         if self.mode == "session":
             content = MDBoxLayout()
             close_btn = MDRaisedButton(
@@ -357,8 +360,11 @@ class EditMetricPopup(MDDialog):
         self.screen = screen
         self.metric = metric
         self.mode = mode
-        # Ensure dialog uses most of the screen on small devices
-        kwargs.setdefault("size_hint", (0.95, 0.95))
+        # Ensure dialog uses most of the screen on small devices. ``size_hint_y``
+        # alone has no effect for :class:`MDDialog`, so we also specify the
+        # height directly.
+        kwargs.setdefault("size_hint", (0.95, None))
+        kwargs.setdefault("height", Window.height * 0.9)
         if self.mode == "session":
             content = MDBoxLayout()
             close_btn = MDRaisedButton(


### PR DESCRIPTION
## Summary
- ensure metric selection and editing dialogs occupy 90% of screen height
- adjust metric type editing popup to use explicit height for small screens

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d900eb888332a5864fa4ff65db36