### PR TITLE
Prevent metric edit popup crash when metric value is None

### DIFF
--- a/ui/popups.py
+++ b/ui/popups.py
@@ -607,7 +607,12 @@ class EditMetricPopup(MDDialog):
             if self.enum_values_field.parent is not None:
                 form.remove_widget(self.enum_values_field)
 
-        self.value_field.text = self.metric.get("value", "")
+        # ``MDTextField`` expects a string value. Some metrics store ``None``
+        # for their default, which would raise an ``AttributeError`` when
+        # assigned directly. Convert ``None`` to an empty string to keep the
+        # popup responsive on small devices.
+        value = self.metric.get("value")
+        self.value_field.text = "" if value is None else str(value)
 
         def update_enum_visibility(*args):
             show = self.input_widgets["type"].text == "enum"


### PR DESCRIPTION
## Summary
- Guard metric edit popup from assigning `None` to `MDTextField`
- Add inline explanation for converting `None` values to empty strings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a69e72da108332b021292589a3539e