### PR TITLE
Fix Kivy kv import comment parsing

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -3,7 +3,8 @@
 #:import PINK_BG ui.colors.PINK_BG
 #:import PURPLE_BG ui.colors.PURPLE_BG
 #:import TempoVisualizer ui.tempo_visualizer.TempoVisualizer
-#:import scaled_sp tiny_screen.scaled_sp  # TINY-SCREEN: font scaling helper
+# TINY-SCREEN: font scaling helper
+#:import scaled_sp tiny_screen.scaled_sp
 RootUI:
     WelcomeScreen:
         name: "welcome"


### PR DESCRIPTION
## Summary
- separate tiny-screen import comment from `#:import` line to satisfy Kivy parser

## Testing
- `pytest`
- `python - <<'PY' from kivy.lang.builder import Builder; Builder.load_file('main.kv'); print('parse ok') PY` *(fails: ModuleNotFoundError: No module named 'kivy')*
- `pip install kivy` *(fails: Could not find a version that satisfies the requirement kivy)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c2fea0308332952ea05caea2728b