### PR TITLE
Handle missing downloads dir during database import

### DIFF
--- a/ui/screens/general/settings_screen.py
+++ b/ui/screens/general/settings_screen.py
@@ -88,7 +88,14 @@ class SettingsScreen(MDScreen):
                 select_path=self.select_import_file,
                 ext=[".db"],
             )
-        self.file_manager.show(str(db_io.get_downloads_dir()))
+        try:
+            # The downloads directory may be unavailable on some platforms.
+            downloads_dir = db_io.get_downloads_dir()
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.error("Downloads directory lookup failed: %s", exc)
+            toast("Import unavailable")
+            return
+        self.file_manager.show(str(downloads_dir))
 
     def close_file_manager(self, *_) -> None:
         """Close the file picker if it is open."""


### PR DESCRIPTION
## Summary
- Handle errors when determining downloads directory for database import
- Notify user and log when imports are unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ece4e7e88332b865b7004e0d64f1