### PR TITLE
Align metric grid columns to largest widget

### DIFF
--- a/tests/test_row_controller.py
+++ b/tests/test_row_controller.py
@@ -1,0 +1,73 @@
+"""Tests for :mod:`ui.row_controller` enforcing column width behaviour."""
+
+import types
+import sys
+from importlib import util
+from pathlib import Path
+
+
+def _import_grid_controller():
+    """Import :class:`GridController` with stubbed Kivy dependencies."""
+
+    kivy = types.ModuleType("kivy")
+    kivy_clock = types.ModuleType("kivy.clock")
+
+    def schedule_once(func, *args, **kwargs):
+        func(0)
+        return types.SimpleNamespace(cancel=lambda: None)
+
+    kivy_clock.Clock = types.SimpleNamespace(schedule_once=schedule_once)
+    sys.modules["kivy"] = kivy
+    sys.modules["kivy.clock"] = kivy_clock
+
+    spec = util.spec_from_file_location(
+        "row_controller", Path(__file__).resolve().parents[1] / "ui" / "row_controller.py"
+    )
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # Clean up stubs so other tests remain unaffected.
+    sys.modules.pop("kivy.clock", None)
+    sys.modules.pop("kivy", None)
+    return module.GridController
+
+
+class DummyWidget:
+    """Minimal stand-in for Kivy widgets used in tests."""
+
+    def __init__(self, width=0, height=0):
+        self.width = width
+        self.height = height
+        self._width_cb = None
+        self._height_cb = None
+
+    def bind(self, **kwargs):
+        self._width_cb = kwargs.get("width")
+        self._height_cb = kwargs.get("height")
+
+    def set_width(self, value):
+        self.width = value
+        if self._width_cb:
+            self._width_cb(self, value)
+
+    def set_height(self, value):
+        self.height = value
+        if self._height_cb:
+            self._height_cb(self, value)
+
+
+def test_column_width_matches_largest_widget():
+    GridController = _import_grid_controller()
+    controller = GridController()
+
+    w1 = DummyWidget(width=50, height=20)
+    w2 = DummyWidget(width=80, height=20)
+
+    controller.register(0, 0, w1)
+    controller.register(1, 0, w2)
+
+    assert w1.width == 80 and w2.width == 80
+
+    w1.set_width(120)
+    assert w1.width == 120 and w2.width == 120
+

--- a/ui/row_controller.py
+++ b/ui/row_controller.py
@@ -5,9 +5,9 @@ input screen now renders a single grid where both rows and columns must
 align.  This module therefore provides :class:`GridController` which
 normalises row heights and column widths simultaneously.  Every widget in
 the same row shares the *minimum* height observed for that row and every
-widget in the same column shares the *minimum* width observed for that
-column.  Using the minimum keeps the layout compact on the small screens
-targeted by the application.
+widget in the same column shares the *maximum* width observed for that
+column.  Using the largest width ensures cells align cleanly without
+clipping while rows remain compact for small screens.
 """
 
 from collections import defaultdict
@@ -21,7 +21,7 @@ class GridController:
 
     Widgets register with a ``row`` and ``col`` index via :meth:`register`.
     When a widget's size changes the controller recomputes the minimum
-    height for that row and the minimum width for that column, applying
+    height for that row and the maximum width for that column, applying
     those dimensions to all widgets in the same row or column.  Updates
     are scheduled with :class:`~kivy.clock.Clock` so the widget's natural
     size is available before measurements occur.
@@ -74,16 +74,16 @@ class GridController:
 
     # ------------------------------------------------------------------
     def _update_col(self, col: int) -> None:
-        """Apply the minimum width of column *col* to all its widgets."""
+        """Apply the maximum width of column *col* to all its widgets."""
 
         widths = [getattr(w, "width", 0) for w in self._cols[col] if getattr(w, "width", 0) > 0]
         if not widths:
             return
-        min_width = min(widths)
-        if min_width != self._col_widths.get(col):
-            self._col_widths[col] = min_width
+        max_width = max(widths)
+        if max_width != self._col_widths.get(col):
+            self._col_widths[col] = max_width
             for w in self._cols[col]:
-                w.width = min_width
+                w.width = max_width
 
     # ------------------------------------------------------------------
     def _update(self, row: int, col: int) -> None:


### PR DESCRIPTION
## Summary
- ensure GridController applies the widest widget width to each column
- cover column-width behaviour with a dedicated unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a85f69d9088332848a4185972f438a