### PR TITLE
Fix metric input field initialization

### DIFF
--- a/ui/screens/session/metric_input_screen.py
+++ b/ui/screens/session/metric_input_screen.py
@@ -499,7 +499,6 @@ class MetricInputScreen(MDScreen):
             widget = MDTextField(
                 multiline=False,
                 input_filter=input_filter,
-                text=str(value) if value not in (None, "") else "",
             )
             widget.bind(
                 text=lambda inst,
@@ -508,6 +507,10 @@ class MetricInputScreen(MDScreen):
                 mtype=mtype,
                 set_idx=set_idx: self._on_cell_change(name, mtype, set_idx, inst)
             )
+            # ``MDTextField`` text is assigned after initialization to mirror
+            # the pattern in ``EditMetricPopup`` and avoid constructor-side
+            # quirks on small devices.
+            widget.text = "" if value in (None, "") else str(value)
         widget.size_hint = (None, None)
         widget.height = dp(40)
         widget.width = dp(100)  # Increased for easier data entry on small screens.


### PR DESCRIPTION
## Summary
- Avoid passing initial text into MDTextField during metric input widget creation
- Assign initial text after binding to mimic EditMetricPopup pattern and improve reliability on small devices

## Testing
- `pytest -q`
- ⚠️ `python main.py` (missing Kivy dependency)


------
https://chatgpt.com/codex/tasks/task_e_68a85f927cc48332b4a359a6b5b1e63e