### PR TITLE
Refactor metric input screen to single grid

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -604,10 +604,8 @@ RootUI:
 <MetricInputScreen>:
     on_pre_enter: root.on_pre_enter()
     exercise_bar: exercise_bar
-    metric_names: metric_names
-    metric_values: metric_values
-    metric_names_scroll: metric_names_scroll
-    metric_values_scroll: metric_values_scroll
+    metric_grid: metric_grid
+    metric_scroll: metric_scroll
     md_bg_color: PURPLE_BG
     BoxLayout:
         orientation: "vertical"
@@ -682,42 +680,19 @@ RootUI:
                     md_bg_color: root.post_color
                     text_color: 1, 1, 1, 1
                     on_release: root.toggle_filter('post')
-        BoxLayout:
-            orientation: "horizontal"
-            size_hint_y: 1
-            Splitter:
-                id: metric_splitter
-                sizable_from: "right"
-                strip_size: dp(8)
-                min_size: 0
-                size_hint_x: None
-                width: dp(100)
-                ScrollView:
-                    id: metric_names_scroll
-                    size_hint_x: None
-                    width: self.parent.width
-                    do_scroll_x: False
-                    do_scroll_y: True
-                    bar_width: 0
-                    BoxLayout:
-                        id: metric_names
-                        orientation: "vertical"
-                        size_hint_y: None
-                        height: self.minimum_height
-                        spacing: dp(5)
-            ScrollView:
-                id: metric_values_scroll
-                do_scroll_x: True
-                do_scroll_y: True
-                bar_width: 0
-                GridLayout:
-                    id: metric_values
-                    size_hint: None, None
-                    cols: 1
-                    row_default_height: dp(40)
-                    height: self.minimum_height
-                    width: self.minimum_width
-                    spacing: dp(5)
+        ScrollView:
+            id: metric_scroll
+            do_scroll_x: True
+            do_scroll_y: True
+            bar_width: 0
+            GridLayout:
+                id: metric_grid
+                size_hint: None, None
+                cols: 1
+                row_default_height: dp(40)
+                height: self.minimum_height
+                width: self.minimum_width
+                spacing: dp(5)
         MDRaisedButton:
             size_hint_y: 0.1
             text: "Back"

--- a/tests/test_metric_input_screen.py
+++ b/tests/test_metric_input_screen.py
@@ -194,9 +194,7 @@ def test_metric_store_fallback_on_rebuild():
     metric_module.MDApp.get_running_app = classmethod(lambda cls: dummy_app)
 
     screen.session = dummy_session
-    screen.metric_names = _Layout()
-    screen.metric_values = _Layout()
-    screen.set_headers = _Layout()
+    screen.metric_grid = _Layout()
 
     screen.update_metrics()
     screen._on_cell_change("Reps", "int", 0, metric_module.MDTextField(text="5"))


### PR DESCRIPTION
## Summary
- Replace dual metric panes with one scrollable grid
- Introduce GridController to align rows and columns by minimum size
- Update metric input rendering and tests for new layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7bd0191ec8332b809b44ec164ec46