### PR TITLE
Add session and set navigation

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -627,9 +627,13 @@ RootUI:
                 padding: "0dp", "0dp"
         BoxLayout:
             size_hint_y: None
-            height: dp(40)
+            height: dp(60)
             spacing: dp(10)
             padding: "0dp", "10dp"
+            MDIconButton:
+                icon: "skip-previous"
+                disabled: not root.can_skip_left
+                on_release: root.skip_left()
             MDIconButton:
                 icon: "chevron-left"
                 disabled: not root.can_nav_left
@@ -638,10 +642,16 @@ RootUI:
                 text: root.label_text
                 halign: "center"
                 valign: "middle"
+                size_hint_y: None
+                text_size: self.width, None
             MDIconButton:
                 icon: "chevron-right"
                 disabled: not root.can_nav_right
                 on_release: root.navigate_right()
+            MDIconButton:
+                icon: "skip-next"
+                disabled: not root.can_skip_right
+                on_release: root.skip_right()
         ScrollView:
             do_scroll_x: False
             do_scroll_y: True

--- a/tests/test_metric_input_screen.py
+++ b/tests/test_metric_input_screen.py
@@ -47,14 +47,18 @@ kivymd_modules = {
 }
 
 class _DummyWidget:
-    def __init__(self, *args, **kwargs):
-        pass
+    def __init__(self, *args, disabled=False, **kwargs):
+        self.disabled = disabled
 
     def bind(self, **kwargs):
         self._binding = kwargs
 
+    def on_pre_enter(self, *args, **kwargs):
+        pass
+
 class _TextField(_DummyWidget):
     def __init__(self, text="", **kwargs):
+        super().__init__(**kwargs)
         self.text = text
     def bind(self, **kwargs):
         if not hasattr(self, "_binding"):
@@ -64,6 +68,7 @@ class _TextField(_DummyWidget):
 
 class _Slider(_DummyWidget):
     def __init__(self, value=0, **kwargs):
+        super().__init__(**kwargs)
         self.value = value
         self.hint = False
         self.hint_text = ""
@@ -81,14 +86,16 @@ class _Slider(_DummyWidget):
                 cb(instance, value)
 
 class _Spinner(_DummyWidget):
-    def __init__(self, text="", values=()):
+    def __init__(self, text="", values=(), **kwargs):
+        super().__init__(**kwargs)
         self.text = text
         self.values = values
     def bind(self, **kwargs):
         self._binding = kwargs
 
 class _Checkbox(_DummyWidget):
-    def __init__(self, active=False):
+    def __init__(self, active=False, **kwargs):
+        super().__init__(**kwargs)
         self.active = active
     def bind(self, **kwargs):
         self._binding = kwargs
@@ -110,6 +117,10 @@ class _Layout(list):
 
     def add_widget(self, widget):
         self.append(widget)
+
+    @property
+    def children(self):
+        return list(reversed(self))
 
     def __bool__(self):
         return True
@@ -299,5 +310,100 @@ def test_save_metrics_records_new_set(monkeypatch):
     assert dummy_session.recorded
     assert manager.current == "rest"
     assert dummy_app.record_new_set is False
