### PR TITLE
Add automatic database backup and restore system

### DIFF
--- a/BACKUP_GUIDE.md
+++ b/BACKUP_GUIDE.md
@@ -1,2 +1,23 @@
-there are 2 back up folders. the one on the top level is for the dev. it contains the backups that the dev makes while making the app
-the one in data/backup is for the app to dynamically use to ensure that if the main workout.db is ever currupt or anything, it would use the backup stored in that direcotry
+# Database Backup Guide
+
+The project uses two different backup locations:
+
+- `backups/` – manual snapshots created by developers during migrations or other maintenance tasks.
+- `data/backup/` – automatic backup used by the app at runtime. It stores a single copy of `workout.db` that is kept up to date.
+
+## Automatic Backup Workflow
+
+A fresh backup is written to `data/backup/workout.db` after each of the following actions:
+
+- saving a metric definition or override
+- saving a user exercise
+- saving a preset
+- completing a workout session
+
+Each backup overwrites the previous one; only the most recent copy is retained. The file is written via a temporary file and atomic rename to avoid corrupting both the live database and the backup.
+
+## Automatic Restore
+
+On startup the app verifies `data/workout.db` with `PRAGMA integrity_check`. If the database is missing or corrupt, the app deletes it and restores the last backup from `data/backup/workout.db`.
+
+These mechanisms ensure a fallback is always available without keeping a long history of backups.

