### PR TITLE
chore: bump welcome version to 0.1.1

### DIFF
--- a/main.py
+++ b/main.py
@@ -598,7 +598,7 @@ class WorkoutApp(MDApp):
     # Incremented when a metric type is added or edited
     metric_library_version: int = 0
     # Displayed application version on the welcome screen
-    app_version = StringProperty("1.0.0")
+    app_version = StringProperty("0.1.1")
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)


### PR DESCRIPTION
## Summary
- display app version 0.1.1 on the welcome screen

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a74303b9788332aca00f72e5c7d6c4