+
+
+def test_session_and_set_navigation_read_only(monkeypatch):
+    screen = MetricInputScreen()
+
+    class DummySession:
+        def __init__(self):
+            self.current_exercise = 0
+            self.exercises = [
+                {
+                    "name": "Bench",
+                    "sets": 3,
+                    "metric_defs": [
+                        {
+                            "name": "Reps",
+                            "type": "int",
+                            "is_required": True,
+                            "input_timing": "post_set",
+                        }
+                    ],
+                    "results": [],
+                }
+            ]
+            self.metric_store = {}
+            self.exercise_history = {
+                0: [
+                    {
+                        "date": "Mon 23 Aug 25",
+                        "sets": [
+                            {"metrics": {"Reps": 8}},
+                            {"metrics": {"Reps": 7}},
+                        ],
+                    }
+                ]
+            }
+
+        def edit_set_metrics(self, *args, **kwargs):
+            pass
+
+        def set_pre_set_metrics(self, *args, **kwargs):
+            pass
+
+    dummy_session = DummySession()
+    dummy_app = types.SimpleNamespace(workout_session=dummy_session)
+    monkeypatch.setattr(metric_module.MDApp, "get_running_app", classmethod(lambda cls: dummy_app))
+
+    screen.metrics_list = _Layout()
+    screen.exercise_bar = _Layout()
+    screen.on_pre_enter()
+
+    assert screen.label_text == "Current session\nSet 1"
+    assert screen.can_skip_left
+    assert not screen.metric_cells["Reps"].disabled
+
+    screen.skip_left()
+    assert screen.label_text.startswith("Mon 23 Aug 25")
+    assert screen.metric_cells["Reps"].disabled
+    assert screen.metric_cells["Reps"].text == "8"
+
+    screen.navigate_right()
+    assert screen.label_text.endswith("Set 2")
+    assert screen.metric_cells["Reps"].text == "7"
+
+    screen.skip_right()
+    assert screen.label_text == "Current session\nSet 1"
+    assert not screen.metric_cells["Reps"].disabled
+
+
+def test_skip_buttons_disabled_without_history(monkeypatch):
+    screen = MetricInputScreen()
+
+    class DummySession:
+        def __init__(self):
+            self.current_exercise = 0
+            self.exercises = [
+                {
+                    "name": "Bench",
+                    "sets": 1,
+                    "metric_defs": [],
+                    "results": [],
+                }
+            ]
+            self.metric_store = {}
+            self.exercise_history = {}
+
+    dummy_session = DummySession()
+    dummy_app = types.SimpleNamespace(workout_session=dummy_session)
+    monkeypatch.setattr(metric_module.MDApp, "get_running_app", classmethod(lambda cls: dummy_app))
+
+    screen.metrics_list = _Layout()
+    screen.exercise_bar = _Layout()
+    screen.on_pre_enter()
+
+    assert not screen.can_skip_left
+    assert not screen.can_skip_right
 
 

--- a/ui/screens/session/metric_input_screen.py
+++ b/ui/screens/session/metric_input_screen.py
@@ -19,6 +19,7 @@ from kivymd.uix.label import MDLabel
 from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.button import MDFlatButton
 from kivy.uix.boxlayout import BoxLayout
+from ui.colors import PINK_BG, PURPLE_BG
 
 
 class MetricInputScreen(MDScreen):
@@ -28,6 +29,8 @@ class MetricInputScreen(MDScreen):
     label_text = StringProperty("")
     can_nav_left = BooleanProperty(False)
     can_nav_right = BooleanProperty(False)
+    can_skip_left = BooleanProperty(False)
+    can_skip_right = BooleanProperty(False)
     exercise_bar = ObjectProperty(None)
 
     def __init__(self, **kwargs):
@@ -35,6 +38,8 @@ class MetricInputScreen(MDScreen):
         self.session = None
         self.exercise_idx = 0
         self.set_idx = 0
+        self.session_idx = 0
+        self.sessions: list[dict] = []
         self.metric_cells = {}
 
     # ------------------------------------------------------------------
@@ -47,6 +52,7 @@ class MetricInputScreen(MDScreen):
         else:
             self.exercise_idx = 0
         self.populate_exercise_bar()
+        self._load_history()
         self.update_display()
         return super().on_pre_enter(*args)
 
@@ -86,6 +92,7 @@ class MetricInputScreen(MDScreen):
     def select_exercise(self, index: int):
         self.exercise_idx = index
         self.set_idx = 0
+        self._load_history()
         self.update_display()
 
     # ------------------------------------------------------------------
@@ -95,12 +102,25 @@ class MetricInputScreen(MDScreen):
             self.label_text = ""
             self.can_nav_left = False
             self.can_nav_right = False
+            self.can_skip_left = False
+            self.can_skip_right = False
             return
 
