### PR TITLE
feat: add tiny-screen utilities and overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,85 @@ memory usage, and architecture must respect this. If in doubt:
 - Reduce memory usage.
 - Test on the lowest-end device you have.
 
+
+## Tiny-screen additions
+
+Files touched: `tiny_screen.py`, `tiny_overlay.py`, `tiny_dialog.py`, `tiny_perf.py`, `devtool/scrollview_example.py`, `main.py`, `main.kv`, `ui/screens/general/home_screen.py`, `ui/popups.py`.
+
+New flags: `TINY_FORCE_DENSITY`, `TINY_FONT_SCALE`, `TINY_DEVICE_PROFILE`, `TINY_COMPACT_OVERRIDE`, `TINY_OVERLAY`, `TINY_PERF`.
+
+Revert with:
+```
+git restore tiny_screen.py tiny_overlay.py tiny_dialog.py tiny_perf.py devtool/scrollview_example.py main.py main.kv ui/screens/general/home_screen.py ui/popups.py
+```
+
+Exemplar integrations: font scaling in `main.kv`, safe-area padding in `HomeScreen`, dialog safety via `EditMetricPopup`.
+
+### Tiny-Screen Dev Mode
+
+The global compact rule triggers when the **smallest-width (sw)** is
+`min(Window.width, Window.height) / Metrics.density <= 360dp`. The helper
+`tiny_screen.bind_window()` updates `tiny_screen.IS_COMPACT` as the window
+resizes.
+
+#### Environment Flags
+
+Set these before launching the app to emulate different devices:
+
+- `TINY_FORCE_DENSITY` – float to override density/DPI.
+- `TINY_FONT_SCALE` – multiplier for text sizes (1.0–1.3).
+- `TINY_DEVICE_PROFILE` – path to JSON file
+  `{"density":1.5,"fontscale":1.2,"safe_area":{"top":24,"bottom":24}}`.
+- `TINY_COMPACT_OVERRIDE` – `0`/`1`/`auto` to force compact mode.
+- `TINY_OVERLAY` – `1` to show the metrics overlay on start.
+- `TINY_PERF` – `1` to enable performance logging.
+
+#### Device Profiles
+
+Store JSON profiles (e.g. `data/device_profiles/compact_phone.json`) with
+keys `density`, `fontscale`, and `safe_area` (`top`, `bottom`). These are read
+by `tiny_screen.apply_env_overrides()` before Kivy metrics are used.
+
+#### Metrics Overlay
+
+Toggle with `Ctrl+O` or start with `TINY_OVERLAY=1`. The overlay displays
+window size, density, dp/sp pixel conversions, smallest-width, font scale and
+safe-area insets.
+
+#### Compact Mode
+
+Other screens may check `tiny_screen.IS_COMPACT` to swap layouts (e.g.
+icon-only buttons or reduced padding). This supplements existing behaviors
+such as vertical button bars under 400dp.
+
+#### Safe Area and Font Scale
+
+`tiny_screen.apply_safe_area_padding(widget, top=True, bottom=True)` pads a
+widget by the active safe-area values. `tiny_screen.scaled_sp(value)` applies
+the font-scale multiplier before calling `sp`.
+
+#### Performance Logging
+
+Enable `TINY_PERF=1` to log first-frame time and screen switch durations with
+the `TINY-PERF:` prefix.
+
+#### ScrollView Pattern
+
+See `devtool/scrollview_example.py` for the correct `ScrollView` pattern:
+`ScrollView -> child(size_hint_y=None, height=<bind minimum_height>)`.
+
+#### Quick Test Matrix
+
+- Portrait ~320dp with font scale `1.0`, `1.2`, `1.3`
+- Keyboard shown/hidden
+- One dialog exceeding viewport
+- One long list using `ScrollView`
+
+Ensure no content is clipped and tap targets remain 40–48dp.
+
+#### Compatibility Notes
+
+`half_screen` and `HalfScreenWrapper` remain unchanged and can be combined
+with the above environment flags. Existing behaviors like vertical button bars
+under 400dp remain active; `IS_COMPACT` simply provides an additional global
+check.

--- a/devtool/scrollview_example.py
+++ b/devtool/scrollview_example.py
@@ -1,0 +1,16 @@
+"""Reference component demonstrating proper ScrollView usage.
+# TINY-SCREEN: scrollview snippet
+"""
+from kivy.uix.scrollview import ScrollView
+from kivy.uix.boxlayout import BoxLayout
+from kivy.metrics import dp
+
+
+class LongContentExample(ScrollView):
+    def __init__(self, **kwargs):
+        super().__init__(do_scroll_x=False, **kwargs)
+        box = BoxLayout(orientation="vertical", size_hint_y=None, padding=dp(10), spacing=dp(10))
+        box.bind(minimum_height=box.setter("height"))
+        self.add_widget(box)
+        for i in range(20):
+            box.add_widget(BoxLayout(size_hint_y=None, height=dp(40)))

