### PR TITLE
Revamp welcome screen layout

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -730,7 +730,7 @@ RootUI:
     md_bg_color: PINK_BG
     BoxLayout:
         orientation: "vertical"
-        spacing: "10dp"
+        spacing: 0
         padding: "20dp"
         MDLabel:
             text: app.app_version
@@ -738,15 +738,31 @@ RootUI:
             theme_text_color: "Custom"
             text_color: 0.5, 0.5, 0.5, 1
             font_style: "Caption"
-            adaptive_height: True
-        MDLabel:
-            text: "Welcome - start your fitness journey"
-            halign: "center"
-            theme_text_color: "Custom"
-            text_color: 0.2, 0.6, 0.86, 1
-        MDRaisedButton:
-            text: "Enter"
-            on_release: app.root.current = "home"
+            size_hint_y: 0.1
+        ScrollView:
+            size_hint_y: 0.7
+            do_scroll_x: False
+            MDBoxLayout:
+                orientation: "vertical"
+                size_hint_y: None
+                height: self.minimum_height
+                padding: "10dp"
+                MDTextField:
+                    id: welcome_message
+                    text: root.message
+                    hint_text: "Welcome message"
+                    multiline: True
+                    mode: "rectangle"
+                    size_hint_y: None
+                    height: self.minimum_height
+                    on_text: root.message = self.text
+        AnchorLayout:
+            size_hint_y: 0.2
+            anchor_x: "center"
+            anchor_y: "center"
+            MDRaisedButton:
+                text: "Enter"
+                on_release: app.root.current = "home"
 
 <SectionWidget>:
     orientation: "vertical"

--- a/ui/screens/general/welcome_screen.py
+++ b/ui/screens/general/welcome_screen.py
@@ -1,10 +1,27 @@
+"""Implementation of the app's welcome screen.
+
+The welcome screen is intentionally lightweight. It shows the application
+version, allows editing of a short welcome message and provides an "Enter"
+button to proceed to the main application.  The layout is defined in the
+``main.kv`` file.
+"""
+
 try:  # pragma: no cover - fallback for environments without Kivy
     from kivymd.uix.screen import MDScreen
+    from kivy.properties import StringProperty
 except Exception:  # pragma: no cover - simple stubs
     MDScreen = object
+
+    class StringProperty:  # type: ignore
+        """Fallback stand-in used when Kivy is unavailable."""
+
+        def __init__(self, default: str = ""):
+            self.default = default
 
 
 class WelcomeScreen(MDScreen):
     """Initial screen displayed when the app starts."""
 
-    pass
+    #: Editable message shown in the welcome screen's text box.
+    message = StringProperty("Welcome - start your fitness journey")
+


### PR DESCRIPTION
## Summary
- Restructure WelcomeScreen layout with version label, editable message area, and centered entry button
- Add configurable message property and detailed documentation for the WelcomeScreen

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4767d70c88332a3fe01ff02302c4a