### PR TITLE
Ensure metric inputs load when switching exercises

### DIFF
--- a/ui/screens/session/metric_input_screen.py
+++ b/ui/screens/session/metric_input_screen.py
@@ -90,8 +90,21 @@ class MetricInputScreen(MDScreen):
                 child.md_bg_color = color
 
     def select_exercise(self, index: int):
+        """Switch to another exercise from the navigation bar."""
+
+        if not self.session or index < 0 or index >= len(self.session.exercises):
+            return
+
         self.exercise_idx = index
         self.set_idx = 0
+
+        if hasattr(self.session, "load_exercise_details"):
+            try:
+                # Ensure metric definitions are ready before rendering inputs.
+                self.session.load_exercise_details(index)
+            except IndexError:
+                return
+
         self._load_history()
         self.update_display()
 
@@ -180,6 +193,14 @@ class MetricInputScreen(MDScreen):
         self.metric_cells.clear()
         if not self.session or self.exercise_idx >= len(self.session.exercises):
             return
+
+        if hasattr(self.session, "load_exercise_details"):
+            try:
+                # Loading details on-demand ensures metric definitions exist
+                # when switching between exercises.
+                self.session.load_exercise_details(self.exercise_idx)
+            except IndexError:
+                return
 
         if not self.sessions:
             self.sessions = [{"date": None}]


### PR DESCRIPTION
## Summary
- load exercise details whenever the metric input screen switches to a different exercise
- refresh metric definitions before rebuilding the metric list so inputs appear for every exercise

## Testing
- pytest tests/test_metric_input_screen.py

------
https://chatgpt.com/codex/tasks/task_e_68c84424f97083328f4671b8593bd5f5