### PR TITLE
Handle MDDialog args in FullScreenDialog

### DIFF
--- a/main.py
+++ b/main.py
@@ -317,7 +317,9 @@ class LoadingDialog(FullScreenDialog):
         spinner.pos_hint = {"center_x": 0.5}
         box.add_widget(spinner)
         box.add_widget(MDLabel(text=text, halign="center"))
-        super().__init__(type="custom", content_cls=box, **kwargs)
+        # ``FullScreenDialog`` ignores the old ``MDDialog`` ``type`` parameter,
+        # so only pass the spinner layout as ``content_cls``.
+        super().__init__(content_cls=box, **kwargs)
 
 
 class EditMetricTypePopup(FullScreenDialog):
@@ -344,9 +346,10 @@ class EditMetricTypePopup(FullScreenDialog):
                     self.metric = m
                     break
         content, buttons, title = self._build_widgets()
+        # ``FullScreenDialog`` supersedes the old ``MDDialog`` interface and
+        # doesn't require a ``type`` argument.
         super().__init__(
             title=title,
-            type="custom",
             content_cls=content,
             buttons=buttons,
             **kwargs,

--- a/ui/dialogs.py
+++ b/ui/dialogs.py
@@ -45,6 +45,10 @@ else:
         ----------
         title:
             Optional title displayed at the top of the screen.
+        text:
+            Optional body text displayed above ``content_cls``. This mirrors
+            the older ``MDDialog`` API so existing call sites can pass a
+            message without constructing a custom widget.
         content_cls:
             Main widget displayed in the body of the screen.
         buttons:
@@ -55,10 +59,15 @@ else:
             self,
             *,
             title: str = "",
+            text: str = "",
             content_cls=None,
             buttons: list | tuple | None = None,
             **kwargs,
         ):
+            # ``MDDialog`` accepted a ``type`` kwarg which is irrelevant for the
+            # simplified ``FullScreenDialog``.  Pop it from ``kwargs`` so Kivy
+            # doesn't raise ``TypeError`` for an unknown property.
+            kwargs.pop("type", None)
             super().__init__(**kwargs)
 
             self.ids = {}
@@ -69,6 +78,19 @@ else:
                 layout.add_widget(
                     MDLabel(
                         text=title,
+                        size_hint_y=None,
+                        height=dp(48),
+                        halign="center",
+                        valign="center",
+                    )
+                )
+
+            if text:
+                # ``MDDialog`` allowed a message via ``text``. Re-create that
+                # behaviour with a lightweight label to minimise widget count.
+                layout.add_widget(
+                    MDLabel(
+                        text=text,
                         size_hint_y=None,
                         height=dp(48),
                         halign="center",


### PR DESCRIPTION
## Summary
- allow FullScreenDialog to accept legacy `text` and ignore `type` keywords
- remove unnecessary `type` usage in LoadingDialog and document FullScreenDialog usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7c3b22cfc83329ce026a4005684ac