### PR TITLE
Only prompt for session recovery when a session exists

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -80,7 +80,7 @@ def test_home_screen_triggers_recovery(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
-def test_home_screen_no_recovery_shows_info(monkeypatch):
+def test_home_screen_no_recovery_shows_nothing(monkeypatch):
     from ui.screens.general.home_screen import HomeScreen
     from backend.workout_session import WorkoutSession
 
@@ -92,15 +92,15 @@ def test_home_screen_no_recovery_shows_info(monkeypatch):
 
     called = {}
 
-    def fake_dialog(self):
+    def fake_dialog(self, *args):
         called["called"] = True
 
-    monkeypatch.setattr(HomeScreen, "_show_no_session_dialog", fake_dialog)
+    monkeypatch.setattr(HomeScreen, "_show_recovery_dialog", fake_dialog)
 
     screen = HomeScreen()
     screen.on_enter()
 
-    assert called.get("called") is True
+    assert called.get("called") is None
 
 
 def test_rest_screen_toggle_ready_changes_state():

--- a/ui/screens/general/home_screen.py
+++ b/ui/screens/general/home_screen.py
@@ -28,14 +28,13 @@ from backend.workout_session import WorkoutSession
 
 
 class HomeScreen(MDScreen):
-    """Primary screen that always prompts about session recovery."""
+    """Primary screen that offers to recover a previous session if available."""
 
     def on_enter(self, *args):
+        """When entering, prompt to recover a session if one exists."""
         session = WorkoutSession.load_from_recovery()
         if session:
             self._show_recovery_dialog(session)
-        else:
-            self._show_no_session_dialog()
         return super().on_enter(*args)
 
     def _show_recovery_dialog(self, session: WorkoutSession) -> None:
@@ -63,17 +62,6 @@ class HomeScreen(MDScreen):
                 MDFlatButton(text="No", on_release=discard),
                 MDRaisedButton(text="Yes", on_release=recover),
             ],
-        )
-        dialog.open()
-        self._recovery_dialog = dialog
-
-    def _show_no_session_dialog(self) -> None:
-        def close(*_):
-            dialog.dismiss()
-
-        dialog = MDDialog(
-            text="No recovered session found.",
-            buttons=[MDRaisedButton(text="Continue", on_release=close)],
         )
         dialog.open()
         self._recovery_dialog = dialog


### PR DESCRIPTION
## Summary
- Avoid showing an informational popup when no workout session recovery data exists
- Update tests to expect no dialog if there is no recovery session

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5dc7ea13c83328217d01c50823178