### PR TITLE
Expand dialogs to full-screen overlays

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ from kivymd.uix.list import (
 from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.button import MDIconButton
 from kivymd.uix.card import MDSeparator
-from kivymd.uix.dialog import MDDialog
+from ui.dialogs import FullScreenDialog
 from kivymd.uix.floatlayout import MDFloatLayout
 from kivymd.uix.tab import MDTabsBase
 
@@ -293,7 +293,7 @@ class Tab(MDBoxLayout, MDTabsBase):
     """A basic tab for use with :class:`~kivymd.uix.tab.MDTabs`."""
 
 
-class LoadingDialog(MDDialog):
+class LoadingDialog(FullScreenDialog):
     """Simple dialog displaying a spinner while work is performed."""
 
     def __init__(self, text: str = "Loading...", **kwargs):
@@ -310,7 +310,7 @@ class LoadingDialog(MDDialog):
         super().__init__(type="custom", content_cls=box, **kwargs)
 
 
-class EditMetricTypePopup(MDDialog):
+class EditMetricTypePopup(FullScreenDialog):
     """Popup for editing or creating metric types from the library."""
 
     def __init__(
@@ -324,11 +324,7 @@ class EditMetricTypePopup(MDDialog):
         self.metric_name = metric_name
         self.is_user_created = is_user_created
         self.metric = None
-        # Default to nearly full-screen to keep buttons visible on small devices.
-        # ``MDDialog`` does not respect vertical ``size_hint`` values, so specify
-        # the height explicitly to occupy most of the window.
-        kwargs.setdefault("size_hint", (0.95, None))
-        kwargs.setdefault("height", Window.height * 0.9)
+        # ``FullScreenDialog`` handles full-screen sizing.
         if metric_name:
             for m in screen.all_metrics or []:
                 if (
@@ -339,7 +335,11 @@ class EditMetricTypePopup(MDDialog):
                     break
         content, buttons, title = self._build_widgets()
         super().__init__(
-            title=title, type="custom", content_cls=content, buttons=buttons, **kwargs
+            title=title,
+            type="custom",
+            content_cls=content,
+            buttons=buttons,
+            **kwargs,
         )
 
     def _build_widgets(self):
@@ -486,6 +486,8 @@ class EditMetricTypePopup(MDDialog):
 
         # Fill the dialog space and allow scrolling for compact screens
         layout = ScrollView(do_scroll_y=True, size_hint=(1, 1))
+        # ``FullScreenDialog`` uses this reference to adjust height on open.
+        self._scroll_view = layout
         info_widgets = []
         if self.metric and not self.is_user_created:
             has_copy = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ if importlib.util.find_spec("kivy") is None or importlib.util.find_spec("kivymd"
 
     class RestScreen:
         def confirm_finish(self):
-            dialog = stub.MDDialog()
+            dialog = stub.FullScreenDialog()
             dialog.open()
 
     class DummyDialog:
@@ -27,7 +27,7 @@ if importlib.util.find_spec("kivy") is None or importlib.util.find_spec("kivymd"
             pass
 
     stub.RestScreen = RestScreen
-    stub.MDDialog = DummyDialog
+    stub.FullScreenDialog = DummyDialog
     stub.MDRaisedButton = lambda *a, **k: None
     sys.modules["ui.screens.session.rest_screen"] = stub
     import builtins

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -210,7 +210,7 @@ def test_undo_skip_stays_on_rest(monkeypatch, sample_db):
         def dismiss(self):
             pass
 
-    monkeypatch.setattr(rest_screen_module, "MDDialog", DummyDialog)
+    monkeypatch.setattr(rest_screen_module, "FullScreenDialog", DummyDialog)
     monkeypatch.setattr(rest_screen_module, "MDFlatButton", lambda *a, **k: None)
 
     screen = rest_screen_module.RestScreen()
@@ -268,7 +268,7 @@ def test_confirm_finish_opens_dialog(monkeypatch):
         rest_screen_module = importlib.import_module("ui.screens.session.rest_screen")
     except ModuleNotFoundError:
         pytest.skip("RestScreen module not available")
-    monkeypatch.setattr(rest_screen_module, "MDDialog", DummyDialog)
+    monkeypatch.setattr(rest_screen_module, "FullScreenDialog", DummyDialog)
     monkeypatch.setattr(rest_screen_module, "MDRaisedButton", lambda *a, **k: None)
     if hasattr(rest_screen_module, "MDFlatButton"):
         monkeypatch.setattr(rest_screen_module, "MDFlatButton", lambda *a, **k: None)
@@ -306,7 +306,7 @@ def test_confirm_finish_discard(monkeypatch):
     if not hasattr(rest_screen_module, "MDFlatButton"):
         pytest.skip("RestScreen stub without discard support")
 
-    monkeypatch.setattr(rest_screen_module, "MDDialog", DummyDialog)
+    monkeypatch.setattr(rest_screen_module, "FullScreenDialog", DummyDialog)
     monkeypatch.setattr(rest_screen_module, "MDRaisedButton", dummy_button)
     monkeypatch.setattr(rest_screen_module, "MDFlatButton", dummy_button)
 
@@ -986,7 +986,7 @@ def test_save_exercise_duplicate_name(monkeypatch, tmp_path):
         def open(self_inner):
             opened["value"] = True
 
-    monkeypatch.setattr(sys.modules["main"], "MDDialog", DummyDialog)
+    monkeypatch.setattr(sys.modules["main"], "FullScreenDialog", DummyDialog)
 
     screen.save_exercise()
 

--- a/ui/dialogs.py
+++ b/ui/dialogs.py
@@ -1,0 +1,37 @@
+try:
+    from kivymd.uix.dialog import MDDialog
+    from kivymd.app import MDApp
+    from kivy.core.window import Window
+    from kivy.clock import Clock
+except Exception:  # pragma: no cover - fallback when Kivy isn't available
+    class MDDialog:  # minimal stub
+        def __init__(self, *a, **k):
+            pass
+        def open(self, *a, **k):
+            pass
+        def dismiss(self, *a, **k):
+            pass
+    class FullScreenDialog(MDDialog):
+        """Stub used when Kivy isn't installed."""
+        pass
+else:
+    class FullScreenDialog(MDDialog):
+        """MDDialog that expands to cover the entire window."""
+        def __init__(self, **kwargs):
+            self._scroll_view = getattr(self, "_scroll_view", None)
+            kwargs.setdefault("size_hint", (1, None))
+            kwargs.setdefault("radius", [0, 0, 0, 0])
+            app = MDApp.get_running_app()
+            bg = getattr(getattr(app, "theme_cls", None), "bg_light", (1, 1, 1, 1))
+            kwargs.setdefault("md_bg_color", bg)
+            super().__init__(**kwargs)
+            self.bind(on_open=self._resize_to_window)
+        def _resize_to_window(self, *_):
+            self.width = Window.width
+            self.height = Window.height
+            if self._scroll_view is None:
+                return
+            def _adjust(*_):
+                btn_h = self.ids.button_box.height if "button_box" in self.ids else 0
+                self._scroll_view.height = max(0, Window.height - btn_h)
+            Clock.schedule_once(_adjust, 0)

--- a/ui/popups.py
+++ b/ui/popups.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 from kivymd.app import MDApp
 from kivy.metrics import dp
 from kivy.core.window import Window
-from kivy.clock import Clock
 from kivy.uix.spinner import Spinner
 from kivy.uix.scrollview import ScrollView
-from kivymd.uix.dialog import MDDialog
+from ui.dialogs import FullScreenDialog
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.textfield import MDTextField
 from kivymd.uix.selectioncontrol import MDCheckbox
@@ -35,7 +34,7 @@ METRIC_FIELD_ORDER = [
 ]
 
 
-class AddMetricPopup(MDDialog):
+class AddMetricPopup(FullScreenDialog):
     """Popup dialog for selecting or creating metrics."""
 
     def __init__(
@@ -48,22 +47,8 @@ class AddMetricPopup(MDDialog):
         self.screen = screen
         self.mode = mode
         self.popup_mode = popup_mode
-        # Store a reference to the active ScrollView so it can be resized once
-        # the dialog opens. ``MDDialog`` recalculates its height during
-        # ``open`` which can cause scrollable content to collapse on small
-        # screens. By tracking the ScrollView we can later apply a height that
-        # fills most of the window while leaving room for the action buttons.
+        # Track the active ScrollView so ``FullScreenDialog`` can size it on open.
         self._scroll_view = None
-        # Disable the vertical size hint so the dialog height can be set
-        # explicitly on ``on_open``. Using a full width size hint ensures the
-        # popup occupies the entire screen which prevents long metric lists from
-        # extending beyond the visible area on small devices.
-        kwargs.setdefault("size_hint", (1, None))
-        # Remove rounded corners; otherwise the dialog leaves small gaps at the
-        # screen edges which looks odd for a full-screen overlay.
-        kwargs.setdefault("radius", [0, 0, 0, 0])
-        md_bg = MDApp.get_running_app().theme_cls.bg_light
-        kwargs.setdefault("md_bg_color", md_bg)
         if self.mode == "session":
             content = MDBoxLayout(size_hint=(1, 1))
             close_btn = MDRaisedButton(
@@ -92,10 +77,6 @@ class AddMetricPopup(MDDialog):
             buttons=buttons,
             **kwargs,
         )
-        # Apply final sizing once the dialog is visible. This ensures the
-        # dialog covers the entire screen and the ScrollView consumes all
-        # remaining vertical space.
-        self.bind(on_open=self._apply_dialog_sizing)
 
     # ------------------------------------------------------------------
     # Building widgets for both modes
@@ -120,9 +101,7 @@ class AddMetricPopup(MDDialog):
 
         scroll = ScrollView(do_scroll_y=True, size_hint=(1, None))
         scroll.add_widget(list_view)
-        # Remember the ScrollView so we can adjust its height after the dialog
-        # opens. ``size_hint_y`` is disabled to prevent the view from collapsing
-        # when ``MDDialog`` recalculates its own height.
+        # ``FullScreenDialog`` uses this reference to adjust the height on open.
         self._scroll_view = scroll
 
         new_btn = MDRaisedButton(
@@ -262,7 +241,7 @@ class AddMetricPopup(MDDialog):
         # Make form scrollable so content fits on small screens.
         scroll = ScrollView(do_scroll_y=True, size_hint=(1, None))
         scroll.add_widget(form)
-        # Store reference for later resizing in ``_apply_dialog_sizing``.
+        # ``FullScreenDialog`` uses this reference to adjust the height on open.
         self._scroll_view = scroll
 
         save_btn = MDRaisedButton(text="Save", on_release=self.save_metric)
@@ -270,28 +249,6 @@ class AddMetricPopup(MDDialog):
         buttons = [save_btn, back_btn]
         return scroll, buttons, "New Metric"
 
-    # ------------------------------------------------------------------
-    # Sizing helpers
-    # ------------------------------------------------------------------
-    def _apply_dialog_sizing(self, *_):
-        """Resize the dialog and its scroll view so it covers the entire
-        window. The metric list then occupies all remaining space below the
-        action buttons, preventing content from being clipped on small screens."""
-
-        target = Window.height
-        self.height = target
-        # ``size_hint_x`` is 1 so width follows the window; however MDDialog may
-        # still report a smaller width until it is explicitly set.
-        self.width = Window.width
-        if self._scroll_view is None:
-            return
-
-        def _resize_scroll(*_args):
-            button_height = self.ids.button_box.height if "button_box" in self.ids else 0
-            self._scroll_view.height = max(0, target - button_height)
-
-        # Defer until next frame so ``button_box`` has a valid height.
-        Clock.schedule_once(_resize_scroll, 0)
 
     def _build_choice_widgets(self):
         label = MDLabel(text="Choose an option", halign="center")
@@ -337,7 +294,7 @@ class AddMetricPopup(MDDialog):
                 if dialog:
                     dialog.dismiss()
 
-            dialog = MDDialog(
+            dialog = FullScreenDialog(
                 title="Duplicate Metric",
                 text=f"{name} is already added to this exercise.",
                 buttons=[MDRaisedButton(text="OK", on_release=_close)],
@@ -418,7 +375,7 @@ class AddMetricPopup(MDDialog):
         self.show_metric_list()
 
 
-class EditMetricPopup(MDDialog):
+class EditMetricPopup(FullScreenDialog):
     """Popup for editing an existing metric."""
 
     def __init__(
@@ -431,11 +388,7 @@ class EditMetricPopup(MDDialog):
         self.screen = screen
         self.metric = metric
         self.mode = mode
-        # Ensure dialog uses most of the screen on small devices. ``size_hint_y``
-        # alone has no effect for :class:`MDDialog`, so we also specify the
-        # height directly.
-        kwargs.setdefault("size_hint", (0.95, None))
-        kwargs.setdefault("height", Window.height * 0.9)
+        # ``FullScreenDialog`` handles full-screen sizing.
         if self.mode == "session":
             content = MDBoxLayout()
             close_btn = MDRaisedButton(
@@ -451,7 +404,11 @@ class EditMetricPopup(MDDialog):
             return
         content, buttons, title = self._build_widgets()
         super().__init__(
-            title=title, type="custom", content_cls=content, buttons=buttons, **kwargs
+            title=title,
+            type="custom",
+            content_cls=content,
+            buttons=buttons,
+            **kwargs,
         )
 
     def _build_widgets(self):
@@ -633,6 +590,8 @@ class EditMetricPopup(MDDialog):
         # Allow the form to scroll within the dialog and prevent clipping
         layout = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         layout.add_widget(form)
+        # ``FullScreenDialog`` uses this reference to adjust height on open.
+        self._scroll_view = layout
 
         save_btn = MDRaisedButton(text="Save", on_release=self.save_metric)
         cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())
@@ -800,7 +759,7 @@ class EditMetricPopup(MDDialog):
                 cancel_action()
                 apply_updates()
 
-            dialog = MDDialog(
+            dialog = FullScreenDialog(
                 title="Save Metric",
                 type="custom",
                 content_cls=content,
@@ -929,7 +888,7 @@ class EditMetricPopup(MDDialog):
                     cancel_action()
                     apply_updates()
 
-                dialog = MDDialog(
+                dialog = FullScreenDialog(
                     title="Save Metric",
                     type="custom",
                     content_cls=content,
@@ -1004,7 +963,7 @@ class EditMetricPopup(MDDialog):
                 cancel_action()
                 apply_updates()
 
-            dialog = MDDialog(
+            dialog = FullScreenDialog(
                 title="Save Metric",
                 type="custom",
                 content_cls=content,
@@ -1026,23 +985,20 @@ class EditMetricPopup(MDDialog):
             apply_updates()
 
 
-class PreSessionMetricPopup(MDDialog):
+class PreSessionMetricPopup(FullScreenDialog):
     """Popup for entering pre-session metrics."""
 
     def __init__(self, metrics: list[dict], on_save, **kwargs):
         self.metrics = metrics
         self.on_save = on_save
-        # Match the behaviour of the other metric popups by having the dialog
-        # consume most of the available screen space on small devices. ``size_hint_y``
-        # is ignored by :class:`MDDialog`, and it resets explicit heights during
-        # construction, so height is assigned after initialization.
-        kwargs.setdefault("size_hint", (0.95, None))
+        # ``FullScreenDialog`` handles full-screen sizing.
         content, buttons = self._build_widgets()
         super().__init__(
-            title="Session Metrics", type="custom", content_cls=content, buttons=buttons, **kwargs
-        )
-        Clock.schedule_once(
-            lambda *_: setattr(self, "height", Window.height * 0.9)
+            title="Session Metrics",
+            type="custom",
+            content_cls=content,
+            buttons=buttons,
+            **kwargs,
         )
 
     def _build_widgets(self):
@@ -1056,6 +1012,8 @@ class PreSessionMetricPopup(MDDialog):
             self.metric_list.add_widget(self._create_row(m))
         scroll = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         scroll.add_widget(self.metric_list)
+        # ``FullScreenDialog`` uses this reference to adjust height on open.
+        self._scroll_view = scroll
         save_btn = MDRaisedButton(text="Save", on_release=lambda *_: self._on_save())
         cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *_: self.dismiss())
         return scroll, [save_btn, cancel_btn]

--- a/ui/screens/general/edit_exercise_screen.py
+++ b/ui/screens/general/edit_exercise_screen.py
@@ -21,7 +21,7 @@ from kivymd.uix.list import OneLineListItem, MDList
 from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.button import MDIconButton, MDRaisedButton
 from kivymd.uix.card import MDSeparator
-from kivymd.uix.dialog import MDDialog
+from ui.dialogs import FullScreenDialog
 from kivymd.uix.label import MDIcon
 from ui.popups import AddMetricPopup, EditMetricPopup
 
@@ -111,7 +111,7 @@ class EditExerciseScreen(MDScreen):
                 dialog.dismiss()
             self._navigate_to(new_index)
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             title="Discard Changes?",
             text="You have unsaved changes. Discard them?",
             buttons=[
@@ -269,7 +269,7 @@ class EditExerciseScreen(MDScreen):
             if dialog:
                 dialog.dismiss()
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             title="Remove Metric?",
             text=f"Delete {metric_name}?",
             buttons=[
@@ -339,7 +339,7 @@ class EditExerciseScreen(MDScreen):
             if self.name_field:
                 self.name_field.error = True
             conn.close()
-            dialog = MDDialog(
+            dialog = FullScreenDialog(
                 title="Error",
                 text="Name cannot be empty",
                 buttons=[
@@ -361,7 +361,7 @@ class EditExerciseScreen(MDScreen):
             if self.name_field:
                 self.name_field.error = True
             conn.close()
-            dialog = MDDialog(
+            dialog = FullScreenDialog(
                 title="Error",
                 text="Duplicate name",
                 buttons=[
@@ -475,7 +475,7 @@ class EditExerciseScreen(MDScreen):
                     if err:
                         err.dismiss()
 
-                err = MDDialog(
+                err = FullScreenDialog(
                     title="Save Failed",
                     text=str(exc),
                     buttons=[MDRaisedButton(text="OK", on_release=_dismiss)],
@@ -503,7 +503,7 @@ class EditExerciseScreen(MDScreen):
             )
             content.add_widget(checkbox)
             content.add_widget(label)
-            dialog = MDDialog(
+            dialog = FullScreenDialog(
                 title="Confirm Save",
                 type="custom",
                 text=msg,
@@ -535,7 +535,7 @@ class EditExerciseScreen(MDScreen):
                     )
                     extra_content.add_widget(checkbox)
                     extra_content.add_widget(label)
-            dialog = MDDialog(
+            dialog = FullScreenDialog(
                 title="Confirm Save",
                 type="custom" if extra_content else "simple",
                 text=msg,
@@ -560,7 +560,7 @@ class EditExerciseScreen(MDScreen):
                 if self.manager:
                     self.manager.current = self.previous_screen
 
-            dialog = MDDialog(
+            dialog = FullScreenDialog(
                 title="Discard Changes?",
                 text="You have unsaved changes. Discard them?",
                 buttons=[

--- a/ui/screens/general/edit_preset_screen.py
+++ b/ui/screens/general/edit_preset_screen.py
@@ -22,7 +22,7 @@ from kivymd.uix.label import MDLabel
 from kivymd.uix.list import MDList, OneLineListItem
 from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.button import MDRaisedButton
-from kivymd.uix.dialog import MDDialog
+from ui.dialogs import FullScreenDialog
 import os
 import sqlite3
 
@@ -148,7 +148,7 @@ class SectionWidget(MDBoxLayout):
             if dialog:
                 dialog.dismiss()
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             title="Remove Section?",
             text=f"Delete {self.section_name}?",
             buttons=[
@@ -539,7 +539,7 @@ class EditPresetScreen(MDScreen):
             app.preset_editor.validate()
         except ValueError as exc:
 
-            dialog = MDDialog(
+            dialog = FullScreenDialog(
                 title="Error",
                 text=str(exc),
                 buttons=[
@@ -561,7 +561,7 @@ class EditPresetScreen(MDScreen):
                 if self.manager:
                     self.manager.current = "presets"
             except Exception as err:
-                err_dialog = MDDialog(
+                err_dialog = FullScreenDialog(
                     title="Error",
                     text=str(err),
                     buttons=[
@@ -572,7 +572,7 @@ class EditPresetScreen(MDScreen):
                 )
                 err_dialog.open()
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             title="Confirm Save",
             text=f"Save changes to {app.preset_editor.preset_name}?",
             buttons=[
@@ -600,7 +600,7 @@ class EditPresetScreen(MDScreen):
                     if self.manager:
                         self.manager.current = "presets"
 
-                dialog = MDDialog(
+                dialog = FullScreenDialog(
                     title="Discard Changes?",
                     text="You have unsaved changes. Discard them?",
                     buttons=[
@@ -713,7 +713,7 @@ class SelectedExerciseItem(MDBoxLayout):
             if dialog:
                 dialog.dismiss()
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             title="Remove Exercise?",
             text=f"Delete {self.text} from this workout?",
             buttons=[
@@ -807,7 +807,7 @@ class ExerciseSelectionPanel(MDBoxLayout):
         close_btn = MDRaisedButton(
             text="Close", on_release=lambda *a: self.filter_dialog.dismiss()
         )
-        self.filter_dialog = MDDialog(
+        self.filter_dialog = FullScreenDialog(
             title="Filter Exercises",
             type="custom",
             content_cls=scroll,
@@ -834,16 +834,18 @@ class ExerciseSelectionPanel(MDBoxLayout):
         self.populate_exercises()
 
 
-class AddPresetMetricPopup(MDDialog):
+class AddPresetMetricPopup(FullScreenDialog):
     """Popup for adding preset-level metrics."""
 
     def __init__(self, screen: "EditPresetScreen", **kwargs):
         self.screen = screen
         content, buttons = self._build_widgets()
-        # Expand popup to cover most of the screen for better visibility on small devices
-        kwargs.setdefault("size_hint", (0.95, 0.95))
         super().__init__(
-            title="Select Metric", type="custom", content_cls=content, buttons=buttons, **kwargs
+            title="Select Metric",
+            type="custom",
+            content_cls=content,
+            buttons=buttons,
+            **kwargs,
         )
 
     def _build_widgets(self):
@@ -871,6 +873,8 @@ class AddPresetMetricPopup(MDDialog):
         # Use available space and make list scrollable so action buttons remain on screen
         scroll = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         scroll.add_widget(list_view)
+        # ``FullScreenDialog`` uses this reference to adjust height on open.
+        self._scroll_view = scroll
 
         cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())
         buttons = [cancel_btn]
@@ -885,14 +889,12 @@ class AddPresetMetricPopup(MDDialog):
         self.screen.update_save_enabled()
 
 
-class AddSessionMetricPopup(MDDialog):
+class AddSessionMetricPopup(FullScreenDialog):
     """Popup for adding session-level metrics."""
 
     def __init__(self, screen: "EditPresetScreen", **kwargs):
         self.screen = screen
         content, buttons = self._build_widgets()
-        # Ensure dialog is nearly full screen to avoid hidden buttons
-        kwargs.setdefault("size_hint", (0.95, 0.95))
         super().__init__(
             title="Select Metric",
             type="custom",
@@ -926,6 +928,8 @@ class AddSessionMetricPopup(MDDialog):
         # Occupy available space and enable scrolling for small displays
         scroll = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         scroll.add_widget(list_view)
+        # ``FullScreenDialog`` uses this reference to adjust height on open.
+        self._scroll_view = scroll
 
         cancel_btn = MDRaisedButton(text="Cancel", on_release=lambda *a: self.dismiss())
         buttons = [cancel_btn]

--- a/ui/screens/general/exercise_library.py
+++ b/ui/screens/general/exercise_library.py
@@ -14,7 +14,7 @@ from kivy.properties import (
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.list import MDList, OneLineListItem
 from kivy.uix.scrollview import ScrollView
-from kivymd.uix.dialog import MDDialog
+from ui.dialogs import FullScreenDialog
 from kivymd.uix.button import MDRaisedButton
 
 import os
@@ -198,7 +198,7 @@ class ExerciseLibraryScreen(MDScreen):
         title = (
             "Filter Exercises" if self.current_tab == "exercises" else "Filter Metrics"
         )
-        self.filter_dialog = MDDialog(
+        self.filter_dialog = FullScreenDialog(
             title=title, type="custom", content_cls=scroll, buttons=[close_btn]
         )
         self.filter_dialog.open()
@@ -268,7 +268,7 @@ class ExerciseLibraryScreen(MDScreen):
             if dialog:
                 dialog.dismiss()
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             title="Delete Exercise?",
             text=f"Delete {exercise_name}?",
             buttons=[
@@ -297,7 +297,7 @@ class ExerciseLibraryScreen(MDScreen):
             if dialog:
                 dialog.dismiss()
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             title="Delete Metric?",
             text=f"Delete {metric_name}?",
             buttons=[

--- a/ui/screens/general/home_screen.py
+++ b/ui/screens/general/home_screen.py
@@ -1,13 +1,13 @@
 try:  # pragma: no cover - fallback for environments without Kivy
     from kivymd.app import MDApp
     from kivymd.uix.screen import MDScreen
-    from kivymd.uix.dialog import MDDialog
+    from ui.dialogs import FullScreenDialog
     from kivymd.uix.button import MDFlatButton, MDRaisedButton
 except Exception:  # pragma: no cover - simple stubs
     MDApp = object
     MDScreen = object
 
-    class MDDialog:
+    class FullScreenDialog:
         def __init__(self, *a, **k):
             pass
 
@@ -56,7 +56,7 @@ class HomeScreen(MDScreen):
             session.clear_recovery_files()
             dialog.dismiss()
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             text="Recover previous workout session?",
             buttons=[
                 MDFlatButton(text="No", on_release=discard),

--- a/ui/screens/session/rest_screen.py
+++ b/ui/screens/session/rest_screen.py
@@ -1,7 +1,7 @@
 try:  # pragma: no cover - fallback for environments without Kivy
     from kivymd.app import MDApp
     from kivymd.uix.screen import MDScreen
-    from kivymd.uix.dialog import MDDialog
+    from ui.dialogs import FullScreenDialog
     from kivymd.uix.button import MDFlatButton, MDRaisedButton
     from kivymd.toast import toast
     from kivy.clock import Clock
@@ -15,7 +15,7 @@ except Exception:  # pragma: no cover - simple stubs
     MDApp = object
     MDScreen = object
 
-    class MDDialog:  # minimal placeholder
+    class FullScreenDialog:  # minimal placeholder
         def __init__(self, *a, **k):
             pass
 
@@ -201,7 +201,7 @@ class RestScreen(MDScreen):
             else "Are you sure you want to undo the last set and resume it?"
         )
         if not hasattr(self, "_undo_dialog") or not self._undo_dialog:
-            self._undo_dialog = MDDialog(
+            self._undo_dialog = FullScreenDialog(
                 text=text,
                 buttons=[
                     MDFlatButton(text="Cancel", on_release=lambda *_: self._undo_dialog.dismiss()),
@@ -250,7 +250,7 @@ class RestScreen(MDScreen):
             toast("No next exercise")
             return
         if not hasattr(self, "_skip_dialog") or not self._skip_dialog:
-            self._skip_dialog = MDDialog(
+            self._skip_dialog = FullScreenDialog(
                 text="Skip this exercise and move to the next?",
                 buttons=[
                     MDFlatButton(text="Cancel", on_release=lambda *_: self._skip_dialog.dismiss()),
@@ -315,7 +315,7 @@ class RestScreen(MDScreen):
             if dialog:
                 dialog.dismiss()
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             title="Finish Workout?",
             text="Are you sure you want to finish this workout?",
             buttons=[

--- a/ui/screens/session/workout_active_screen.py
+++ b/ui/screens/session/workout_active_screen.py
@@ -2,7 +2,7 @@ from kivymd.uix.screen import MDScreen
 from kivy.properties import NumericProperty, StringProperty, ObjectProperty
 from kivy.clock import Clock
 from kivymd.app import MDApp
-from kivymd.uix.dialog import MDDialog
+from ui.dialogs import FullScreenDialog
 from kivymd.uix.button import MDFlatButton
 from kivy.core.text import LabelBase
 from kivymd.font_definitions import fonts_path
@@ -100,7 +100,7 @@ class WorkoutActiveScreen(MDScreen):
 
     def show_undo_confirmation(self):
         if not hasattr(self, "_undo_dialog") or not self._undo_dialog:
-            self._undo_dialog = MDDialog(
+            self._undo_dialog = FullScreenDialog(
                 text="Are you sure you want to undo and return to rest?",
                 buttons=[
                     MDFlatButton(text="Cancel", on_release=lambda *_: self._undo_dialog.dismiss()),

--- a/ui/screens/session/workout_summary_screen.py
+++ b/ui/screens/session/workout_summary_screen.py
@@ -2,7 +2,7 @@ from kivymd.app import MDApp
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.list import OneLineListItem
 from kivy.properties import ObjectProperty
-from kivymd.uix.dialog import MDDialog
+from ui.dialogs import FullScreenDialog
 from kivymd.uix.button import MDRaisedButton
 
 from backend.sessions import save_completed_session, validate_workout_session
@@ -49,7 +49,7 @@ class WorkoutSummaryScreen(MDScreen):
         def close_dialog(*_):
             dialog.dismiss()
 
-        dialog = MDDialog(
+        dialog = FullScreenDialog(
             title="Save Error",
             text=message,
             buttons=[MDRaisedButton(text="OK", on_release=close_dialog)],


### PR DESCRIPTION
## Summary
- add reusable `FullScreenDialog` that resizes dialogs to fill the window
- update app and test dialogs to use `FullScreenDialog` for consistent full-screen popups

## Testing
- `python3 -m py_compile main.py tests/conftest.py tests/test_ui.py ui/popups.py ui/screens/general/edit_exercise_screen.py ui/screens/general/edit_preset_screen.py ui/screens/general/exercise_library.py ui/screens/general/home_screen.py ui/screens/session/rest_screen.py ui/screens/session/workout_active_screen.py ui/screens/session/workout_summary_screen.py ui/dialogs.py`
- `pytest` *(fails: command not found, pytest not installed)*
- `python3 -m pip install pytest --break-system-packages` *(fails: Could not find a version that satisfies the requirement pytest; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bddf89e083328050e9ae37471afc