-        ex = self.session.exercises[self.exercise_idx]
-        self.label_text = f"Set {self.set_idx + 1}"
+        current_is_latest = self.session_idx == len(self.sessions) - 1
+        if current_is_latest:
+            ex = self.session.exercises[self.exercise_idx]
+            total_sets = ex["sets"]
+            session_label = "Current session"
+        else:
+            sess = self.sessions[self.session_idx]
+            total_sets = len(sess.get("sets", []))
+            session_label = sess.get("date", "")
+        self.label_text = f"{session_label}\nSet {self.set_idx + 1}"
         self.can_nav_left = self.set_idx > 0
-        self.can_nav_right = self.set_idx < ex["sets"] - 1
+        self.can_nav_right = self.set_idx < max(total_sets - 1, 0)
+        self.can_skip_left = self.session_idx > 0
+        self.can_skip_right = self.session_idx < len(self.sessions) - 1
+        self.md_bg_color = PURPLE_BG if current_is_latest else PINK_BG
 
     def navigate_left(self):
         if self.set_idx > 0:
@@ -110,10 +130,35 @@ class MetricInputScreen(MDScreen):
     def navigate_right(self):
         if not self.session:
             return
-        ex = self.session.exercises[self.exercise_idx]
-        if self.set_idx < ex["sets"] - 1:
+        if self.session_idx == len(self.sessions) - 1:
+            total_sets = self.session.exercises[self.exercise_idx]["sets"]
+        else:
+            total_sets = len(self.sessions[self.session_idx].get("sets", []))
+        if self.set_idx < total_sets - 1:
             self.set_idx += 1
             self.update_display()
+
+    def skip_left(self):
+        if self.session_idx > 0:
+            self.session_idx -= 1
+            self.set_idx = 0
+            self.update_display()
+
+    def skip_right(self):
+        if self.session_idx < len(self.sessions) - 1:
+            self.session_idx += 1
+            self.set_idx = 0
+            self.update_display()
+
+    def _load_history(self):
+        """Load past session data for the current exercise."""
+        self.sessions = []
+        if self.session and hasattr(self.session, "exercise_history"):
+            history = self.session.exercise_history.get(self.exercise_idx, [])
+            self.sessions.extend(history)
+        # always append placeholder for the current session
+        self.sessions.append({"date": None})
+        self.session_idx = len(self.sessions) - 1
 
     # ------------------------------------------------------------------
     # Metric rendering --------------------------------------------------
@@ -134,10 +179,22 @@ class MetricInputScreen(MDScreen):
         if not self.session or self.exercise_idx >= len(self.session.exercises):
             return
 
+        if not self.sessions:
+            self.sessions = [{"date": None}]
+            self.session_idx = 0
+
         exercise = self.session.exercises[self.exercise_idx]
         metrics = self._apply_filters(exercise.get("metric_defs", []))
-        results = exercise.get("results", [])
-        store = self.session.metric_store.get((self.exercise_idx, self.set_idx), {})
+
+        if self.session_idx == len(self.sessions) - 1:
+            results = exercise.get("results", [])
+            store = self.session.metric_store.get((self.exercise_idx, self.set_idx), {})
+            read_only = False
+        else:
+            past = self.sessions[self.session_idx]
+            results = past.get("sets", [])
+            store = {}
+            read_only = True
 
         for metric in metrics:
             name = metric.get("name")
@@ -148,10 +205,10 @@ class MetricInputScreen(MDScreen):
                 value = store.get(name)
             if value in (None, ""):
                 value = metric.get("value")
-            row = self._create_row(metric, value)
+            row = self._create_row(metric, value, read_only=read_only)
             self.metrics_list.add_widget(row)
 
-    def _create_row(self, metric, value):
+    def _create_row(self, metric, value, read_only=False):
         name = metric.get("name", "")
         row = BoxLayout(orientation="horizontal", size_hint_y=None, height=dp(40))
         name_lbl = MDLabel(text=name, size_hint_x=0.4, size_hint_y=None, halign="left", valign="middle")
