### PR TITLE
Fix finish dialog cancel and discard flows

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -282,25 +282,11 @@ def test_confirm_finish_opens_dialog(monkeypatch):
     assert opened["value"]
 
 
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_confirm_finish_discard(monkeypatch):
     """Pressing discard abandons the session and returns to home."""
 
     import importlib
-
-    captured = {}
-
-    class DummyDialog:
-        def __init__(self, *a, **k):
-            captured["buttons"] = k.get("buttons", [])
-
-        def open(self):
-            pass
-
-        def dismiss(self):
-            pass
-
-    def dummy_button(*_a, **k):
-        return type("B", (), {"on_release": k.get("on_release")})
 
     try:
         rest_screen_module = importlib.import_module("ui.screens.session.rest_screen")
@@ -308,6 +294,27 @@ def test_confirm_finish_discard(monkeypatch):
         pytest.skip("RestScreen module not available")
     if not hasattr(rest_screen_module, "MDFlatButton"):
         pytest.skip("RestScreen stub without discard support")
+
+    captured = {"dismissed": 0}
+
+    class DummyDialog:
+        def __init__(self, *a, **k):
+            captured["buttons"] = k.get("buttons", [])
+            self._previous = None
+
+        def open(self):
+            app = rest_screen_module.MDApp.get_running_app()
+            self._previous = app.root.current
+            app.root.current = "_dialog"
+
+        def dismiss(self):
+            captured["dismissed"] += 1
+            app = rest_screen_module.MDApp.get_running_app()
+            if self._previous is not None:
+                app.root.current = self._previous
+
+    def dummy_button(*_a, **k):
+        return type("B", (), {"on_release": k.get("on_release")})
 
     monkeypatch.setattr(rest_screen_module, "FullScreenDialog", DummyDialog)
     monkeypatch.setattr(rest_screen_module, "MDRaisedButton", dummy_button)
@@ -320,7 +327,8 @@ def test_confirm_finish_discard(monkeypatch):
             cleared["value"] = True
 
     dummy_root = type("R", (), {"current": "rest"})()
-    dummy_app = type("A", (), {"root": dummy_root, "workout_session": DummySession()})()
+    dummy_session = DummySession()
+    dummy_app = type("A", (), {"root": dummy_root, "workout_session": dummy_session})()
 
     class DummyAppClass:
         @staticmethod
@@ -332,12 +340,89 @@ def test_confirm_finish_discard(monkeypatch):
     screen = rest_screen_module.RestScreen()
     screen.confirm_finish()
 
+    assert dummy_root.current == "_dialog"
+
     discard_btn = captured["buttons"][1]
     discard_btn.on_release(None)
 
+    assert captured["dismissed"] == 1
     assert dummy_root.current == "home"
     assert cleared["value"]
     assert dummy_app.workout_session is None
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_confirm_finish_cancel_keeps_session(monkeypatch):
+    """Cancel should close the dialog and leave the session untouched."""
+
+    import importlib
+
+    try:
+        rest_screen_module = importlib.import_module("ui.screens.session.rest_screen")
+    except ModuleNotFoundError:
+        pytest.skip("RestScreen module not available")
+    if not hasattr(rest_screen_module, "MDFlatButton"):
+        pytest.skip("RestScreen stub without discard support")
+
+    captured = {"dismissed": 0}
+
+    class DummyDialog:
+        def __init__(self, *a, **k):
+            captured["buttons"] = k.get("buttons", [])
+            self._previous = None
+
+        def open(self):
+            app = rest_screen_module.MDApp.get_running_app()
+            self._previous = app.root.current
+            app.root.current = "_dialog"
+
+        def dismiss(self):
+            captured["dismissed"] += 1
+            app = rest_screen_module.MDApp.get_running_app()
+            if self._previous is not None:
+                app.root.current = self._previous
+
+    def dummy_button(*_a, **k):
+        return type("B", (), {"on_release": k.get("on_release")})
+
+    monkeypatch.setattr(rest_screen_module, "FullScreenDialog", DummyDialog)
+    monkeypatch.setattr(rest_screen_module, "MDRaisedButton", dummy_button)
+    monkeypatch.setattr(rest_screen_module, "MDFlatButton", dummy_button)
+
+    class DummySession:
+        def __init__(self):
+            self.cleared = False
+
+        def clear_recovery_files(self):
+            self.cleared = True
+
+    dummy_root = type("R", (), {"current": "rest"})()
+    dummy_session = DummySession()
+    dummy_app = type(
+        "A",
+        (),
+        {"root": dummy_root, "workout_session": dummy_session},
+    )()
+
+    class DummyAppClass:
+        @staticmethod
+        def get_running_app():
+            return dummy_app
+
+    monkeypatch.setattr(rest_screen_module, "MDApp", DummyAppClass)
+
+    screen = rest_screen_module.RestScreen()
+    screen.confirm_finish()
+
+    assert dummy_root.current == "_dialog"
+
+    cancel_btn = captured["buttons"][0]
+    cancel_btn.on_release(None)
+
+    assert captured["dismissed"] == 1
+    assert dummy_root.current == "rest"
+    assert dummy_session.cleared is False
+    assert dummy_app.workout_session is dummy_session
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")

