### PR TITLE
feat: add pydroid check for downloads dir

### DIFF
--- a/backend/db_io.py
+++ b/backend/db_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
+import os
 import shutil
 import sqlite3
 import time
@@ -25,22 +26,36 @@ REQUIRED_TABLES = [
 def get_downloads_dir() -> Path:
     """Return a user-accessible Downloads directory.
 
-    On Android we resolve the path to the primary external storage so that
-    exported files appear in the device's shared ``Download`` folder. Storage
-    permissions are requested at runtime. When the Android APIs are not
-    available (e.g. during desktop testing), ``~/Downloads`` is used instead.
+    The function first checks whether the runtime exposes the Android
+    ``PythonActivity`` class or appears to be running inside Pydroid. If
+    either condition is not met, Android-specific permission logic is skipped
+    and ``Path.home() / "Downloads"`` is returned. On a full Android
+    environment the function requests the necessary storage permissions and
+    resolves the path to the system's shared ``Download`` directory.
 
     The directory is created if it does not already exist and a
     :class:`~pathlib.Path` to it is returned.
     """
-    try:
-        # These modules only exist on Android; importing them at runtime keeps
-        # desktop development lightweight.
-        from android.permissions import Permission, request_permissions  # type: ignore
-        from android.storage import primary_external_storage_path  # type: ignore
-    except Exception:
+    android_api_available = True
+    if "PYDROID_HOME" in os.environ:
+        android_api_available = False
+    else:
+        try:
+            # ``PythonActivity`` is provided by python-for-android builds but is
+            # absent in environments like Pydroid. Attempting to access it is a
+            # lightweight way to detect full Android support.
+            from jnius import autoclass  # type: ignore
+
+            autoclass("org.kivy.android.PythonActivity")
+        except Exception:
+            android_api_available = False
+
+    if not android_api_available:
         downloads = Path.home() / "Downloads"
     else:
+        from android.permissions import Permission, request_permissions  # type: ignore
+        from android.storage import primary_external_storage_path  # type: ignore
+
         request_permissions(
             [Permission.READ_EXTERNAL_STORAGE, Permission.WRITE_EXTERNAL_STORAGE]
         )


### PR DESCRIPTION
## Summary
- detect Pydroid or missing PythonActivity and skip Android permission logic
- document fallback to home Downloads when Android APIs unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ece5d0d88332b793479cf595a42a