### PR TITLE
Remove new metric option from exercise metric selection

### DIFF
--- a/ui/dialogs/add_metric_popup.py
+++ b/ui/dialogs/add_metric_popup.py
@@ -127,9 +127,9 @@ class AddMetricPopup(MDScreen):
             list_view.add_widget(item)
         scroll = ScrollView(do_scroll_y=True, size_hint=(1, 1))
         scroll.add_widget(list_view)
-        new_btn = MDRaisedButton(text="New Metric", on_release=self.show_new_metric_form)
+        # Only allow selecting existing metrics; creation is handled elsewhere.
         cancel_btn = MDRaisedButton(text="Cancel", on_release=self.close)
-        return scroll, [new_btn, cancel_btn], "Select Metric"
+        return scroll, [cancel_btn], "Select Metric"
 
     def _build_new_metric_widgets(self):
         default_height = dp(48)


### PR DESCRIPTION
## Summary
- Disable creating new metrics from the metric selection dialog by removing the "New Metric" button

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a893f83d00833293d9633a8ea01fb2