### PR TITLE
docs: clarify metric popup layouts

### DIFF
--- a/ui/popups.py
+++ b/ui/popups.py
@@ -81,6 +81,12 @@ class AddMetricPopup(MDDialog):
     # Building widgets for both modes
     # ------------------------------------------------------------------
     def _build_select_widgets(self):
+        """Create the metric selection list for the popup.
+
+        The list's ``minimum_height`` is bound to its ``height`` so the
+        surrounding :class:`ScrollView` can calculate the correct size and
+        display all options.
+        """
         metric_types = metrics.get_all_metric_types()
         existing = {m.get("name") for m in self.screen.exercise_obj.metrics}
         metric_types = [
@@ -109,6 +115,12 @@ class AddMetricPopup(MDDialog):
         return scroll, buttons, "Select Metric"
 
     def _build_new_metric_widgets(self):
+        """Create the form used for defining a new metric.
+
+        Binding the form layout's ``minimum_height`` to its ``height`` prevents
+        the configuration fields from collapsing inside the surrounding
+        :class:`ScrollView`.
+        """
         default_height = dp(48)
         self.input_widgets = {}
 
@@ -141,6 +153,8 @@ class AddMetricPopup(MDDialog):
             ] + [field for field in schema if field["name"] not in METRIC_FIELD_ORDER]
 
         form = MDBoxLayout(orientation="vertical", spacing="8dp", size_hint_y=None)
+        # Bind ``minimum_height`` so the ScrollView knows the form's content
+        # height; otherwise the layout would collapse to zero.
         form.bind(minimum_height=form.setter("height"))
 
         def enable_auto_resize(text_field: MDTextField):


### PR DESCRIPTION
## Summary
- document explicit height usage for `MDDialog` popups
- describe list and form bindings so popups size correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5ea6f213c83328e1398efd7bdd464