### PR TITLE
Fix export naming and JSON export flow

### DIFF
--- a/tests/test_export_flow.py
+++ b/tests/test_export_flow.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from backend import db_io
 from backend import export_utils
+import json
+import sqlite3
 
 
 def test_make_export_name(monkeypatch):
@@ -31,4 +33,27 @@ def test_export_database_auto_name(tmp_path, monkeypatch):
     assert exported.name == "workout_2025_08_22_14__37__05.db"
     assert exported.exists()
     assert exported.parent == dest_dir
+
+
+def test_export_database_json_auto_name(tmp_path, monkeypatch):
+    class FixedDatetime(export_utils.datetime):  # type: ignore
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2025, 8, 22, 14, 37, 5)
+
+    monkeypatch.setattr(export_utils, "datetime", FixedDatetime)
+
+    src = tmp_path / "source.db"
+    with sqlite3.connect(src) as conn:
+        conn.execute("CREATE TABLE test(id INTEGER)")
+        conn.execute("INSERT INTO test(id) VALUES (1)")
+    dest_dir = tmp_path / "dest"
+    dest_dir.mkdir()
+
+    exported = db_io.export_database_json(db_path=src, dest_dir=dest_dir)
+    assert exported.name == "workout_2025_08_22_14__37__05.json"
+    assert exported.exists()
+    with exported.open() as fh:
+        data = json.load(fh)
+    assert data == {"test": [{"id": 1}]}
 

--- a/ui/screens/general/settings_screen.py
+++ b/ui/screens/general/settings_screen.py
@@ -16,7 +16,6 @@ except Exception:  # pragma: no cover - minimal stubs for testing
         pass
 
 from kivy.properties import StringProperty
-import json
 import logging
 
 from backend import settings as app_settings
@@ -53,7 +52,8 @@ class SettingsScreen(MDScreen):
     def export_db(self) -> None:
         """Launch Android's 'Save as' picker to export the database."""
         try:
-            saf_backup.start_export(DB_PATH)
+            temp_db = db_io.export_database(db_path=DB_PATH, dest_dir=DB_PATH.parent)
+            saf_backup.start_export(temp_db)
         except Exception as exc:
             logging.exception("Database export failed")
             toast(f"Export failed: {exc}")
@@ -61,10 +61,7 @@ class SettingsScreen(MDScreen):
     def export_json(self) -> None:
         """Export the SQLite database as a JSON file via SAF."""
         try:
-            data = db_io.sqlite_to_json(DB_PATH)
-            temp_json = DB_PATH.with_name("workout_export.json")
-            with open(temp_json, "w", encoding="utf-8") as fh:
-                json.dump(data, fh)
+            temp_json = db_io.export_database_json(db_path=DB_PATH, dest_dir=DB_PATH.parent)
             saf_backup.start_export(temp_json)
         except Exception as exc:
             logging.exception("JSON export failed")


### PR DESCRIPTION
## Summary
- ensure database exports use timestamped copies and JSON exports use the generic sqlite-to-JSON helper
- preserve provided filename during SAF export and clean up temporary files
- add tests covering JSON export naming and content

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a854165ed88332a7e4a80ce004b471