### PR TITLE
Fix missing value field for editing library metrics

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -476,6 +476,33 @@ def test_edit_metric_popup_no_duplicate_field():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_edit_metric_popup_shows_value_field():
+    """Metrics with library input timing expose the value field."""
+
+    class DummyExercise:
+        metrics = [
+            {
+                "name": "Tempo",
+                "input_timing": "library",
+                "type": "int",
+            }
+        ]
+
+    class DummyScreen:
+        exercise_obj = DummyExercise()
+        previous_screen = "exercise_library"
+
+    metric = DummyScreen.exercise_obj.metrics[0]
+    popup = EditMetricPopup(DummyScreen(), metric, mode="library")
+    children = popup.content_cls.children[0].children
+    value_fields = [
+        c for c in children if getattr(c, "hint_text", "") == "Value"
+    ]
+    assert len(value_fields) == 1
+    popup.dismiss()
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_add_metric_popup_filters_scope(monkeypatch):
     class DummyScreen:
         exercise_obj = type("obj", (), {"metrics": []})()

--- a/ui/popups.py
+++ b/ui/popups.py
@@ -535,6 +535,18 @@ class EditMetricPopup(MDDialog):
         self.enum_values_field.hint_text_font_size = "12sp"
         enable_auto_resize(self.enum_values_field)
 
+        # Text field for a default metric value. It appears only when editing
+        # metrics that request input during library creation, keeping the UI
+        # compact for other contexts.
+        self.value_field = MDTextField(
+            hint_text="Value",
+            size_hint_y=None,
+            height=default_height,
+            multiline=True,
+        )
+        self.value_field.hint_text_font_size = "12sp"
+        enable_auto_resize(self.value_field)
+
         for key, widget in self.input_widgets.items():
             if key not in self.metric:
                 continue


### PR DESCRIPTION
## Summary
- define `value_field` in `EditMetricPopup` so editing library metrics no longer crashes
- cover value field visibility with a unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a69ae22b988332830b2086bb21d9ab