### PR TITLE
Enable adding metrics in EditExerciseScreen

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -1166,17 +1166,17 @@ RootUI:
             Screen:
                 name: "metrics"
                 FloatLayout:
-                ScrollView:
-                    MDList:
-                        id: metrics_list
-                MDFloatingActionButton:
-                    icon: "plus"
-                    md_bg_color: app.theme_cls.primary_color
-                    pos_hint: {"center_x": 0.5, "y": 0.02}
-                    tooltip_text: "Add Metric"
-                    opacity: 1 if root.mode != "session" else 0
-                    disabled: root.mode == "session"
-                    on_release: root.open_add_metric_popup()
+                    ScrollView:
+                        MDList:
+                            id: metrics_list
+                    MDFloatingActionButton:
+                        icon: "plus"
+                        md_bg_color: app.theme_cls.primary_color
+                        pos_hint: {"center_x": 0.5, "y": 0.02}
+                        tooltip_text: "Add Metric"
+                        opacity: 1 if root.mode != "session" else 0
+                        disabled: root.mode == "session"
+                        on_release: root.open_add_metric_popup()
             Screen:
                 name: "details"
                 ScrollView:


### PR DESCRIPTION
## Summary
- Restructure metrics tab layout so added metrics appear in list
- Test that adding a metric populates the EditExerciseScreen metrics list

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8939803208332ac3b3fd003c29578