--- a/main.kv
+++ b/main.kv
@@ -3,6 +3,7 @@
 #:import PINK_BG ui.colors.PINK_BG
 #:import PURPLE_BG ui.colors.PURPLE_BG
 #:import TempoVisualizer ui.tempo_visualizer.TempoVisualizer
+#:import scaled_sp tiny_screen.scaled_sp  # TINY-SCREEN: font scaling helper
 RootUI:
     WelcomeScreen:
         name: "welcome"
@@ -46,6 +47,7 @@ RootUI:
     ScrollView:
         do_scroll_x: False
         MDBoxLayout:
+            id: content_box  # TINY-SCREEN: safe-area padding
             orientation: "vertical"
             size_hint_y: None
             height: self.minimum_height
@@ -53,6 +55,7 @@ RootUI:
             padding: "20dp"
             MDLabel:
                 text: "Home"
+                font_size: scaled_sp(20)  # TINY-SCREEN: apply font scale
                 halign: "center"
                 theme_text_color: "Custom"
                 text_color: 0.2, 0.6, 0.86, 1

--- a/main.py
+++ b/main.py
@@ -3,6 +3,8 @@ TESTING = True
 half_screen = False
 import os
 os.environ["KIVY_AUDIO"] = "sdl2"
+import tiny_screen  # TINY-SCREEN: env overrides
+tiny_screen.apply_env_overrides()
 from kivymd.app import MDApp
 from kivy.lang import Builder
 from kivy.clock import Clock
@@ -31,6 +33,8 @@ from kivymd.uix.card import MDSeparator
 from kivymd.uix.dialog import MDDialog
 from kivymd.uix.floatlayout import MDFloatLayout
 from kivymd.uix.tab import MDTabsBase
+from tiny_overlay import enable_overlay, toggle_overlay  # TINY-SCREEN: dev overlay
+from tiny_perf import log_first_paint, perf_timer  # TINY-SCREEN: perf logging
 
 try:
     from kivymd.uix.spinner import MDSpinner
@@ -226,7 +230,8 @@ class HalfScreenWrapper(GridLayout):
         return self._manager.has_screen(name)
 
     def switch_to(self, screen, **options):
-        return self._manager.switch_to(screen, **options)
+        with perf_timer("switch_to"):  # TINY-SCREEN: perf logging
+            return self._manager.switch_to(screen, **options)
 
 
 def apply_half_screen(enabled: bool):
@@ -621,7 +626,12 @@ class WorkoutApp(MDApp):
 
     def build(self):
         root = Builder.load_file(str(Path(__file__).with_name("main.kv")))
+        tiny_screen.bind_window()  # TINY-SCREEN: update compact flag
         Window.bind(on_keyboard=self._on_keyboard)
+        Window.bind(on_key_down=self._dev_key_down)  # TINY-SCREEN: overlay toggle
+        if tiny_screen._OVERLAY_STARTUP:
+            enable_overlay()
+        log_first_paint()  # TINY-SCREEN: perf
         if platform in ("android", "ios"):
             root = HalfScreenWrapper(root)
         Clock.schedule_once(lambda dt: apply_half_screen(half_screen))
@@ -629,6 +639,12 @@ class WorkoutApp(MDApp):
 
     def _on_keyboard(self, window, key, scancode, codepoint, modifiers):
         if key in (27, 1001) and not TESTING:
+            return True
+        return False
+
+    def _dev_key_down(self, window, key, scancode, codepoint, modifiers):
+        if key == ord("o") and "ctrl" in modifiers:
+            toggle_overlay()  # TINY-SCREEN: toggle metrics overlay
             return True
         return False
 

--- a/tiny_dialog.py
+++ b/tiny_dialog.py
@@ -1,0 +1,22 @@
+"""Dialog helpers for safe display on tiny screens.
+# TINY-SCREEN: dialog safety mixin
+"""
+from kivy.core.window import Window
+from kivy.clock import Clock
+from kivy.metrics import dp
+
+from tiny_screen import get_safe_area_insets
+
+
+class SafeDialogMixin:
+    """Mixin to cap dialog height within the visible viewport."""
+
+    def open(self, *a, **k):  # type: ignore[override]
+        super().open(*a, **k)  # type: ignore[misc]
+        Clock.schedule_once(self._enforce_max_height, 0)
+
+    def _enforce_max_height(self, *_):
+        sa = get_safe_area_insets()
+        max_h = Window.height - dp(sa.get("top", 0) + sa.get("bottom", 0))
+        if self.height > max_h:
+            self.height = max_h

