### PR TITLE
Prefer predefined metrics by default

### DIFF
--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -27,7 +27,8 @@ def get_metrics_for_exercise(
 
         if is_user_created is None:
             cursor.execute(
-                "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0 ORDER BY is_user_created DESC LIMIT 1",
+                # Prefer predefined exercises before user-created variants.
+                "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0 ORDER BY is_user_created ASC LIMIT 1",
                 (exercise_name,),
             )
         else:
@@ -507,7 +508,8 @@ def update_metric_type(
         cursor = conn.cursor()
         if is_user_created is None:
             cursor.execute(
-                "SELECT id FROM library_metric_types WHERE name = ? AND deleted = 0 ORDER BY is_user_created DESC LIMIT 1",
+                # Prefer predefined metric types before user-created variants.
+                "SELECT id FROM library_metric_types WHERE name = ? AND deleted = 0 ORDER BY is_user_created ASC LIMIT 1",
                 (metric_type_name,),
             )
         else:
@@ -667,7 +669,7 @@ def set_exercise_metric_override(
     """Apply an override for ``metric_type_name`` for a specific exercise.
 
     ``is_user_created`` selects between predefined and user-created copies of
-    the exercise.  If ``None`` (the default), the user-created variant will be
+    the exercise.  If ``None`` (the default), the predefined variant will be
     chosen when it exists.
     """
 
@@ -676,7 +678,8 @@ def set_exercise_metric_override(
 
         if is_user_created is None:
             cursor.execute(
-                "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0 ORDER BY is_user_created DESC LIMIT 1",
+                # Prefer predefined exercises before user-created variants.
+                "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0 ORDER BY is_user_created ASC LIMIT 1",
                 (exercise_name,),
             )
         else:
@@ -828,7 +831,8 @@ def uses_default_metric(
         cursor = conn.cursor()
         if is_user_created is None:
             cursor.execute(
-                "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0 ORDER BY is_user_created DESC LIMIT 1",
+                # Prefer predefined exercises before user-created variants.
+                "SELECT id FROM library_exercises WHERE name = ? AND deleted = 0 ORDER BY is_user_created ASC LIMIT 1",
                 (exercise_name,),
             )
         else:

--- a/tests/test_enum_values.py
+++ b/tests/test_enum_values.py
@@ -31,4 +31,13 @@ def test_enum_values_default_and_override(sample_db: Path) -> None:
 
     metrics_bench2 = metrics.get_metrics_for_exercise("Bench Press", db_path=sample_db)
     vals_bench2 = next(m["values"] for m in metrics_bench2 if m["name"] == "Machine")
-    assert vals_bench2 == ["A"]
+    assert vals_bench2 == ["A", "B"]
+
+    # The override lives on the user-created variant.
+    metrics_bench_override = metrics.get_metrics_for_exercise(
+        "Bench Press", db_path=sample_db, is_user_created=True
+    )
+    vals_bench_override = next(
+        m["values"] for m in metrics_bench_override if m["name"] == "Machine"
+    )
+    assert vals_bench_override == ["A"]


### PR DESCRIPTION
## Summary
- Default to built-in metric types and exercises before user-created variants
- Update enum values test to reflect new metric precedence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7efeaff8c833286b733dc1cf773aa