### PR TITLE
Format Metric Input sliders with two decimal places

### DIFF
--- a/tests/test_metric_input_screen.py
+++ b/tests/test_metric_input_screen.py
@@ -57,8 +57,14 @@ class _TextField(_DummyWidget):
 class _Slider(_DummyWidget):
     def __init__(self, value=0, **kwargs):
         self.value = value
+        self.hint = False
+        self.hint_text = ""
+
     def bind(self, **kwargs):
         self._binding = kwargs
+
+    def on_value(self, instance, value):
+        self.value = value
 
 class _Spinner(_DummyWidget):
     def __init__(self, text="", values=()):
@@ -172,8 +178,8 @@ def test_slider_hint_updates_with_two_decimals():
     widget = screen._create_input_widget(metric, 0.1, 0)
     assert widget.hint_text == "0.10"
 
-    # Simulate value change via bound callback
-    widget._binding["value"](widget, 0.567)
+    # Simulate value change
+    widget.on_value(widget, 0.567)
     assert widget.hint_text == "0.57"
 
 

--- a/ui/screens/session/metric_input_screen.py
+++ b/ui/screens/session/metric_input_screen.py
@@ -17,6 +17,20 @@ from kivymd.uix.button import MDFlatButton
 from ui.row_controller import GridController
 
 
+class MetricSlider(MDSlider):
+    """Slider showing its value with two decimal places."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        # Ensure initial hint text reflects current value.
+        self.hint_text = f"{self.value:.2f}"
+
+    def on_value(self, instance, value):
+        """Update the bubble hint when the value changes."""
+        super().on_value(instance, value)
+        self.hint_text = f"{value:.2f}"
+
+
 class MetricInputScreen(MDScreen):
     """Screen for entering workout metrics with navigation and filtering."""
 
@@ -366,11 +380,6 @@ class MetricInputScreen(MDScreen):
             scroll.do_scroll_y = True
         return False
 
-    @staticmethod
-    def _update_slider_hint(slider, value):
-        """Update slider hint text to show two decimal places."""
-        slider.hint_text = f"{value:.2f}"
-
     def _on_cell_change(self, name, mtype, set_idx, widget):
         app = MDApp.get_running_app()
         session = getattr(app, "workout_session", None)
@@ -409,12 +418,10 @@ class MetricInputScreen(MDScreen):
         mtype = metric.get("type", "str")
         values = metric.get("values", [])
         if mtype == "slider":
-            widget = MDSlider(min=0, max=1, value=value or 0)
+            widget = MetricSlider(min=0, max=1, value=value or 0)
             widget.hint = True
-            self._update_slider_hint(widget, widget.value)
 
             def _value_change(inst, val, name=name, mtype=mtype, set_idx=set_idx):
-                self._update_slider_hint(inst, val)
                 self._on_cell_change(name, mtype, set_idx, inst)
 
             widget.bind(


### PR DESCRIPTION
## Summary
- add `MetricSlider` subclass to show value bubbles with two decimal places on Metric Input screen
- adjust Metric Input Screen to use `MetricSlider` and keep change local to that screen
- extend tests with slider stub and updated assertions for decimal formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f6ce2cec8332bc1d35b0750fae50