### PR TITLE
Align metric grid columns to widest widget

### DIFF
--- a/tests/test_row_controller.py
+++ b/tests/test_row_controller.py
@@ -1,0 +1,53 @@
+"""Tests for the GridController sizing behaviour."""
+
+from importlib.machinery import ModuleSpec
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+
+# ---------------------------------------------------------------------------
+# Provide minimal Kivy Clock stub so GridController can be imported without
+# the real Kivy dependency. ``schedule_once`` executes callbacks immediately
+# to keep tests synchronous.
+clock_mod = types.ModuleType("kivy.clock")
+clock_mod.Clock = types.SimpleNamespace(schedule_once=lambda func, _dt=0: func(0))
+clock_mod.__spec__ = ModuleSpec("kivy.clock", loader=None)
+sys.modules["kivy.clock"] = clock_mod
+sys.modules["kivy"] = types.ModuleType("kivy")
+
+# Import GridController from the project.
+spec = importlib.util.spec_from_file_location(
+    "row_controller", Path(__file__).resolve().parents[1] / "ui" / "row_controller.py"
+)
+row_controller = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(row_controller)
+GridController = row_controller.GridController
+
+# Clean up stubs so they don't leak into other tests.
+sys.modules.pop("kivy.clock", None)
+sys.modules.pop("kivy", None)
+
+
+def test_column_width_expands_to_largest_widget():
+    """Column width should match the widest widget registered."""
+
+    class Widget:
+        def __init__(self, width: float):
+            self.width = width
+            self.height = 10
+
+        def bind(self, **kwargs):
+            # GridController hooks into size changes; binding support is
+            # recorded but unused in this lightweight test widget.
+            self._bindings = kwargs
+
+    gc = GridController()
+    w1 = Widget(50)
+    w2 = Widget(120)
+    gc.register(0, 0, w1)
+    gc.register(1, 0, w2)
+
+    assert w1.width == 120
+    assert w2.width == 120

--- a/ui/row_controller.py
+++ b/ui/row_controller.py
@@ -4,10 +4,11 @@ The original implementation only synchronised row heights.  The metric
 input screen now renders a single grid where both rows and columns must
 align.  This module therefore provides :class:`GridController` which
 normalises row heights and column widths simultaneously.  Every widget in
-the same row shares the *minimum* height observed for that row and every
-widget in the same column shares the *minimum* width observed for that
-column.  Using the minimum keeps the layout compact on the small screens
-targeted by the application.
+the same row shares the *minimum* height observed for that row while
+widgets in the same column expand to match the *maximum* width observed in
+that column.  Using the minimum for height preserves vertical compactness
+on small screens, whereas taking the maximum width ensures columns are wide
+enough for their largest widget.
 """
 
 from collections import defaultdict
@@ -21,7 +22,7 @@ class GridController:
 
     Widgets register with a ``row`` and ``col`` index via :meth:`register`.
     When a widget's size changes the controller recomputes the minimum
-    height for that row and the minimum width for that column, applying
+    height for that row and the maximum width for that column, applying
     those dimensions to all widgets in the same row or column.  Updates
     are scheduled with :class:`~kivy.clock.Clock` so the widget's natural
     size is available before measurements occur.
@@ -74,16 +75,16 @@ class GridController:
 
     # ------------------------------------------------------------------
     def _update_col(self, col: int) -> None:
-        """Apply the minimum width of column *col* to all its widgets."""
+        """Apply the maximum width of column *col* to all its widgets."""
 
         widths = [getattr(w, "width", 0) for w in self._cols[col] if getattr(w, "width", 0) > 0]
         if not widths:
             return
-        min_width = min(widths)
-        if min_width != self._col_widths.get(col):
-            self._col_widths[col] = min_width
+        max_width = max(widths)
+        if max_width != self._col_widths.get(col):
+            self._col_widths[col] = max_width
             for w in self._cols[col]:
-                w.width = min_width
+                w.width = max_width
 
     # ------------------------------------------------------------------
     def _update(self, row: int, col: int) -> None:

--- a/ui/screens/session/metric_input_screen.py
+++ b/ui/screens/session/metric_input_screen.py
@@ -76,7 +76,9 @@ class MetricInputScreen(MDScreen):
         self.metric_grid = None
         self.metric_scroll = None
         self.metric_cells = {}
-        # Controller keeping cells aligned within the grid.
+        # Controller keeping cells aligned within the grid. It equalises row
+        # heights and expands columns to match the widest widget in each
+        # column so inputs and labels line up neatly on narrow screens.
         self.grid_controller = GridController()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- expand GridController so each column matches the widest widget
- document column sizing on MetricInputScreen
- add unit test for GridController column width behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a85f7ade4c83328a310cc71652c910