### PR TITLE
Switch tempo lookup to metric type names

### DIFF
--- a/backend/metrics.py
+++ b/backend/metrics.py
@@ -40,8 +40,10 @@ def get_metrics_for_exercise(
 ) -> list:
     """Return metric definitions for ``exercise_name``.
 
-    Each item in the returned list is a dictionary with ``name`` and ``type``
-    keys. ``values`` will contain any allowed values for ``enum`` metrics.
+    Each dictionary contains the display label, capture timing, validation
+    flags, and canonical identifiers under ``library_metric_type_id`` and
+    ``library_metric_type_name``. ``values`` includes the allowed options for
+    ``enum`` metrics when present.
     """
 
     with sqlite3.connect(str(db_path)) as conn:
@@ -65,8 +67,8 @@ def get_metrics_for_exercise(
 
         cursor.execute(
             """
-        SELECT mt.id,
-               mt.name,
+        SELECT mt.id AS library_metric_type_id,
+               mt.name AS library_metric_type_name,
                COALESCE(em.type, mt.type),
                COALESCE(em.input_timing, mt.input_timing),
                COALESCE(em.is_required, mt.is_required),
@@ -85,7 +87,7 @@ def get_metrics_for_exercise(
         metrics = []
         for (
             metric_type_id,
-            name,
+            metric_type_name,
             mtype,
             input_timing,
             is_required,
@@ -102,7 +104,7 @@ def get_metrics_for_exercise(
                     values = []
             metrics.append(
                 {
-                    "name": name,
+                    "name": metric_type_name,
                     "type": mtype,
                     "input_timing": input_timing,
                     "is_required": bool(is_required),
@@ -111,6 +113,7 @@ def get_metrics_for_exercise(
                     "values": values,
                     "value": value,
                     "library_metric_type_id": metric_type_id,
+                    "library_metric_type_name": metric_type_name,
                     "preset_exercise_metric_id": None,
                 }
             )
@@ -128,7 +131,8 @@ def get_metrics_for_exercise(
                    COALESCE(sem.enum_values_json, mt.enum_values_json),
                    COALESCE(sem.metric_description, mt.description),
                    sem.value,
-                   COALESCE(sem.library_metric_type_id, mt.id)
+                   COALESCE(sem.library_metric_type_id, mt.id),
+                   mt.name AS library_metric_type_name
             FROM preset_exercise_metrics sem
             JOIN preset_section_exercises se ON sem.section_exercise_id = se.id
             JOIN preset_preset_sections s ON se.section_id = s.id
@@ -152,6 +156,7 @@ def get_metrics_for_exercise(
                 description,
                 value,
                 lib_type_id,
+                lib_type_name,
             ) in cursor.fetchall():
                 values = []
                 if mtype == "enum" and enum_json:
@@ -169,13 +174,14 @@ def get_metrics_for_exercise(
                     "description": description,
                     "value": value,
                     "library_metric_type_id": lib_type_id,
+                    "library_metric_type_name": lib_type_name,
                 }
             names = {m["name"] for m in metrics}
             for m in metrics:
                 o = overrides.get(m["name"])
                 if o:
                     for k, v in o.items():
-                        if k == "library_metric_type_id" and v is None:
+                        if k in {"library_metric_type_id", "library_metric_type_name"} and v is None:
                             continue
                         m[k] = v
             for name, data in overrides.items():
@@ -188,7 +194,11 @@ def get_metrics_for_exercise(
 def get_metrics_for_preset(
     preset_name: str, db_path: Path = DEFAULT_DB_PATH
 ) -> list:
-    """Return preset-level metric definitions for ``preset_name``."""
+    """Return preset-level metric definitions for ``preset_name``.
+
+    The returned dictionaries mirror :func:`get_metrics_for_exercise`, exposing
+    both the preset display label and the canonical library metric metadata.
+    """
 
     with sqlite3.connect(str(db_path)) as conn:
         cursor = conn.cursor()
@@ -204,6 +214,7 @@ def get_metrics_for_preset(
             """
             SELECT pm.id,
                    COALESCE(pm.library_metric_type_id, mt.id),
+                   mt.name AS library_metric_type_name,
                    pm.metric_name,
                    COALESCE(pm.metric_description, mt.description),
                    COALESCE(pm.type, mt.type),
@@ -223,6 +234,7 @@ def get_metrics_for_preset(
         for (
             pm_id,
             lib_type_id,
+            lib_type_name,
             name,
             description,
             mtype,
@@ -249,6 +261,7 @@ def get_metrics_for_preset(
                     "description": description,
                     "value": value,
                     "library_metric_type_id": lib_type_id,
+                    "library_metric_type_name": lib_type_name,
                     "preset_metric_id": pm_id,
                 }
             )

--- a/backend/workout_session.py
+++ b/backend/workout_session.py
@@ -15,6 +15,29 @@ from core import (
 )
 
 
+# Canonical metric name used for tempo tracking.
+_TEMPO_METRIC_TYPE_NAME = "Tempo"
+# Cached lowercase representation to avoid repeated ``str.lower`` calls when
+# scanning metric definitions during a session.
+_TEMPO_METRIC_TYPE_NAME_LOWER = _TEMPO_METRIC_TYPE_NAME.lower()
+
+
+def _is_tempo_metric(metric_def: dict[str, object]) -> bool:
+    """Return ``True`` if ``metric_def`` represents the tempo metric type.
+
+    The canonical metric type name is the primary identifier, supporting newer
+    session data that ships with ``library_metric_type_name``.  Persisted
+    sessions created before the introduction of canonical names only contain
+    ``library_metric_type_id``; the fallback ID check preserves compatibility
+    with those records so they remain readable.
+    """
+
+    type_name = metric_def.get("library_metric_type_name")
+    if isinstance(type_name, str) and type_name.strip().lower() == _TEMPO_METRIC_TYPE_NAME_LOWER:
+        return True
+    return metric_def.get("library_metric_type_id") == 3
+
+
 # Directory for persisting in-progress session state.  This lives within the
 # repository's ``data`` folder so the files are part of the code base and will
 # survive across app restarts.
@@ -631,15 +654,14 @@ class WorkoutSession:
         metric_defs = (
             self.preset_snapshot[exercise_index].get("metric_defs") or []
         )
-        tempo_name = next(
-            (
-                m["name"]
-                for m in metric_defs
-                if m.get("library_metric_type_id") == 3
-            ),
+        tempo_metric = next(
+            (m for m in metric_defs if _is_tempo_metric(m)),
             None,
         )
-        if not tempo_name:
+        if not tempo_metric:
+            return None
+        tempo_name = tempo_metric.get("name")
+        if not isinstance(tempo_name, str) or not tempo_name:
             return None
         value = self.metric_store.get((exercise_index, set_index), {}).get(tempo_name)
         if value is None:

--- a/core.py
+++ b/core.py
@@ -27,8 +27,10 @@ def get_metrics_for_exercise(
 ) -> list:
     """Return metric definitions for ``exercise_name``.
 
-    Each item in the returned list is a dictionary with ``name`` and ``type``
-    keys. ``values`` will contain any allowed values for ``enum`` metrics.
+    Each dictionary contains the display label, capture timing, validation
+    flags, and canonical identifiers under ``library_metric_type_id`` and
+    ``library_metric_type_name``. ``values`` includes the allowed options for
+    ``enum`` metrics when present.
     """
 
     with sqlite3.connect(str(db_path)) as conn:
@@ -51,8 +53,8 @@ def get_metrics_for_exercise(
 
         cursor.execute(
             """
-        SELECT mt.id,
-               mt.name,
+        SELECT mt.id AS library_metric_type_id,
+               mt.name AS library_metric_type_name,
                COALESCE(em.type, mt.type),
                COALESCE(em.input_timing, mt.input_timing),
                COALESCE(em.is_required, mt.is_required),
@@ -71,7 +73,7 @@ def get_metrics_for_exercise(
         metrics = []
         for (
             metric_type_id,
-            name,
+            metric_type_name,
             mtype,
             input_timing,
             is_required,
@@ -88,7 +90,7 @@ def get_metrics_for_exercise(
                     values = []
             metrics.append(
                 {
-                    "name": name,
+                    "name": metric_type_name,
                     "type": mtype,
                     "input_timing": input_timing,
                     "is_required": bool(is_required),
@@ -97,6 +99,7 @@ def get_metrics_for_exercise(
                     "values": values,
                     "value": value,
                     "library_metric_type_id": metric_type_id,
+                    "library_metric_type_name": metric_type_name,
                     "preset_exercise_metric_id": None,
                 }
             )
@@ -114,7 +117,8 @@ def get_metrics_for_exercise(
                    COALESCE(sem.enum_values_json, mt.enum_values_json),
                    COALESCE(sem.metric_description, mt.description),
                    sem.value,
-                   COALESCE(sem.library_metric_type_id, mt.id)
+                   COALESCE(sem.library_metric_type_id, mt.id),
+                   mt.name AS library_metric_type_name
             FROM preset_exercise_metrics sem
             JOIN preset_section_exercises se ON sem.section_exercise_id = se.id
             JOIN preset_preset_sections s ON se.section_id = s.id
@@ -138,6 +142,7 @@ def get_metrics_for_exercise(
                 description,
                 value,
                 lib_type_id,
+                lib_type_name,
             ) in cursor.fetchall():
                 values = []
                 if mtype == "enum" and enum_json:
@@ -155,13 +160,14 @@ def get_metrics_for_exercise(
                     "description": description,
                     "value": value,
                     "library_metric_type_id": lib_type_id,
+                    "library_metric_type_name": lib_type_name,
                 }
             names = {m["name"] for m in metrics}
             for m in metrics:
                 o = overrides.get(m["name"])
                 if o:
                     for k, v in o.items():
-                        if k == "library_metric_type_id" and v is None:
+                        if k in {"library_metric_type_id", "library_metric_type_name"} and v is None:
                             continue
                         m[k] = v
             for name, data in overrides.items():
@@ -174,7 +180,11 @@ def get_metrics_for_exercise(
 def get_metrics_for_preset(
     preset_name: str, db_path: Path = DEFAULT_DB_PATH
 ) -> list:
-    """Return preset-level metric definitions for ``preset_name``."""
+    """Return preset-level metric definitions for ``preset_name``.
+
+    The returned dictionaries mirror :func:`get_metrics_for_exercise`, exposing
+    both the preset display label and the canonical library metric metadata.
+    """
 
     with sqlite3.connect(str(db_path)) as conn:
         cursor = conn.cursor()
@@ -190,6 +200,7 @@ def get_metrics_for_preset(
             """
             SELECT pm.id,
                    COALESCE(pm.library_metric_type_id, mt.id),
+                   mt.name AS library_metric_type_name,
                    pm.metric_name,
                    COALESCE(pm.metric_description, mt.description),
                    COALESCE(pm.type, mt.type),
@@ -209,6 +220,7 @@ def get_metrics_for_preset(
         for (
             pm_id,
             lib_type_id,
+            lib_type_name,
             name,
             description,
             mtype,
@@ -235,6 +247,7 @@ def get_metrics_for_preset(
                     "description": description,
                     "value": value,
                     "library_metric_type_id": lib_type_id,
+                    "library_metric_type_name": lib_type_name,
                     "preset_metric_id": pm_id,
                 }
             )


### PR DESCRIPTION
## Summary
- include canonical metric type names when loading exercise and preset metrics, preserving override metadata
- add a tempo metric helper that prefers canonical names with an id fallback for legacy data
- update session tempo lookup to rely on the helper and fetch tempo values by the metric display label

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d03211ad388332bc6c9760f6c07e58