### PR TITLE
Implement resizable metric split view

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -608,8 +608,6 @@ RootUI:
     metric_values: metric_values
     metric_names_scroll: metric_names_scroll
     metric_values_scroll: metric_values_scroll
-    set_header_scroll: set_header_scroll
-    set_headers: set_headers
     md_bg_color: PURPLE_BG
     BoxLayout:
         orientation: "vertical"
@@ -687,13 +685,11 @@ RootUI:
         BoxLayout:
             orientation: "horizontal"
             size_hint_y: 1
-            BoxLayout:
-                orientation: "vertical"
-                size_hint_x: None
-                width: dp(100)
-                Widget:
-                    size_hint_y: None
-                    height: dp(30)
+            Splitter:
+                id: metric_splitter
+                sizable_from: "right"
+                strip_size: dp(8)
+                min_size: dp(60)
                 ScrollView:
                     id: metric_names_scroll
                     do_scroll_x: False
@@ -705,35 +701,19 @@ RootUI:
                         size_hint_y: None
                         height: self.minimum_height
                         spacing: dp(5)
-            BoxLayout:
-                orientation: "vertical"
-                ScrollView:
-                    id: set_header_scroll
-                    size_hint_y: None
-                    height: dp(30)
-                    do_scroll_x: True
-                    do_scroll_y: False
-                    bar_width: 0
-                    BoxLayout:
-                        id: set_headers
-                        orientation: "horizontal"
-                        size_hint_x: None
-                        width: self.minimum_width
-                        height: dp(30)
-                        spacing: dp(5)
-                ScrollView:
-                    id: metric_values_scroll
-                    do_scroll_x: True
-                    do_scroll_y: True
-                    bar_width: 0
-                    GridLayout:
-                        id: metric_values
-                        size_hint: None, None
-                        cols: 1
-                        row_default_height: dp(40)
-                        height: self.minimum_height
-                        width: self.minimum_width
-                        spacing: dp(5)
+            ScrollView:
+                id: metric_values_scroll
+                do_scroll_x: True
+                do_scroll_y: True
+                bar_width: 0
+                GridLayout:
+                    id: metric_values
+                    size_hint: None, None
+                    cols: 1
+                    row_default_height: dp(40)
+                    height: self.minimum_height
+                    width: self.minimum_width
+                    spacing: dp(5)
         MDRaisedButton:
             size_hint_y: 0.1
             text: "Back"

--- a/ui/row_controller.py
+++ b/ui/row_controller.py
@@ -1,0 +1,66 @@
+"""Utilities for synchronizing row heights across multiple widgets.
+
+The :class:`RowController` maintains a mapping of row indices to
+widgets that should share the same height.  When any registered widget
+changes size, the tallest height for that row is applied to all widgets
+in the row.  This is required for the metric input screen where metric
+names and values live in separate containers but must align perfectly.
+"""
+
+from collections import defaultdict
+from typing import Dict, List, Any
+
+from kivy.clock import Clock
+
+
+class RowController:
+    """Track and apply uniform heights for rows of widgets.
+
+    Widgets register themselves with a row index via :meth:`register`.
+    The controller ensures every widget in the same row always shares the
+    maximum height seen for that row.  Updates are scheduled with
+    ``Clock`` so layout calculations have finished before measurements
+    occur.
+    """
+
+    def __init__(self) -> None:
+        self._heights: Dict[int, float] = {}
+        self._widgets: Dict[int, List[Any]] = defaultdict(list)
+
+    # ------------------------------------------------------------------
+    def register(self, row: int, widget: Any) -> None:
+        """Register *widget* to participate in unified row sizing.
+
+        Parameters
+        ----------
+        row:
+            Row index the widget belongs to.
+        widget:
+            The widget whose ``height`` should match others in the row.
+        """
+
+        self._widgets[row].append(widget)
+        if hasattr(widget, "bind"):
+            widget.bind(height=lambda inst, val: self._update_row(row, val))
+        # Defer initial sizing until after the next frame to ensure the
+        # widget's preferred height is available.
+        initial_height = getattr(widget, "height", 0)
+        Clock.schedule_once(lambda _dt: self._update_row(row, initial_height))
+
+    # ------------------------------------------------------------------
+    def _update_row(self, row: int, height: float) -> None:
+        """Apply ``height`` to all widgets in *row* if it is the maximum."""
+
+        if height <= 0:
+            return
+        if height > self._heights.get(row, 0):
+            self._heights[row] = height
+            for w in self._widgets[row]:
+                w.height = height
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        """Forget all tracked widgets and heights."""
+
+        self._heights.clear()
+        self._widgets.clear()


### PR DESCRIPTION
## Summary
- add `RowController` to keep metric rows aligned between panes
- redesign metric input layout with splitter and in-grid headers
- draw borders around metric cells for clear gridlines

## Testing
- `pytest tests/test_metric_input_screen.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'kivy.app')*
- `pip install kivy` *(fails: Could not find a version that satisfies the requirement kivy)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a0a18ed48332b37d03cbc457ff36