### PR TITLE
Fix exercise editor metric dialog reload

### DIFF
--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -823,6 +823,25 @@ def test_edit_exercise_add_metric_updates_list(monkeypatch):
 
 
 @pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
+def test_edit_exercise_skip_reload_flag():
+    """Dialogs should not trigger a database reload when dismissed."""
+
+    screen = EditExerciseScreen()
+    screen.skip_next_reload = True
+
+    called = {"load": False}
+
+    def fake_load():
+        called["load"] = True
+
+    screen._load_exercise = fake_load
+    screen.on_pre_enter()
+
+    assert called["load"] is False
+    assert screen.skip_next_reload is False
+
+
+@pytest.mark.skipif(not kivy_available, reason="Kivy and KivyMD are required")
 def test_exercise_selection_panel_filters(monkeypatch):
     panel = ExerciseSelectionPanel()
     panel.exercise_list = type(

--- a/ui/dialogs/add_metric_popup.py
+++ b/ui/dialogs/add_metric_popup.py
@@ -80,6 +80,10 @@ class AddMetricPopup(MDScreen):
     def open(self) -> None:
         """Display the dialog as a new screen."""
         app = MDApp.get_running_app()
+        if self.screen and hasattr(self.screen, "skip_next_reload"):
+            # Prevent the parent screen from reloading data (and discarding
+            # pending edits) when this dialog is dismissed.
+            self.screen.skip_next_reload = True
         app.root.add_widget(self)
         app.root.current = self.name
         app._dialog_stack.append(self)

--- a/ui/dialogs/edit_metric_popup.py
+++ b/ui/dialogs/edit_metric_popup.py
@@ -287,6 +287,10 @@ class EditMetricPopup(MDScreen):
             self.previous_screen = app.root.current
         if not self.name:
             self.name = f"_dialog_{id(self)}"
+        if self.screen and hasattr(self.screen, "skip_next_reload"):
+            # Returning from the dialog should keep unsaved edits intact on
+            # compact devices where reloading is expensive and confusing.
+            self.screen.skip_next_reload = True
         app.root.add_widget(self)
         app.root.current = self.name
         if hasattr(app, "_dialog_stack"):

--- a/ui/screens/general/edit_exercise_screen.py
+++ b/ui/screens/general/edit_exercise_screen.py
@@ -62,6 +62,7 @@ class EditExerciseScreen(MDScreen):
     exercise_rest = NumericProperty(DEFAULT_REST_DURATION)
     section_length = NumericProperty(0)
     mode = StringProperty("library")
+    skip_next_reload = BooleanProperty(False)
 
     def __init__(self, mode: str = "library", **kwargs):
         super().__init__(**kwargs)
@@ -145,6 +146,14 @@ class EditExerciseScreen(MDScreen):
         # If a loading dialog is already active, avoid reloading the screen
         # and simply continue with the normal transition.
         if self.loading_dialog:
+            return super().on_pre_enter(*args)
+
+        # Dialog screens (e.g. metric pickers) temporarily switch away from
+        # this screen.  When they close, :meth:`on_pre_enter` fires again but
+        # we must not discard unsaved, in-memory edits.  The flag is set just
+        # before those dialogs are shown to skip the reload on the way back.
+        if self.skip_next_reload:
+            self.skip_next_reload = False
             return super().on_pre_enter(*args)
 
         if self.previous_screen == "edit_preset":
@@ -303,6 +312,7 @@ class EditExerciseScreen(MDScreen):
     def open_add_metric_popup(self):
         if self.mode == "session":
             return
+        self.skip_next_reload = True
         popup = AddMetricPopup(
             self, self.manager.current, popup_mode="select", mode=self.mode
         )
@@ -311,6 +321,7 @@ class EditExerciseScreen(MDScreen):
     def open_new_metric_popup(self):
         if self.mode == "session":
             return
+        self.skip_next_reload = True
         popup = AddMetricPopup(
             self, self.manager.current, popup_mode="new", mode=self.mode
         )
@@ -319,6 +330,7 @@ class EditExerciseScreen(MDScreen):
     def open_edit_metric_popup(self, metric):
         if self.mode == "session":
             return
+        self.skip_next_reload = True
         popup = EditMetricPopup(self, metric, mode=self.mode, previous_screen=self.manager.current if self.manager else "")
         popup.open()
 


### PR DESCRIPTION
## Summary
- prevent EditExerciseScreen from reloading when returning from dialog-based popups so metrics stay in memory
- have metric selection/edit dialogs mark the parent screen to skip the next reload
- add a regression test ensuring the skip flag stops on_pre_enter from reloading

## Testing
- pytest tests/test_ui.py::test_edit_exercise_skip_reload_flag -q

------
https://chatgpt.com/codex/tasks/task_e_68d05ab4a9c48332b4a777385580dd32