### PR TITLE
Handle missing metric definitions in MetricInputScreen

### DIFF
--- a/tests/test_metric_input_screen.py
+++ b/tests/test_metric_input_screen.py
@@ -154,6 +154,29 @@ def test_metrics_sorted_by_required_and_timing():
     assert [m["name"] for m in visible] == ["A", "B", "C", "D"]
 
 
+def test_update_metrics_handles_missing_defs():
+    screen = MetricInputScreen()
+
+    class DummySession:
+        def __init__(self):
+            self.exercises = [
+                {"name": "Bench", "sets": 1, "metric_defs": None, "results": []}
+            ]
+            self.metric_store = {}
+
+    dummy_session = DummySession()
+    dummy_app = types.SimpleNamespace(workout_session=dummy_session)
+    metric_module.MDApp.get_running_app = classmethod(lambda cls: dummy_app)
+
+    screen.session = dummy_session
+    screen.metrics_list = _Layout()
+
+    screen.update_metrics()
+
+    assert screen.metric_cells == {}
+    assert len(screen.metrics_list) == 0
+
+
 def test_on_cell_change_updates_session():
     screen = MetricInputScreen()
 

--- a/ui/screens/session/metric_input_screen.py
+++ b/ui/screens/session/metric_input_screen.py
@@ -124,6 +124,8 @@ class MetricInputScreen(MDScreen):
 
     def _apply_filters(self, metrics):
         """Return metrics sorted in display order."""
+        if not metrics:
+            return []
         return sorted(metrics, key=self._sort_key)
 
     def update_metrics(self):
@@ -135,7 +137,7 @@ class MetricInputScreen(MDScreen):
             return
 
         exercise = self.session.exercises[self.exercise_idx]
-        metrics = self._apply_filters(exercise.get("metric_defs", []))
+        metrics = self._apply_filters(exercise.get("metric_defs") or [])
         results = exercise.get("results", [])
         store = self.session.metric_store.get((self.exercise_idx, self.set_idx), {})
 


### PR DESCRIPTION
## Summary
- Avoid crashes when selecting exercises without metric definitions by treating missing metrics as empty lists
- Test MetricInputScreen with absent metric definitions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5917849d48332a3905a4ac03bced7