### PR TITLE
Tighten metric nav spacing for small screens

### DIFF
--- a/main.kv
+++ b/main.kv
@@ -611,7 +611,7 @@ RootUI:
         BoxLayout:
             size_hint_y: None
             height: dp(60)
-            spacing: dp(4)
+            spacing: dp(1)
             padding: "0dp", "8dp"
             MDIconButton:
                 icon: "skip-previous"
@@ -633,7 +633,7 @@ RootUI:
                 valign: "middle"
                 size_hint_y: None
                 text_size: self.width, None
-                font_size: scaled_sp(14)
+                font_size: scaled_sp(12)
             MDIconButton:
                 icon: "chevron-right"
                 disabled: not root.can_nav_right


### PR DESCRIPTION
## Summary
- reduce the spacing between metric navigation icons so the row stays compact on narrow devices
- lower the navigation label font size slightly to keep the text from clipping between the controls

## Testing
- pytest tests/test_metric_input_screen.py

------
https://chatgpt.com/codex/tasks/task_e_68c9948e288083329ba3aced71100a72