### PR TITLE
Support default metric values in exercise editor

### DIFF
--- a/backend/workout_session.py
+++ b/backend/workout_session.py
@@ -212,11 +212,11 @@ class WorkoutSession:
         )
         info["exercise_description"] = description
         info["metric_defs"] = metric_defs
-        template = {m["name"]: None for m in metric_defs}
+        template = {m["name"]: m.get("value") for m in metric_defs}
         for set_idx in range(info["sets"]):
             store = self.metric_store.setdefault((index, set_idx), {})
-            for name in template:
-                store.setdefault(name, None)
+            for name, default in template.items():
+                store.setdefault(name, default)
         self._ensure_session_entry(index)
         self.session_data[index]["exercise_info"] = info
         self._exercises[index] = {**info, "results": self.session_data[index]["results"]}

--- a/tests/test_metric_input_screen.py
+++ b/tests/test_metric_input_screen.py
@@ -216,6 +216,46 @@ def test_metric_store_fallback_on_rebuild():
     assert screen.metric_cells[("Reps", 0)].text == "5"
 
 
+def test_metric_defaults_prefilled():
+    """Default metric values should populate widgets and the store."""
+    screen = MetricInputScreen()
+
+    class DummySession:
+        def __init__(self):
+            self.exercises = [
+                {
+                    "name": "Bench",
+                    "sets": 1,
+                    "metric_defs": [
+                        {
+                            "name": "Grip Width",
+                            "type": "str",
+                            "input_timing": "pre_set",
+                            "is_required": True,
+                            "value": "wide",
+                        }
+                    ],
+                    "results": [],
+                }
+            ]
+            self.metric_store = {}
+
+        def set_pre_set_metrics(self, data, ex, st):
+            self.metric_store[(ex, st)] = data
+
+    dummy_session = DummySession()
+    dummy_app = types.SimpleNamespace(workout_session=dummy_session)
+    metric_module.MDApp.get_running_app = classmethod(lambda cls: dummy_app)
+
+    screen.session = dummy_session
+    screen.metric_grid = _Layout()
+
+    screen.update_metrics()
+
+    assert screen.metric_cells[("Grip Width", 0)].text == "wide"
+    assert dummy_session.metric_store[(0, 0)]["Grip Width"] == "wide"
+
+
 def test_save_metrics_records_new_set(monkeypatch):
     """Saving metrics should finalize the recently completed set."""
     screen = MetricInputScreen()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -35,6 +35,7 @@ if kivy_available:
         PresetOverviewScreen,
     )
     from ui.dialogs.edit_metric_popup import EditMetricPopup
+    from ui.dialogs.pre_session_metric_popup import PreSessionMetricPopup
     from ui.dialogs.add_metric_popup import AddMetricPopup
     from ui.expandable_list_item import ExerciseSummaryItem
     import time
@@ -502,6 +503,22 @@ def test_edit_metric_popup_shows_value_field():
     ]
     assert len(value_fields) == 1
     popup.close()
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_pre_session_popup_prefills_defaults():
+    metric = {"name": "Grip", "type": "str", "value": "wide"}
+
+    collected = {}
+
+    def on_save(data):
+        collected.update(data)
+
+    popup = PreSessionMetricPopup([metric], on_save, previous_screen="prev")
+    widget = popup.metric_list.children[0].input_widget
+    assert widget.text == "wide"
+    popup._on_save()
+    assert collected["Grip"] == "wide"
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")

--- a/ui/dialogs/edit_metric_popup.py
+++ b/ui/dialogs/edit_metric_popup.py
@@ -177,7 +177,7 @@ class EditMetricPopup(MDScreen):
         enable_auto_resize(self.enum_values_field)
 
         # Text field for a default metric value. It appears only when editing
-        # metrics that request input during library creation, keeping the UI
+        # metrics that expect input during library creation, keeping the UI
         # compact for other contexts.
         self.value_field = MDTextField(
             hint_text="Value",
@@ -241,14 +241,12 @@ class EditMetricPopup(MDScreen):
             self.enum_values_field.input_filter = _filter
 
         def update_value_visibility(*args):
-            # Value defaults are currently supported only when editing an
-            # exercise from the library. Other contexts will expose this field
-            # in a future iteration.
+            # Expose the value field only when the metric requests a library
+            # time value. This avoids consuming precious screen space on small
+            # devices when the field is irrelevant.
             show = (
-                self.mode == "library"
-                and getattr(self.screen, "previous_screen", "") == "exercise_library"
-                and "input_timing" in self.input_widgets
-                and self.input_widgets["input_timing"].text == "preset"
+                "input_timing" in self.input_widgets
+                and self.input_widgets["input_timing"].text == "library"
             )
             has_parent = self.value_field.parent is not None
             if show and not has_parent:

--- a/ui/dialogs/pre_session_metric_popup.py
+++ b/ui/dialogs/pre_session_metric_popup.py
@@ -115,17 +115,20 @@ class PreSessionMetricPopup(MDScreen):
         row.type = mtype
         row.required = metric.get("is_required", False)
         row.add_widget(MDLabel(text=name, size_hint_x=0.4))
+        default = metric.get("value")
         if mtype == "slider":
-            widget = MDSlider(min=0, max=1, value=0)
+            widget = MDSlider(min=0, max=1, value=default or 0)
         elif mtype == "enum":
-            widget = Spinner(text=values[0] if values else "", values=values)
+            text = default if default not in (None, "") else (values[0] if values else "")
+            widget = Spinner(text=text, values=values)
         else:
             input_filter = None
             if mtype == "int":
                 input_filter = "int"
             elif mtype == "float":
                 input_filter = "float"
-            widget = MDTextField(multiline=False, input_filter=input_filter)
+            text = "" if default in (None, "") else str(default)
+            widget = MDTextField(multiline=False, input_filter=input_filter, text=text)
         row.input_widget = widget
         row.add_widget(widget)
         return row

--- a/ui/screens/session/metric_input_screen.py
+++ b/ui/screens/session/metric_input_screen.py
@@ -323,7 +323,7 @@ class MetricInputScreen(MDScreen):
             self.metric_grid.add_widget(name_lbl)
             self.grid_controller.register(row, 0, name_lbl)
             for s in range(set_count):
-                store = self.session.metric_store.get((self.exercise_idx, s), {})
+                store = self.session.metric_store.setdefault((self.exercise_idx, s), {})
                 value = None
                 if s < len(results):
                     value = results[s].get("metrics", {}).get(name)
@@ -331,6 +331,11 @@ class MetricInputScreen(MDScreen):
                     # Fallback to pre-set metrics stored in metric_store so
                     # previously entered values for unfinished sets reappear.
                     value = store.get(name)
+                    if value in (None, ""):
+                        default = metric.get("value")
+                        if default not in (None, ""):
+                            value = default
+                            store[name] = default
                 widget = self._create_input_widget(metric, value, s)
                 self.metric_cells[(name, s)] = widget
                 self.metric_grid.add_widget(widget)


### PR DESCRIPTION
## Summary
- show a Value field when metric timing is set to "library"
- pre-fill metric inputs across session and preset flows using default values
- exercise defaults now saved in the workout session store

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7eaa48d408332b38cd454460e3178