### PR TITLE
Fix SAF permission flags and streamline import/export

### DIFF
--- a/ui/screens/general/settings_screen.py
+++ b/ui/screens/general/settings_screen.py
@@ -16,6 +16,7 @@ except Exception:  # pragma: no cover - minimal stubs for testing
         pass
 
 from kivy.properties import StringProperty
+import json
 import logging
 
 from backend import settings as app_settings
@@ -58,21 +59,14 @@ class SettingsScreen(MDScreen):
             toast(f"Export failed: {exc}")
 
     def export_json(self) -> None:
-        """Export the SQLite database as a JSON file."""
+        """Export the SQLite database as a JSON file via SAF."""
         try:
-            path = db_io.export_database_json()
-            logging.info("Database JSON exported to %s", path)
-            toast(f"Exported to {path}")
-        except FileNotFoundError:
-            logging.exception("JSON export failed: destination missing")
-            toast("Export failed: destination missing")
-        except PermissionError:
-            logging.exception("JSON export failed: permission denied")
-            toast(
-                "Export failed: All files access not granted. "
-                "Please enable 'All files access' for Workout App in system settings."
-            )
-        except OSError as exc:
+            data = db_io.sqlite_to_json(DB_PATH)
+            temp_json = DB_PATH.with_name("workout_export.json")
+            with open(temp_json, "w", encoding="utf-8") as fh:
+                json.dump(data, fh)
+            saf_backup.start_export(temp_json, suggested_name="workout.json")
+        except Exception as exc:
             logging.exception("JSON export failed")
             toast(f"Export failed: {exc}")
 


### PR DESCRIPTION
## Summary
- ensure SAF intents include persistable read/write flags
- persist granted URI permissions returned by SAF
- stream imported data in chunks and migrate JSON export to SAF

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a729611b0c83329149ebc3eb481066