### PR TITLE
Fix recovery cache initialization

### DIFF
--- a/backend/workout_session.py
+++ b/backend/workout_session.py
@@ -1081,6 +1081,13 @@ class WorkoutSession:
         obj.section_starts = data.get("section_starts", [])
         obj.section_names = data.get("section_names", [])
         obj.exercise_sections = data.get("exercise_sections", [])
+        # ``exercise_history`` and ``_exercise_history_cache`` are runtime caches that
+        # are intentionally omitted from the persisted recovery payload.  They must be
+        # recreated when loading so recovered sessions can access metric history
+        # without raising ``AttributeError`` when the MetricInputScreen queries past
+        # workouts.
+        obj.exercise_history = {}
+        obj._exercise_history_cache = {}
         obj._rebuild_exercises()
         return obj
 


### PR DESCRIPTION
## Summary
- recreate the history caches when rebuilding a WorkoutSession from recovery data
- prevent AttributeError when the MetricInputScreen loads history in a recovered session

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9927eea7c8332941efc07c9b41c70