### PR TITLE
Show two decimal slider hints

### DIFF
--- a/tests/test_metric_input_screen.py
+++ b/tests/test_metric_input_screen.py
@@ -163,6 +163,20 @@ def test_on_cell_change_updates_session():
     assert dummy_session.pending[(0, 0)] == {"Reps": 5}
 
 
+def test_slider_hint_updates_with_two_decimals():
+    """Slider widgets should display hint text with two decimal places."""
+    screen = MetricInputScreen()
+    metric_module.MDApp.get_running_app = classmethod(lambda cls: None)
+
+    metric = {"name": "RPE", "type": "slider"}
+    widget = screen._create_input_widget(metric, 0.1, 0)
+    assert widget.hint_text == "0.10"
+
+    # Simulate value change via bound callback
+    widget._binding["value"](widget, 0.567)
+    assert widget.hint_text == "0.57"
+
+
 def test_metric_store_fallback_on_rebuild():
     """Widget should prefill metrics from session.metric_store for unfinished sets."""
     screen = MetricInputScreen()

--- a/ui/screens/session/metric_input_screen.py
+++ b/ui/screens/session/metric_input_screen.py
@@ -361,6 +361,11 @@ class MetricInputScreen(MDScreen):
             scroll.do_scroll_y = True
         return False
 
+    @staticmethod
+    def _update_slider_hint(slider, value):
+        """Update slider hint text to show two decimal places."""
+        slider.hint_text = f"{value:.2f}"
+
     def _on_cell_change(self, name, mtype, set_idx, widget):
         app = MDApp.get_running_app()
         session = getattr(app, "workout_session", None)
@@ -400,15 +405,15 @@ class MetricInputScreen(MDScreen):
         values = metric.get("values", [])
         if mtype == "slider":
             widget = MDSlider(min=0, max=1, value=value or 0)
+            widget.hint = True
+            self._update_slider_hint(widget, widget.value)
+
+            def _value_change(inst, val, name=name, mtype=mtype, set_idx=set_idx):
+                self._update_slider_hint(inst, val)
+                self._on_cell_change(name, mtype, set_idx, inst)
+
             widget.bind(
-                # Capture loop variables to ensure each cell updates correctly
-                value=lambda inst,
-                val,
-                name=name,
-                mtype=mtype,
-                set_idx=set_idx: self._on_cell_change(
-                    name, mtype, set_idx, inst
-                ),
+                value=_value_change,
                 on_touch_down=self.on_slider_touch_down,
                 on_touch_up=self.on_slider_touch_up,
             )


### PR DESCRIPTION
## Summary
- Format slider hint text with two decimal places on the metric input screen
- Test that slider hint updates and preserves precision

## Testing
- `pytest tests/test_metric_input_screen.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7d80856248332aa5772c611392a15