### PR TITLE
Persist pre-session metric inputs

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -522,6 +522,33 @@ def test_pre_session_popup_prefills_defaults():
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_pre_session_popup_null_and_save():
+    metrics_defs = [
+        {"name": "Mood", "type": "str"},
+        {"name": "Style", "type": "enum", "values": ["wide", "narrow"]},
+        {"name": "Energy", "type": "slider"},
+    ]
+
+    collected = {}
+
+    popup = PreSessionMetricPopup(metrics_defs, lambda d: collected.update(d), previous_screen="prev")
+    valid, data = popup._collect()
+    assert valid and data == {"Mood": None, "Style": None, "Energy": None}
+
+    for row in popup.metric_list.children:
+        if row.metric_name == "Mood":
+            row.input_widget.text = "great"
+        elif row.metric_name == "Style":
+            row.input_widget.text = "wide"
+        elif row.metric_name == "Energy":
+            row.input_widget.value = 0.5
+            row.value_entered = True
+
+    popup._on_save()
+    assert collected == {"Mood": "great", "Style": "wide", "Energy": 0.5}
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_add_metric_popup_filters_scope(monkeypatch):
     class DummyScreen:
         exercise_obj = type("obj", (), {"metrics": []})()
@@ -1018,6 +1045,50 @@ def test_pre_session_metrics_prompt_before_start(monkeypatch):
     assert dummy_app.workout_session.data == {"M1": 5}
     assert len(popup_calls) == 1
     assert screen.manager.current == "rest"
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_open_metric_popup_prefills_previous(monkeypatch):
+    from kivy.lang import Builder
+    from pathlib import Path
+
+    Builder.load_file(str(Path(__file__).resolve().parents[1] / "main.kv"))
+
+    class DummyList:
+        def clear_widgets(self):
+            pass
+
+        def add_widget(self, widget):
+            pass
+
+    screen = PresetOverviewScreen()
+    screen.details_list = DummyList()
+    screen.workout_list = DummyList()
+
+    app = type("A", (), {"selected_preset": "Test"})()
+    monkeypatch.setattr(App, "get_running_app", lambda: app)
+    monkeypatch.setattr(
+        metrics,
+        "get_metrics_for_preset",
+        lambda name: [{"name": "M1", "input_timing": "pre_session"}],
+    )
+
+    captured = []
+
+    class DummyPopup:
+        def __init__(self, metrics, callback, previous_screen, **kwargs):
+            captured.extend(metrics)
+
+        def open(self):
+            pass
+
+    monkeypatch.setattr(
+        "ui.dialogs.pre_session_metric_popup.PreSessionMetricPopup", DummyPopup
+    )
+
+    screen._pre_session_metric_data = {"M1": 5}
+    screen.open_metric_popup()
+    assert captured and captured[0]["value"] == 5
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")

--- a/ui/dialogs/pre_session_metric_popup.py
+++ b/ui/dialogs/pre_session_metric_popup.py
@@ -117,10 +117,14 @@ class PreSessionMetricPopup(MDScreen):
         row.add_widget(MDLabel(text=name, size_hint_x=0.4))
         default = metric.get("value")
         if mtype == "slider":
-            widget = MDSlider(min=0, max=1, value=default or 0)
+            widget = MDSlider(min=0, max=1, value=default if default is not None else 0)
+            row.value_entered = default is not None
+            widget.bind(on_touch_up=lambda *_: setattr(row, "value_entered", True))
         elif mtype == "enum":
-            text = default if default not in (None, "") else (values[0] if values else "")
+            text = "" if default in (None, "") else str(default)
             widget = Spinner(text=text, values=values)
+            row.value_entered = default not in (None, "")
+            widget.bind(text=lambda *_: setattr(row, "value_entered", True))
         else:
             input_filter = None
             if mtype == "int":
@@ -175,10 +179,15 @@ class PreSessionMetricPopup(MDScreen):
                 else:
                     value = text
             elif isinstance(widget, MDSlider):
-                value = float(widget.value)
+                if getattr(row, "value_entered", False):
+                    value = float(widget.value)
+                elif required:
+                    valid = False
+                    continue
             elif isinstance(widget, Spinner):
-                value = widget.text
-                if required and value == "":
+                if getattr(row, "value_entered", False):
+                    value = widget.text
+                elif required:
                     valid = False
                     continue
             data[name] = value

--- a/ui/screens/general/preset_overview_screen.py
+++ b/ui/screens/general/preset_overview_screen.py
@@ -103,6 +103,10 @@ class PresetOverviewScreen(MDScreen):
         preset_name = app.selected_preset
         metric_defs = metrics.get_metrics_for_preset(preset_name)
         pre_metrics = [m for m in metric_defs if m.get("input_timing") == "pre_session"]
+        if self._pre_session_metric_data:
+            for m in pre_metrics:
+                if m["name"] in self._pre_session_metric_data:
+                    m["value"] = self._pre_session_metric_data[m["name"]]
         if pre_metrics:
             popup = PreSessionMetricPopup(
                 pre_metrics,


### PR DESCRIPTION
## Summary
- track whether slider and enum inputs are actually set and treat untouched fields as null
- retain previously entered session metrics when reopening the pre-session dialog
- test metric dialog collection of nulls and value reuse across reopenings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf3c040ba48332bac375031f287d92