--- a/ui/screens/session/rest_screen.py
+++ b/ui/screens/session/rest_screen.py
@@ -304,46 +304,54 @@ class RestScreen(MDScreen):
             toast("No next exercise")
                 
     def confirm_finish(self):
-        dialog = None
+        """Ask the user how to proceed when finishing a workout."""
+
+        dialog_state = {"dialog": None}
+
+        def close_dialog(*_args):
+            """Dismiss the confirmation dialog and clear cached references."""
+
+            dialog_obj = dialog_state.get("dialog")
+            if dialog_obj:
+                dialog_obj.dismiss()
+                dialog_state["dialog"] = None
 
         def do_finish(*_args):
+            """Finalize the session and move to the summary screen."""
+
             app = MDApp.get_running_app()
-            if app:
-                session = getattr(app, "workout_session", None)
-                if session and session.end_time is None:
-                    session.end_time = time.time()
+            session = getattr(app, "workout_session", None) if app else None
+            if session and session.end_time is None:
+                session.end_time = time.time()
+            close_dialog()
             if app and app.root:
                 app.root.current = "workout_summary"
-            if dialog:
-                dialog.dismiss()
 
         def do_discard(*_args):
             """Abandon the current session without saving."""
 
             app = MDApp.get_running_app()
-            if app:
-                session = getattr(app, "workout_session", None)
-                if session:
-                    session.clear_recovery_files()
-                    app.workout_session = None
+            session = getattr(app, "workout_session", None) if app else None
+            if session:
+                session.clear_recovery_files()
+                app.workout_session = None
+            close_dialog()
             if app and app.root:
                 app.root.current = "home"
-            if dialog:
-                dialog.dismiss()
 
-        dialog = FullScreenDialog(
+        dialog_state["dialog"] = FullScreenDialog(
             title="Finish Workout?",
             content_cls=MDLabel(
                 text="Are you sure you want to finish this workout?",
                 halign="center",
             ),
             buttons=[
-                MDRaisedButton(text="Cancel", on_release=lambda *_: dialog.dismiss()),
+                MDRaisedButton(text="Cancel", on_release=close_dialog),
                 MDFlatButton(text="Discard", on_release=do_discard),
                 MDRaisedButton(text="Save", on_release=do_finish),
             ],
         )
-        dialog.open()
+        dialog_state["dialog"].open()
 
     def on_touch_down(self, touch):
         if self.ids.timer_label.collide_point(*touch.pos):


### PR DESCRIPTION
## Summary
- ensure the finish workout confirmation dialog is dismissed before navigating so Cancel, Discard, and Save return to the intended screens
- expand unit tests to mimic dialog navigation behaviour and cover both discard and cancel flows

## Testing
- pytest tests/test_ui.py -k "confirm_finish" -q

------
https://chatgpt.com/codex/tasks/task_e_68c8463072b4833287ef84ce36452baa