### PR TITLE
Thicken tempo bar on workout screen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -570,7 +570,8 @@ RootUI:
         TempoVisualizer:
             id: tempo_bar
             size_hint_y: None
-            height: dp(8)
+            height: stopwatch.height / 2
+            # Match tempo bar thickness to half the timer's height for better visibility
             opacity: 0
         MDBoxLayout:
             orientation: "horizontal"


### PR DESCRIPTION
## Summary
- Scale tempo bar height to half the stopwatch label for improved visibility on small screens.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5db5ca9ec833282c4df6af177160d