@@ -159,7 +216,7 @@ class MetricInputScreen(MDScreen):
             texture_size=lambda inst, _val: setattr(inst, "height", inst.texture_size[1]),
             width=lambda inst, _val: setattr(inst, "text_size", (inst.width, None)),
         )
-        widget = self._create_input_widget(metric, value)
+        widget = self._create_input_widget(metric, value, read_only=read_only)
         widget.size_hint_x = 0.6
         widget.size_hint_y = None
         widget.height = dp(40)
@@ -235,28 +292,35 @@ class MetricInputScreen(MDScreen):
         else:
             session.set_pre_set_metrics({name: value}, self.exercise_idx, set_idx)
 
-    def _create_input_widget(self, metric, value):
+    def _create_input_widget(self, metric, value, read_only=False):
         name = metric.get("name")
         mtype = metric.get("type", "str")
         values = metric.get("values", [])
         set_idx = self.set_idx
         if mtype == "slider":
-            widget = MDSlider(min=0, max=1, value=value or 0)
-            widget.bind(
-                value=lambda inst, val, name=name, mtype=mtype, set_idx=set_idx: self._on_cell_change(name, mtype, set_idx, inst),
-                on_touch_down=self.on_slider_touch_down,
-                on_touch_up=self.on_slider_touch_up,
-            )
+            widget = MDSlider(min=0, max=1, value=value or 0, disabled=read_only)
+            if not read_only:
+                widget.bind(
+                    value=lambda inst, val, name=name, mtype=mtype, set_idx=set_idx: self._on_cell_change(name, mtype, set_idx, inst),
+                    on_touch_down=self.on_slider_touch_down,
+                    on_touch_up=self.on_slider_touch_up,
+                )
         elif mtype == "enum":
-            widget = Spinner(text=str(value) if value not in (None, "") else "", values=values)
-            widget.bind(
-                text=lambda inst, val, name=name, mtype=mtype, set_idx=set_idx: self._on_cell_change(name, mtype, set_idx, inst)
+            widget = Spinner(
+                text=str(value) if value not in (None, "") else "",
+                values=values,
+                disabled=read_only,
             )
+            if not read_only:
+                widget.bind(
+                    text=lambda inst, val, name=name, mtype=mtype, set_idx=set_idx: self._on_cell_change(name, mtype, set_idx, inst)
+                )
         elif mtype == "bool":
-            widget = MDCheckbox(active=bool(value))
-            widget.bind(
-                active=lambda inst, val, name=name, mtype=mtype, set_idx=set_idx: self._on_cell_change(name, mtype, set_idx, inst)
-            )
+            widget = MDCheckbox(active=bool(value), disabled=read_only)
+            if not read_only:
+                widget.bind(
+                    active=lambda inst, val, name=name, mtype=mtype, set_idx=set_idx: self._on_cell_change(name, mtype, set_idx, inst),
+                )
         else:
             input_filter = None
             if mtype == "int":
@@ -268,10 +332,12 @@ class MetricInputScreen(MDScreen):
                 multiline=multiline,
                 input_filter=input_filter,
                 text=str(value) if value not in (None, "") else "",
+                disabled=read_only,
             )
-            widget.bind(
-                text=lambda inst, val, name=name, mtype=mtype, set_idx=set_idx: self._on_cell_change(name, mtype, set_idx, inst)
-            )
+            if not read_only:
+                widget.bind(
+                    text=lambda inst, val, name=name, mtype=mtype, set_idx=set_idx: self._on_cell_change(name, mtype, set_idx, inst)
+                )
             if multiline:
                 widget.bind(text=lambda inst, _val: self._resize_textfield(inst))
                 self._resize_textfield(widget)


### PR DESCRIPTION
## Summary
- add skip buttons and session label to MetricInputScreen navigation bar
- track history sessions and toggle read-only inputs for past sessions
- test navigating across sessions and sets

## Testing
- `pytest tests/test_metric_input_screen.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf4153e0d88332a5c729e6a8c183f6