### PR TITLE
Reorder tempo visualizer color sequence

### DIFF
--- a/ui/tempo_visualizer.py
+++ b/ui/tempo_visualizer.py
@@ -48,10 +48,10 @@ class TempoVisualizer(BoxLayout):
     tempo = StringProperty("0000")
     colors = ListProperty(
         [
-            [0.2, 0.6, 1, 1],  # concentric
-            [0.2, 1, 0.6, 1],  # pause top
-            [1, 0.6, 0.2, 1],  # eccentric
-            [1, 0.2, 0.2, 1],  # pause bottom
+            [1, 0.2, 0.2, 1],  # concentric
+            [1, 0.6, 0.2, 1],  # pause top
+            [0.2, 0.6, 1, 1],  # eccentric
+            [0.2, 1, 0.6, 1],  # pause bottom
         ]
     )
 


### PR DESCRIPTION
## Summary
- Reordered tempo visualizer color segments to display red, orange, blue, then green

## Testing
- `pytest -q`
- `pytest tests/test_tempo_visualizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5e3d168708332a9821a60068e9b67