### PR TITLE
Display MetricSlider values with two decimals

### DIFF
--- a/ui/screens/session/metric_input_screen.py
+++ b/ui/screens/session/metric_input_screen.py
@@ -26,8 +26,7 @@ class MetricSlider(MDSlider):
         self.hint_text = f"{self.value:.2f}"
 
     def on_value(self, instance, value):
-        """Update the bubble hint when the value changes."""
-        super().on_value(instance, value)
+        """Display the current value in the hint bubble with two decimals."""
         self.hint_text = f"{value:.2f}"
 
 


### PR DESCRIPTION
## Summary
- Simplified `MetricSlider.on_value` to update the hint bubble directly with two-decimal precision

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a84fc3c3e48332af06c23bc15e6a1f