### PR TITLE
Fix FullScreenDialog initialization crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -318,7 +318,9 @@ class LoadingDialog(FullScreenDialog):
         spinner.pos_hint = {"center_x": 0.5}
         box.add_widget(spinner)
         box.add_widget(MDLabel(text=text, halign="center"))
-        super().__init__(type="custom", content_cls=box, **kwargs)
+        # ``FullScreenDialog`` accepts only ``content_cls`` and not the legacy
+        # ``type`` keyword.
+        super().__init__(content_cls=box, **kwargs)
 
 
 class EditMetricTypePopup(FullScreenDialog):
@@ -347,7 +349,6 @@ class EditMetricTypePopup(FullScreenDialog):
         content, buttons, title = self._build_widgets()
         super().__init__(
             title=title,
-            type="custom",
             content_cls=content,
             buttons=buttons,
             **kwargs,

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -227,7 +227,8 @@ def test_undo_skip_stays_on_rest(monkeypatch, sample_db):
     monkeypatch.setattr(App, "get_running_app", lambda: dummy_app)
 
     screen.show_undo_confirmation()
-    assert screen._undo_dialog.text == "Undo skipped exercise?"
+    # The dialog now stores its label separately for message updates.
+    assert screen._undo_dialog_label.text == "Undo skipped exercise?"
     screen._perform_undo()
     assert dummy_manager.current == "rest"
     assert session.current_exercise == 0

--- a/ui/dialogs/add_metric_popup.py
+++ b/ui/dialogs/add_metric_popup.py
@@ -303,9 +303,14 @@ class AddMetricPopup(MDScreen):
                 if dialog:
                     dialog.dismiss()
 
+            # ``FullScreenDialog`` expects content widgets rather than a ``text``
+            # keyword; show the message using a centered label.
             dialog = FullScreenDialog(
                 title="Duplicate Metric",
-                text=f"{name} is already added to this exercise.",
+                content_cls=MDLabel(
+                    text=f"{name} is already added to this exercise.",
+                    halign="center",
+                ),
                 buttons=[MDRaisedButton(text="OK", on_release=_close)],
             )
             dialog.open()

--- a/ui/dialogs/edit_metric_popup.py
+++ b/ui/dialogs/edit_metric_popup.py
@@ -470,7 +470,6 @@ class EditMetricPopup(MDScreen):
             from ui.dialogs import FullScreenDialog
             dialog = FullScreenDialog(
                 title="Save Metric",
-                type="custom",
                 content_cls=content,
                 buttons=[
                     MDRaisedButton(text="Cancel", on_release=cancel_action),
@@ -587,7 +586,6 @@ class EditMetricPopup(MDScreen):
                 from ui.dialogs import FullScreenDialog
                 dialog = FullScreenDialog(
                     title="Save Metric",
-                    type="custom",
                     content_cls=content,
                     buttons=[
                         MDRaisedButton(text="Cancel", on_release=cancel_action),
@@ -663,7 +661,6 @@ class EditMetricPopup(MDScreen):
             from ui.dialogs import FullScreenDialog
             dialog = FullScreenDialog(
                 title="Save Metric",
-                type="custom",
                 content_cls=content,
                 buttons=[
                     MDRaisedButton(text="Cancel", on_release=cancel_action),

--- a/ui/screens/general/edit_exercise_screen.py
+++ b/ui/screens/general/edit_exercise_screen.py
@@ -114,7 +114,10 @@ class EditExerciseScreen(MDScreen):
 
         dialog = FullScreenDialog(
             title="Discard Changes?",
-            text="You have unsaved changes. Discard them?",
+            content_cls=MDLabel(
+                text="You have unsaved changes. Discard them?",
+                halign="center",
+            ),
             buttons=[
                 MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
                 MDRaisedButton(text="Discard", on_release=do_nav),
@@ -272,7 +275,10 @@ class EditExerciseScreen(MDScreen):
 
         dialog = FullScreenDialog(
             title="Remove Metric?",
-            text=f"Delete {metric_name}?",
+            content_cls=MDLabel(
+                text=f"Delete {metric_name}?",
+                halign="center",
+            ),
             buttons=[
                 MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
                 MDRaisedButton(text="Delete", on_release=do_delete),
@@ -346,7 +352,7 @@ class EditExerciseScreen(MDScreen):
             conn.close()
             dialog = FullScreenDialog(
                 title="Error",
-                text="Name cannot be empty",
+                content_cls=MDLabel(text="Name cannot be empty", halign="center"),
                 buttons=[
                     MDRaisedButton(text="OK", on_release=lambda *a: dialog.dismiss())
                 ],
@@ -368,7 +374,7 @@ class EditExerciseScreen(MDScreen):
             conn.close()
             dialog = FullScreenDialog(
                 title="Error",
-                text="Duplicate name",
+                content_cls=MDLabel(text="Duplicate name", halign="center"),
                 buttons=[
                     MDRaisedButton(text="OK", on_release=lambda *a: dialog.dismiss())
                 ],
@@ -482,7 +488,7 @@ class EditExerciseScreen(MDScreen):
 
                 err = FullScreenDialog(
                     title="Save Failed",
-                    text=str(exc),
+                    content_cls=MDLabel(text=str(exc), halign="center"),
                     buttons=[MDRaisedButton(text="OK", on_release=_dismiss)],
                 )
                 err.open()
@@ -508,11 +514,17 @@ class EditExerciseScreen(MDScreen):
             )
             content.add_widget(checkbox)
             content.add_widget(label)
+            # Combine message and extra content in a vertical box layout.
+            box = MDBoxLayout(
+                orientation="vertical",
+                spacing=dp(8),
+                size_hint_y=None,
+            )
+            box.add_widget(MDLabel(text=msg, halign="center"))
+            box.add_widget(content)
             dialog = FullScreenDialog(
                 title="Confirm Save",
-                type="custom",
-                text=msg,
-                content_cls=content,
+                content_cls=box,
                 buttons=[
                     MDRaisedButton(
                         text="Cancel", on_release=lambda *a: dialog.dismiss()
@@ -540,11 +552,17 @@ class EditExerciseScreen(MDScreen):
                     )
                     extra_content.add_widget(checkbox)
                     extra_content.add_widget(label)
+            box = MDBoxLayout(
+                orientation="vertical",
+                spacing=dp(8),
+                size_hint_y=None,
+            )
+            box.add_widget(MDLabel(text=msg, halign="center"))
+            if extra_content:
+                box.add_widget(extra_content)
             dialog = FullScreenDialog(
                 title="Confirm Save",
-                type="custom" if extra_content else "simple",
-                text=msg,
-                content_cls=extra_content,
+                content_cls=box,
                 buttons=[
                     MDRaisedButton(
                         text="Cancel", on_release=lambda *a: dialog.dismiss()
@@ -567,7 +585,10 @@ class EditExerciseScreen(MDScreen):
 
             dialog = FullScreenDialog(
                 title="Discard Changes?",
-                text="You have unsaved changes. Discard them?",
+                content_cls=MDLabel(
+                    text="You have unsaved changes. Discard them?",
+                    halign="center",
+                ),
                 buttons=[
                     MDRaisedButton(
                         text="Cancel", on_release=lambda *a: dialog.dismiss()

--- a/ui/screens/general/edit_preset_screen.py
+++ b/ui/screens/general/edit_preset_screen.py
@@ -150,7 +150,10 @@ class SectionWidget(MDBoxLayout):
 
         dialog = FullScreenDialog(
             title="Remove Section?",
-            text=f"Delete {self.section_name}?",
+            content_cls=MDLabel(
+                text=f"Delete {self.section_name}?",
+                halign="center",
+            ),
             buttons=[
                 MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
                 MDRaisedButton(text="Delete", on_release=do_delete),
@@ -541,7 +544,7 @@ class EditPresetScreen(MDScreen):
 
             dialog = FullScreenDialog(
                 title="Error",
-                text=str(exc),
+                content_cls=MDLabel(text=str(exc), halign="center"),
                 buttons=[
                     MDRaisedButton(text="OK", on_release=lambda *a: dialog.dismiss())
                 ],
@@ -563,7 +566,7 @@ class EditPresetScreen(MDScreen):
             except Exception as err:
                 err_dialog = FullScreenDialog(
                     title="Error",
-                    text=str(err),
+                    content_cls=MDLabel(text=str(err), halign="center"),
                     buttons=[
                         MDRaisedButton(
                             text="OK", on_release=lambda *a: err_dialog.dismiss()
@@ -574,7 +577,10 @@ class EditPresetScreen(MDScreen):
 
         dialog = FullScreenDialog(
             title="Confirm Save",
-            text=f"Save changes to {app.preset_editor.preset_name}?",
+            content_cls=MDLabel(
+                text=f"Save changes to {app.preset_editor.preset_name}?",
+                halign="center",
+            ),
             buttons=[
                 MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
                 MDRaisedButton(text="Save", on_release=do_confirm),
@@ -602,7 +608,10 @@ class EditPresetScreen(MDScreen):
 
                 dialog = FullScreenDialog(
                     title="Discard Changes?",
-                    text="You have unsaved changes. Discard them?",
+                    content_cls=MDLabel(
+                        text="You have unsaved changes. Discard them?",
+                        halign="center",
+                    ),
                     buttons=[
                         MDRaisedButton(
                             text="Cancel", on_release=lambda *a: dialog.dismiss()
@@ -715,7 +724,10 @@ class SelectedExerciseItem(MDBoxLayout):
 
         dialog = FullScreenDialog(
             title="Remove Exercise?",
-            text=f"Delete {self.text} from this workout?",
+            content_cls=MDLabel(
+                text=f"Delete {self.text} from this workout?",
+                halign="center",
+            ),
             buttons=[
                 MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
                 MDRaisedButton(text="Delete", on_release=do_delete),
@@ -807,9 +819,9 @@ class ExerciseSelectionPanel(MDBoxLayout):
         close_btn = MDRaisedButton(
             text="Close", on_release=lambda *a: self.filter_dialog.dismiss()
         )
+        # Legacy ``type`` keyword removed; provide just title, content and buttons.
         self.filter_dialog = FullScreenDialog(
             title="Filter Exercises",
-            type="custom",
             content_cls=scroll,
             buttons=[close_btn],
         )
@@ -842,7 +854,6 @@ class AddPresetMetricPopup(FullScreenDialog):
         content, buttons = self._build_widgets()
         super().__init__(
             title="Select Metric",
-            type="custom",
             content_cls=content,
             buttons=buttons,
             **kwargs,
@@ -897,7 +908,6 @@ class AddSessionMetricPopup(FullScreenDialog):
         content, buttons = self._build_widgets()
         super().__init__(
             title="Select Metric",
-            type="custom",
             content_cls=content,
             buttons=buttons,
             **kwargs,

--- a/ui/screens/general/exercise_library.py
+++ b/ui/screens/general/exercise_library.py
@@ -16,6 +16,7 @@ from kivymd.uix.list import MDList, OneLineListItem
 from kivy.uix.scrollview import ScrollView
 from ui.dialogs import FullScreenDialog
 from kivymd.uix.button import MDRaisedButton
+from kivymd.uix.label import MDLabel
 
 import os
 from backend import metrics, exercises
@@ -198,8 +199,9 @@ class ExerciseLibraryScreen(MDScreen):
         title = (
             "Filter Exercises" if self.current_tab == "exercises" else "Filter Metrics"
         )
+        # ``FullScreenDialog`` does not support the legacy ``type`` keyword.
         self.filter_dialog = FullScreenDialog(
-            title=title, type="custom", content_cls=scroll, buttons=[close_btn]
+            title=title, content_cls=scroll, buttons=[close_btn]
         )
         self.filter_dialog.open()
 
@@ -270,7 +272,10 @@ class ExerciseLibraryScreen(MDScreen):
 
         dialog = FullScreenDialog(
             title="Delete Exercise?",
-            text=f"Delete {exercise_name}?",
+            content_cls=MDLabel(
+                text=f"Delete {exercise_name}?",
+                halign="center",
+            ),
             buttons=[
                 MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
                 MDRaisedButton(text="Delete", on_release=do_delete),
@@ -299,7 +304,10 @@ class ExerciseLibraryScreen(MDScreen):
 
         dialog = FullScreenDialog(
             title="Delete Metric?",
-            text=f"Delete {metric_name}?",
+            content_cls=MDLabel(
+                text=f"Delete {metric_name}?",
+                halign="center",
+            ),
             buttons=[
                 MDRaisedButton(text="Cancel", on_release=lambda *a: dialog.dismiss()),
                 MDRaisedButton(text="Delete", on_release=do_delete),

--- a/ui/screens/general/home_screen.py
+++ b/ui/screens/general/home_screen.py
@@ -3,6 +3,7 @@ try:  # pragma: no cover - fallback for environments without Kivy
     from kivymd.uix.screen import MDScreen
     from ui.dialogs import FullScreenDialog
     from kivymd.uix.button import MDFlatButton, MDRaisedButton
+    from kivymd.uix.label import MDLabel
 except Exception:  # pragma: no cover - simple stubs
     MDApp = object
     MDScreen = object
@@ -23,6 +24,10 @@ except Exception:  # pragma: no cover - simple stubs
 
     class MDRaisedButton(MDFlatButton):
         pass
+
+    class MDLabel:
+        def __init__(self, *a, **k):
+            pass
 
 from backend.workout_session import WorkoutSession
 from tiny_screen import apply_safe_area_padding  # TINY-SCREEN: safe area
@@ -61,8 +66,14 @@ class HomeScreen(MDScreen):
             session.clear_recovery_files()
             dialog.dismiss()
 
-        dialog = FullScreenDialog(
+        # ``FullScreenDialog`` no longer accepts a ``text`` keyword; use a
+        # simple label as the dialog's content instead.
+        content = MDLabel(
             text="Recover previous workout session?",
+            halign="center",
+        )
+        dialog = FullScreenDialog(
+            content_cls=content,
             buttons=[
                 MDFlatButton(text="No", on_release=discard),
                 MDRaisedButton(text="Yes", on_release=recover),

--- a/ui/screens/session/rest_screen.py
+++ b/ui/screens/session/rest_screen.py
@@ -3,6 +3,7 @@ try:  # pragma: no cover - fallback for environments without Kivy
     from kivymd.uix.screen import MDScreen
     from ui.dialogs import FullScreenDialog
     from kivymd.uix.button import MDFlatButton, MDRaisedButton
+    from kivymd.uix.label import MDLabel
     from kivymd.toast import toast
     from kivy.clock import Clock
     from kivy.properties import (
@@ -31,6 +32,10 @@ except Exception:  # pragma: no cover - simple stubs
 
     class MDRaisedButton(MDFlatButton):
         pass
+
+    class MDLabel:
+        def __init__(self, *a, **k):
+            pass
 
     class _Clock:
         def schedule_interval(self, *a, **k):
@@ -201,15 +206,20 @@ class RestScreen(MDScreen):
             else "Are you sure you want to undo the last set and resume it?"
         )
         if not hasattr(self, "_undo_dialog") or not self._undo_dialog:
+            label = MDLabel(text=text, halign="center")
+            self._undo_dialog_label = label
             self._undo_dialog = FullScreenDialog(
-                text=text,
+                content_cls=label,
                 buttons=[
-                    MDFlatButton(text="Cancel", on_release=lambda *_: self._undo_dialog.dismiss()),
+                    MDFlatButton(
+                        text="Cancel", on_release=lambda *_: self._undo_dialog.dismiss()
+                    ),
                     MDFlatButton(text="Confirm", on_release=self._perform_undo),
                 ],
             )
         else:
-            self._undo_dialog.text = text
+            # Update message when the dialog is reused.
+            self._undo_dialog_label.text = text
         self._undo_dialog.open()
 
     def _perform_undo(self, *args):
@@ -250,10 +260,16 @@ class RestScreen(MDScreen):
             toast("No next exercise")
             return
         if not hasattr(self, "_skip_dialog") or not self._skip_dialog:
-            self._skip_dialog = FullScreenDialog(
+            content = MDLabel(
                 text="Skip this exercise and move to the next?",
+                halign="center",
+            )
+            self._skip_dialog = FullScreenDialog(
+                content_cls=content,
                 buttons=[
-                    MDFlatButton(text="Cancel", on_release=lambda *_: self._skip_dialog.dismiss()),
+                    MDFlatButton(
+                        text="Cancel", on_release=lambda *_: self._skip_dialog.dismiss()
+                    ),
                     MDFlatButton(text="Confirm", on_release=self._perform_skip),
                 ],
             )
@@ -317,7 +333,10 @@ class RestScreen(MDScreen):
 
         dialog = FullScreenDialog(
             title="Finish Workout?",
-            text="Are you sure you want to finish this workout?",
+            content_cls=MDLabel(
+                text="Are you sure you want to finish this workout?",
+                halign="center",
+            ),
             buttons=[
                 MDRaisedButton(text="Cancel", on_release=lambda *_: dialog.dismiss()),
                 MDFlatButton(text="Discard", on_release=do_discard),

--- a/ui/screens/session/workout_active_screen.py
+++ b/ui/screens/session/workout_active_screen.py
@@ -4,6 +4,7 @@ from kivy.clock import Clock
 from kivymd.app import MDApp
 from ui.dialogs import FullScreenDialog
 from kivymd.uix.button import MDFlatButton
+from kivymd.uix.label import MDLabel
 from kivy.core.text import LabelBase
 from kivymd.font_definitions import fonts_path
 from pathlib import Path
@@ -100,10 +101,17 @@ class WorkoutActiveScreen(MDScreen):
 
     def show_undo_confirmation(self):
         if not hasattr(self, "_undo_dialog") or not self._undo_dialog:
-            self._undo_dialog = FullScreenDialog(
+            content = MDLabel(
                 text="Are you sure you want to undo and return to rest?",
+                halign="center",
+            )
+            self._undo_dialog = FullScreenDialog(
+                content_cls=content,
                 buttons=[
-                    MDFlatButton(text="Cancel", on_release=lambda *_: self._undo_dialog.dismiss()),
+                    MDFlatButton(
+                        text="Cancel",
+                        on_release=lambda *_: self._undo_dialog.dismiss(),
+                    ),
                     MDFlatButton(text="Confirm", on_release=self._perform_undo),
                 ],
             )

--- a/ui/screens/session/workout_summary_screen.py
+++ b/ui/screens/session/workout_summary_screen.py
@@ -4,6 +4,7 @@ from kivymd.uix.list import OneLineListItem
 from kivy.properties import ObjectProperty
 from ui.dialogs import FullScreenDialog
 from kivymd.uix.button import MDRaisedButton
+from kivymd.uix.label import MDLabel
 
 from backend.sessions import save_completed_session, validate_workout_session
 
@@ -51,7 +52,7 @@ class WorkoutSummaryScreen(MDScreen):
 
         dialog = FullScreenDialog(
             title="Save Error",
-            text=message,
+            content_cls=MDLabel(text=message, halign="center"),
             buttons=[MDRaisedButton(text="OK", on_release=close_dialog)],
         )
         dialog.open()


### PR DESCRIPTION
## Summary
- replace deprecated `text` and `type` arguments with explicit content widgets for `FullScreenDialog`
- remove legacy usage of `type="custom"` and `text` across dialogs and screens
- adjust tests for new dialog message handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7d2acd4588332a7f4898b050d4e89