--- a/tiny_overlay.py
+++ b/tiny_overlay.py
@@ -1,0 +1,54 @@
+"""Developer metrics overlay to inspect sizing parameters.
+# TINY-SCREEN: overlay widget
+"""
+from kivy.uix.floatlayout import FloatLayout
+from kivy.uix.label import Label
+from kivy.core.window import Window
+from kivy.clock import Clock
+from kivy.metrics import Metrics, dp, sp
+
+from tiny_screen import get_smallest_width_dp, get_safe_area_insets, get_font_scale
+
+
+class TinyOverlay(FloatLayout):
+    def __init__(self, **kwargs):
+        super().__init__(size_hint=(None, None), size=(220, 130), **kwargs)
+        self.label = Label(size=self.size, halign="left", valign="top")
+        self.label.bind(size=self.label.setter("text_size"))
+        self.add_widget(self.label)
+        self.opacity = 0.8
+        self.canvas.opacity = 0.8
+        Window.bind(size=self._reposition)
+        self._reposition()
+        Clock.schedule_interval(self.update, 0.5)
+
+    def _reposition(self, *args):
+        self.pos = (0, Window.height - self.height)
+
+    def update(self, *_):
+        sa = get_safe_area_insets()
+        text = (
+            f"size: {Window.width}x{Window.height}\n"
+            f"dpi: {Window.dpi:.1f} dens:{Metrics.density:.2f}\n"
+            f"dp1:{dp(1):.1f}px sp1:{sp(1):.1f}px\n"
+            f"sw:{get_smallest_width_dp():.0f}dp font:{get_font_scale():.2f}\n"
+            f"safe:{sa}"
+        )
+        self.label.text = text
+
+
+def enable_overlay():
+    if getattr(Window, "_tiny_overlay", None) is None:
+        overlay = TinyOverlay()
+        Window.add_widget(overlay)
+        Window._tiny_overlay = overlay
+    else:
+        Window._tiny_overlay.update()
+
+
+def toggle_overlay(*_):
+    overlay = getattr(Window, "_tiny_overlay", None)
+    if not overlay:
+        enable_overlay()
+        return
+    overlay.opacity = 0 if overlay.opacity else 0.8

--- a/tiny_perf.py
+++ b/tiny_perf.py
@@ -1,0 +1,45 @@
+"""Lightweight performance logging utilities.
+# TINY-SCREEN: perf logging
+"""
+import os
+import time
+from contextlib import contextmanager
+from typing import Callable
+
+from kivy.clock import Clock
+
+ENABLED = bool(os.environ.get("TINY_PERF"))
+
+
+def log_first_paint():
+    if not ENABLED:
+        return
+    start = time.time()
+
+    def _log(*_):
+        dur = (time.time() - start) * 1000
+        print(f"TINY-PERF: first-frame {dur:.1f}ms")
+
+    Clock.schedule_once(_log, 0)
+
+
+@contextmanager
+def perf_timer(label: str):
+    if not ENABLED:
+        yield
+        return
+    start = time.time()
+    try:
+        yield
+    finally:
+        dur = (time.time() - start) * 1000
+        print(f"TINY-PERF: {label} {dur:.1f}ms")
+
+
+def perf_decorator(label: str) -> Callable:
+    def deco(fn: Callable) -> Callable:
+        def wrapper(*a, **k):
+            with perf_timer(label):
+                return fn(*a, **k)
+        return wrapper
+    return deco

