### PR TITLE
Display predefined metrics first in library

### DIFF
--- a/ui/screens/general/exercise_library.py
+++ b/ui/screens/general/exercise_library.py
@@ -177,11 +177,11 @@ class ExerciseLibraryScreen(MDScreen):
         if self.metric_search_text:
             s = self.metric_search_text.lower()
             metrics = [m for m in metrics if s in m["name"].lower()]
-        # Sort metrics so that user-created types appear first and each group
-        # is ordered alphabetically. ``not m['is_user_created']`` ensures
-        # user metrics sort before the premade ones.
+        # Sort metrics so that predefined types appear first and each group
+        # is ordered alphabetically. ``m['is_user_created']`` places
+        # user-created metrics after the predefined ones.
         metrics = sorted(
-            metrics, key=lambda m: (not m["is_user_created"], m["name"].lower())
+            metrics, key=lambda m: (m["is_user_created"], m["name"].lower())
         )
         data = []
         for m in metrics:


### PR DESCRIPTION
## Summary
- Reverse metric tab sorting so predefined metrics appear before user-created metrics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7f4b59a6c8332b72964a4a18443f6