--- a/backend/db_backup.py
+++ b/backend/db_backup.py
@@ -1,0 +1,68 @@
+"""Automatic backup and restoration helpers for the workout database.
+
+The application keeps a single up-to-date copy of ``workout.db`` in
+``data/backup``.  This module exposes utilities to create that backup after
+database mutations and to restore from it if corruption is detected when the
+database is opened.  Copies are performed using a temporary file followed by an
+atomic rename to avoid partial writes.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import sqlite3
+import shutil
+
+# Path to the active database and location for the single backup copy.
+DB_PATH = Path(__file__).resolve().parents[1] / "data" / "workout.db"
+BACKUP_PATH = Path(__file__).resolve().parents[1] / "data" / "backup" / "workout.db"
+
+
+def _atomic_copy(src: Path, dest: Path) -> None:
+    """Copy ``src`` to ``dest`` using a temporary file then rename."""
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(".tmp")
+    shutil.copy2(src, tmp)
+    os.replace(tmp, dest)
+
+
+def create_backup(conn: sqlite3.Connection | None = None) -> None:
+    """Write a fresh backup of the main database.
+
+    Parameters
+    ----------
+    conn:
+        Optional open connection to the source database. If omitted a new
+        connection to :data:`DB_PATH` is created.
+    """
+
+    tmp_backup = BACKUP_PATH.with_suffix(".tmp")
+    if conn is None:
+        with sqlite3.connect(str(DB_PATH)) as src, sqlite3.connect(str(tmp_backup)) as dst:
+            src.backup(dst)
+    else:
+        with sqlite3.connect(str(tmp_backup)) as dst:
+            conn.backup(dst)
+    os.replace(tmp_backup, BACKUP_PATH)
+
+
+def restore_if_corrupt() -> None:
+    """Replace a corrupt main database with the latest backup if available."""
+
+    try:
+        with sqlite3.connect(str(DB_PATH)) as conn:
+            cur = conn.cursor()
+            cur.execute("PRAGMA integrity_check")
+            result = cur.fetchone()
+            if not result or result[0] != "ok":
+                raise sqlite3.DatabaseError("integrity check failed")
+    except Exception:
+        if BACKUP_PATH.exists():
+            if DB_PATH.exists():
+                DB_PATH.unlink()
+            _atomic_copy(BACKUP_PATH, DB_PATH)
+
+
+# Ensure the main database is valid before any other module uses it.
+restore_if_corrupt()

--- a/backend/exercises.py
+++ b/backend/exercises.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from core import DEFAULT_DB_PATH
+from .db_backup import create_backup
 
 if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
     from .exercise import Exercise
@@ -177,6 +178,8 @@ def save_exercise(exercise: "Exercise") -> None:
                 )
 
             conn.commit()
+        # create backup once the transaction succeeds
+        create_backup()
     except sqlite3.Error as exc:  # pragma: no cover - defensive
         raise ValueError(f"Failed to save exercise: {exc}") from exc
 

--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from core import DEFAULT_DB_PATH
 from backend.utils import _to_db_timing, _from_db_timing
+from .db_backup import create_backup
 
 
 def get_metrics_for_exercise(
@@ -410,7 +411,10 @@ def add_metric_type(
         )
         metric_id = cursor.lastrowid
         conn.commit()
-        return metric_id
+    create_backup()
+
+
+    return metric_id
 
 
 def add_metric_to_exercise(
@@ -450,7 +454,7 @@ def add_metric_to_exercise(
                 (exercise_id, metric_id),
             )
             conn.commit()
-
+    create_backup()
 
 def remove_metric_from_exercise(
     exercise_name: str,
@@ -484,8 +488,7 @@ def remove_metric_from_exercise(
             (exercise_id, metric_id),
         )
         conn.commit()
-
-
+    create_backup()
 def update_metric_type(
     metric_type_name: str,
     *,
@@ -543,7 +546,7 @@ def update_metric_type(
                 params,
             )
             conn.commit()
-
+    create_backup()
 
 def set_section_exercise_metric_override(
     preset_name: str,
@@ -646,7 +649,7 @@ def set_section_exercise_metric_override(
                 ),
             )
         conn.commit()
-
+    create_backup()
 
 def set_exercise_metric_override(
     exercise_name: str,
@@ -746,6 +749,7 @@ def set_exercise_metric_override(
                 params,
             )
             conn.commit()
+    create_backup()
 
 
 def delete_metric_type(
@@ -807,7 +811,8 @@ def delete_metric_type(
             (mt_id,),
         )
         conn.commit()
-        return True
+    create_backup()
+    return True
 
 
 def uses_default_metric(

--- a/backend/preset_editor.py
+++ b/backend/preset_editor.py
@@ -9,6 +9,7 @@ from core import (
     DEFAULT_REST_DURATION,
 )
 from backend.utils import _to_db_timing, _from_db_timing
+from .db_backup import create_backup
 
 
 class PresetEditor:
@@ -794,4 +795,5 @@ class PresetEditor:
             )
 
         self.conn.commit()
+        create_backup(self.conn)
         self.mark_saved()

--- a/backend/presets.py
+++ b/backend/presets.py
@@ -5,6 +5,7 @@ import sqlite3
 from pathlib import Path
 
 from backend.exercise import Exercise
+from .db_backup import create_backup
 
 # Default path to the bundled SQLite database (relative to repo root)
 DEFAULT_DB_PATH = Path(__file__).resolve().parents[1] / "data" / "workout.db"
@@ -164,3 +165,5 @@ def apply_exercise_changes_to_presets(
                             ),
                         )
         conn.commit()
+    create_backup()
+

--- a/backend/sessions.py
+++ b/backend/sessions.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 from backend.utils import _to_db_timing
 from core import DEFAULT_DB_PATH
+from .db_backup import create_backup
 
 if TYPE_CHECKING:  # pragma: no cover - for type checkers only
     from backend.workout_session import WorkoutSession
@@ -312,6 +313,8 @@ def save_completed_session(session: "WorkoutSession", db_path: Path | None = Non
                         """,
                         (set_id, metric_id, str(value)),
                     )
+
+    create_backup()
     session.saved = True
     session.clear_recovery_files()
 

--- a/core.py
+++ b/core.py
@@ -8,6 +8,7 @@ import copy
 import json
 
 from backend.utils import _to_db_timing, _from_db_timing
+import backend.db_backup  # ensure database is checked for corruption on startup
 
 # Number of sets each exercise defaults to when starting a workout
 DEFAULT_SETS_PER_EXERCISE = 3


### PR DESCRIPTION
## Summary
- add `backend/db_backup` for atomic database backup and automatic restore
- back up DB after saving metrics, exercises, presets, and sessions
- document backup workflow in BACKUP_GUIDE.md

## Testing
- `pytest` *(fails: CHECK constraint failed: input_timing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e55599d88332a464b0cd2436da05