--- a/tiny_screen.py
+++ b/tiny_screen.py
@@ -1,0 +1,107 @@
+"""Tiny screen utilities for environment overrides and sizing helpers.
+# TINY-SCREEN: new module for compact mode helpers
+"""
+import os
+import json
+from typing import Dict
+
+from kivy.metrics import Metrics, dp, sp
+from kivy.core.window import Window
+
+# --- Environment flags -----------------------------------------------------
+_FORCE_DENSITY = os.environ.get("TINY_FORCE_DENSITY")
+_FONT_SCALE_ENV = os.environ.get("TINY_FONT_SCALE")
+_DEVICE_PROFILE = os.environ.get("TINY_DEVICE_PROFILE")
+_COMPACT_OVERRIDE = os.environ.get("TINY_COMPACT_OVERRIDE", "auto")
+_OVERLAY_STARTUP = os.environ.get("TINY_OVERLAY") == "1"
+
+SAFE_AREA = {"top": 0.0, "bottom": 0.0}
+_FONT_SCALE = 1.0
+
+
+def apply_env_overrides() -> None:
+    """Apply density/font-scale overrides before other Kivy metrics are used."""
+    global _FONT_SCALE, SAFE_AREA
+    profile = {}
+    if _DEVICE_PROFILE:
+        try:
+            with open(_DEVICE_PROFILE, "r", encoding="utf8") as fh:
+                profile = json.load(fh)
+        except Exception:
+            profile = {}
+    density = None
+    if "density" in profile:
+        density = float(profile["density"])
+    if _FORCE_DENSITY:
+        density = float(_FORCE_DENSITY)
+    if density:
+        Metrics.density = density
+        Metrics.dpi = density * 160
+    if "fontscale" in profile:
+        _FONT_SCALE = float(profile["fontscale"])
+    if _FONT_SCALE_ENV:
+        _FONT_SCALE = float(_FONT_SCALE_ENV)
+    if "safe_area" in profile:
+        SAFE_AREA.update(profile.get("safe_area", {}))
+
+
+def get_font_scale() -> float:
+    return _FONT_SCALE
+
+
+def scaled_sp(value: float) -> float:
+    """Return ``sp`` scaled by the active font scale."""
+    return sp(value * _FONT_SCALE)
+
+
+def get_safe_area_insets() -> Dict[str, float]:
+    """Return safe area insets in dp for top and bottom."""
+    return SAFE_AREA.copy()
+
+
+def apply_safe_area_padding(widget, top: bool = False, bottom: bool = False) -> None:
+    """Add safe-area padding to ``widget`` in-place."""
+    sa = get_safe_area_insets()
+    pad = list(getattr(widget, "padding", (0, 0, 0, 0)))
+    if top:
+        pad[1] += dp(sa.get("top", 0))
+    if bottom:
+        pad[3] += dp(sa.get("bottom", 0))
+    widget.padding = pad
+
+
+def get_smallest_width_dp() -> float:
+    """Compute smallest width in dp for current window."""
+    return min(Window.width, Window.height) / Metrics.density
+
+
+IS_COMPACT = False
+
+
+def _recompute_compact(*_args):
+    global IS_COMPACT
+    if _COMPACT_OVERRIDE == "1":
+        IS_COMPACT = True
+    elif _COMPACT_OVERRIDE == "0":
+        IS_COMPACT = False
+    else:
+        IS_COMPACT = get_smallest_width_dp() <= 360
+
+
+def bind_window() -> None:
+    """Bind window size to recompute compact status."""
+    _recompute_compact()
+    Window.bind(size=_recompute_compact)
+
+
+__all__ = [
+    "apply_env_overrides",
+    "scaled_sp",
+    "get_safe_area_insets",
+    "apply_safe_area_padding",
+    "get_smallest_width_dp",
+    "IS_COMPACT",
+    "bind_window",
+    "get_font_scale",
+    "_OVERLAY_STARTUP",
+]

--- a/ui/popups.py
+++ b/ui/popups.py
@@ -8,6 +8,7 @@ from kivy.clock import Clock
 from kivy.uix.spinner import Spinner
 from kivy.uix.scrollview import ScrollView
 from kivymd.uix.dialog import MDDialog
+from tiny_dialog import SafeDialogMixin  # TINY-SCREEN: dialog safety
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.textfield import MDTextField
 from kivymd.uix.selectioncontrol import MDCheckbox
@@ -418,7 +419,7 @@ class AddMetricPopup(MDDialog):
         self.show_metric_list()
 
 
-class EditMetricPopup(MDDialog):
+class EditMetricPopup(SafeDialogMixin, MDDialog):
     """Popup for editing an existing metric."""
 
     def __init__(

--- a/ui/screens/general/home_screen.py
+++ b/ui/screens/general/home_screen.py
@@ -25,10 +25,15 @@ except Exception:  # pragma: no cover - simple stubs
         pass
 
 from backend.workout_session import WorkoutSession
+from tiny_screen import apply_safe_area_padding  # TINY-SCREEN: safe area
 
 
 class HomeScreen(MDScreen):
     """Primary screen that prompts to resume a recovered session if available."""
+
+    def on_kv_post(self, base_widget):
+        apply_safe_area_padding(self.ids.content_box, top=True, bottom=True)  # TINY-SCREEN: safe area padding
+        return super().on_kv_post(base_widget)
 
     def on_enter(self, *args):
         """Attempt to restore any previous workout session."""


### PR DESCRIPTION
## Summary
- add environment-driven tiny-screen utilities with compact-mode detection and developer overlay
- document tiny-screen dev mode and test matrix in AGENTS while restoring README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7be1bb58c833286419633211094cd