### PR TITLE
Add default return destination for workout history screen

### DIFF
--- a/ui/screens/general/workout_history_screen.py
+++ b/ui/screens/general/workout_history_screen.py
@@ -3,18 +3,29 @@ from datetime import datetime
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.list import TwoLineListItem
 from kivy.app import App
+from kivy.properties import StringProperty
 
 from backend.sessions import get_session_history
 
 
 class WorkoutHistoryScreen(MDScreen):
-    """Screen displaying a list of past workouts."""
+    """Display a list of past workouts and open their details.
+
+    Attributes:
+        return_to (str): Name of the screen to return to when the Back
+            button is pressed. Defaults to ``"home"``.
+    """
+
+    return_to = StringProperty("home")
+    """Name of the screen to return to when leaving the history screen."""
 
     def on_pre_enter(self, *args):
+        """Populate the history list before the screen becomes visible."""
         self.populate()
         return super().on_pre_enter(*args)
 
     def populate(self) -> None:
+        """Fill the history list with previous workout sessions."""
         history = get_session_history()
         lst = self.ids.get("history_list")
         if not lst:
@@ -30,6 +41,11 @@ class WorkoutHistoryScreen(MDScreen):
             lst.add_widget(item)
 
     def open_session(self, started_at: float) -> None:
+        """Open the details screen for the selected session.
+
+        Args:
+            started_at: UNIX timestamp when the session began.
+        """
         app = App.get_running_app()
         screen = app.root.get_screen("view_previous_workout")
         screen.show_session(started_at)


### PR DESCRIPTION
## Summary
- define a `return_to` property on `WorkoutHistoryScreen` so the Back button works without crashing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a73a500534833291ee55a3228463ea