### PR TITLE
Use instant transitions across screen managers

### DIFF
--- a/devtool/color.py
+++ b/devtool/color.py
@@ -1,7 +1,7 @@
 # App to visualize and test color palettes for the Workout app
 
 from kivymd.app import MDApp
-from kivy.uix.screenmanager import ScreenManager
+from kivy.uix.screenmanager import ScreenManager, NoTransition
 from kivymd.uix.screen import MDScreen
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.button import MDRaisedButton, MDFlatButton, MDIconButton
@@ -291,7 +291,8 @@ class ColorApp(MDApp):
 
     def build(self):
         self.theme_cls.theme_style = "Light"
-        manager = ScreenManager()
+        # Use NoTransition for instant screen switching while previewing colors
+        manager = ScreenManager(transition=NoTransition())
 
         self.edit_screen = EditColorsScreen(name="edit")
         self.edit_screen.build()

--- a/main.kv
+++ b/main.kv
@@ -6,6 +6,7 @@
 # TINY-SCREEN: font scaling helper
 #:import scaled_sp tiny_screen.scaled_sp
 RootUI:
+    transition: NoTransition()  # Use instant transitions for screen changes
     WelcomeScreen:
         name: "welcome"
     HomeScreen:


### PR DESCRIPTION
## Summary
- Switch root ScreenManager to NoTransition for instantaneous navigation
- Update dev color tool to use NoTransition for instant screen switching

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b476adf21c833285cbe5e873c19586