### PR TITLE
Prevent repeated pre-session metric popup

### DIFF
--- a/main.py
+++ b/main.py
@@ -816,7 +816,26 @@ class PresetOverviewScreen(MDScreen):
     def start_workout(self):
         app = MDApp.get_running_app()
         preset_name = app.selected_preset
+
+        # Start the workout session so exercise data is available, then
+        # determine whether any session-scoped metrics need to be collected
+        # before the workout begins.  These "pre_session" metrics should be
+        # prompted only once per session.
         app.start_workout(preset_name)
+
+        if not app.pre_session_metrics_done:
+            metrics = [
+                m
+                for m in core.get_all_metric_types()
+                if m.get("scope") == "session" and m.get("input_timing") == "pre_session"
+            ]
+            if metrics and self.manager:
+                screen = self.manager.get_screen("metric_input")
+                screen.populate_metrics(metrics)
+                app.pre_session_metrics_done = True
+                self.manager.current = "metric_input"
+                return
+
         if self.manager:
             self.manager.current = "rest"
 
@@ -3072,6 +3091,10 @@ class WorkoutApp(MDApp):
     editing_exercise_index: int = -1
     # True when metrics being entered correspond to a newly completed set
     record_new_set = False
+    # Tracks whether pre-session metrics have been collected for the
+    # currently active workout.  This prevents repeatedly showing the
+    # metric input popup when navigating between screens.
+    pre_session_metrics_done: bool = False
     # Incremented whenever an exercise is added, edited or deleted
     exercise_library_version: int = 0
     # Incremented when a metric type is added or edited
@@ -3112,8 +3135,12 @@ class WorkoutApp(MDApp):
         else:
             self.workout_session = None
 
-        # ensure metric input doesn't accidentally advance sets
+        # Reset session-level flags whenever a new workout starts.
+        # ``record_new_set`` prevents metric entry from advancing a set
+        # prematurely and ``pre_session_metrics_done`` ensures any
+        # pre-session metric dialog appears at most once.
         self.record_new_set = False
+        self.pre_session_metrics_done = False
 
     def mark_set_complete(self):
         if self.workout_session:


### PR DESCRIPTION
## Summary
- ensure pre-session metrics are requested only once per workout
- reset session flags when starting a new workout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f10fa790833290a723068cb462f1